### PR TITLE
Remove YouTrack default base URL

### DIFF
--- a/profiles/youtrack/openapi.json
+++ b/profiles/youtrack/openapi.json
@@ -9,9 +9,6 @@
     },
     "version" : "2025.3"
   },
-  "servers" : [ {
-    "url" : "https://davidruzicka.youtrack.cloud:443/api"
-  } ],
   "security" : [ {
     "permanentToken" : [ ]
   } ],

--- a/profiles/youtrack/profile.json
+++ b/profiles/youtrack/profile.json
@@ -18,6 +18,9 @@
   },
 
   "interceptors": {
+    "base_url": {
+      "value_from_env": "MCP4_API_BASE_URL"
+    },
     "auth": {
       "type": "bearer",
       "value_from_env": "MCP4_API_TOKEN"

--- a/src/constants.test.ts
+++ b/src/constants.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { HTTP_STATUS, MIME_TYPES, OAUTH_PATHS, OAUTH_RATE_LIMIT, TIME, TIMEOUTS } from './constants.js';
+
+describe('constants', () => {
+  describe('TIME', () => {
+    it('should expose consistent time units', () => {
+      expect(TIME.MS_PER_SECOND).toBe(1000);
+      expect(TIME.SECONDS_PER_MINUTE).toBe(60);
+      expect(TIME.MS_PER_MINUTE).toBe(TIME.SECONDS_PER_MINUTE * TIME.MS_PER_SECOND);
+      expect(TIME.MS_PER_HOUR).toBe(TIME.MINUTES_PER_HOUR * TIME.MS_PER_MINUTE);
+    });
+
+    it('should keep derived time units aligned when base changes', () => {
+      const minuteFromSeconds = TIME.SECONDS_PER_MINUTE * TIME.MS_PER_SECOND;
+      const minuteFromHour = TIME.MS_PER_HOUR / TIME.MINUTES_PER_HOUR;
+      expect(minuteFromSeconds).toBe(minuteFromHour);
+    });
+  });
+
+  describe('HTTP_STATUS', () => {
+    it('should map common HTTP statuses to numeric codes', () => {
+      expect(HTTP_STATUS.OK).toBe(200);
+      expect(HTTP_STATUS.NOT_FOUND).toBe(404);
+      expect(HTTP_STATUS.TOO_MANY_REQUESTS).toBe(429);
+      expect(HTTP_STATUS.INTERNAL_SERVER_ERROR).toBe(500);
+    });
+
+    it('should avoid conflicting numeric assignments', () => {
+      const statusValues = Object.values(HTTP_STATUS);
+      const uniqueValues = new Set(statusValues);
+      expect(uniqueValues.size).toBe(statusValues.length);
+    });
+  });
+
+  describe('MIME_TYPES', () => {
+    it('should provide common MIME type headers', () => {
+      expect(MIME_TYPES.JSON).toBe('application/json');
+      expect(MIME_TYPES.EVENT_STREAM).toBe('text/event-stream');
+      expect(MIME_TYPES.FORM_URLENCODED).toBe('application/x-www-form-urlencoded');
+    });
+  });
+
+  describe('OAUTH_PATHS', () => {
+    it('should include required OAuth endpoints', () => {
+      expect(OAUTH_PATHS.AUTHORIZE).toBe('/oauth/authorize');
+      expect(OAUTH_PATHS.TOKEN).toBe('/oauth/token');
+      expect(OAUTH_PATHS.CALLBACK).toBe('/oauth/callback');
+    });
+
+    it('should surface well-known discovery paths', () => {
+      expect(OAUTH_PATHS.WELL_KNOWN_AUTHORIZATION_SERVER).toBe('/.well-known/oauth-authorization-server');
+      expect(OAUTH_PATHS.WELL_KNOWN_PROTECTED_RESOURCE).toBe('/.well-known/oauth-protected-resource/mcp');
+    });
+  });
+
+  describe('TIMEOUTS', () => {
+    it('should derive timeout values from time constants', () => {
+      expect(TIMEOUTS.SESSION_TIMEOUT_MS).toBe(30 * TIME.MS_PER_MINUTE);
+      expect(TIMEOUTS.HEARTBEAT_INTERVAL_MS).toBe(30 * TIME.MS_PER_SECOND);
+      expect(TIMEOUTS.RATE_LIMIT_WINDOW_MS).toBe(TIME.MS_PER_MINUTE);
+      expect(TIMEOUTS.CLEANUP_INTERVAL_MS).toBe(TIME.MS_PER_MINUTE);
+    });
+
+    it('should maintain ordering between session timeout and heartbeat', () => {
+      expect(TIMEOUTS.SESSION_TIMEOUT_MS).toBeGreaterThan(TIMEOUTS.HEARTBEAT_INTERVAL_MS);
+    });
+  });
+
+  describe('OAUTH_RATE_LIMIT', () => {
+    it('should configure sensible OAuth defaults', () => {
+      expect(OAUTH_RATE_LIMIT.MAX_REQUESTS).toBe(10);
+      expect(OAUTH_RATE_LIMIT.WINDOW_MS).toBe(10 * TIME.MS_PER_MINUTE);
+    });
+
+    it('should align window duration with rate limit expectations', () => {
+      const averageRequestsPerMinute = (OAUTH_RATE_LIMIT.MAX_REQUESTS * TIME.MS_PER_MINUTE) / OAUTH_RATE_LIMIT.WINDOW_MS;
+      expect(averageRequestsPerMinute).toBeCloseTo(1);
+    });
+  });
+});

--- a/src/testing/mock-youtrack-server.ts
+++ b/src/testing/mock-youtrack-server.ts
@@ -1,0 +1,211 @@
+import { http, HttpResponse, RequestHandler } from 'msw';
+import { setupServer } from 'msw/node';
+
+const DEFAULT_BASE_URL = 'http://localhost/api';
+
+export interface RequestLogEntry {
+  method: string;
+  url: string;
+  query: Record<string, string | string[]>;
+}
+
+const baseIssue = {
+  id: 'YT-123',
+  idReadable: 'YT-123',
+  summary: 'Mock issue summary',
+  description: 'Mock issue description',
+  resolved: false,
+};
+
+const baseArticle = {
+  id: 'article-1',
+  title: 'Mock article',
+  summary: 'Mock summary',
+  content: 'Mock content',
+};
+
+const baseTag = { id: 'tag-1', name: 'Bug', color: '#ff0000' };
+const baseUser = { id: 'user-1', login: 'mock-user', fullName: 'Mock User', email: 'user@example.com' };
+
+function queryToRecord(searchParams: URLSearchParams): Record<string, string | string[]> {
+  const entries: Record<string, string | string[]> = {};
+  for (const [key, value] of searchParams.entries()) {
+    if (entries[key]) {
+      const existing = entries[key];
+      entries[key] = Array.isArray(existing) ? [...existing, value] : [existing, value];
+    } else {
+      entries[key] = value;
+    }
+  }
+  return entries;
+}
+
+function createEchoResponse(
+  request: Request,
+  payload: unknown = {},
+  requestLog?: RequestLogEntry[]
+): Record<string, unknown> {
+  const url = new URL(request.url);
+  const query = queryToRecord(url.searchParams);
+  if (requestLog) {
+    requestLog.push({
+      method: request.method,
+      url: url.toString(),
+      query,
+    });
+  }
+  return {
+    path: url.pathname,
+    query,
+    method: request.method,
+    data: payload,
+  };
+}
+
+export function createYoutrackHandlers(
+  baseUrl: string = DEFAULT_BASE_URL,
+  requestLog?: RequestLogEntry[]
+): RequestHandler[] {
+  const withBase = (path: string | RegExp) =>
+    typeof path === 'string' ? `${baseUrl}${path}` : new RegExp(`${baseUrl}${path.source}`);
+
+  const issueAttachment = {
+    id: 'att-1',
+    name: 'issue.txt',
+    mimeType: 'text/plain',
+    size: 12,
+  };
+
+  const articleAttachment = {
+    id: 'aat-1',
+    name: 'article.txt',
+    mimeType: 'text/plain',
+    size: 18,
+  };
+
+  const handlers: RequestHandler[] = [
+    // Content retrieval
+    http.get(withBase('/issues'), ({ request }) => HttpResponse.json([createEchoResponse(request, baseIssue, requestLog)])),
+    http.get(withBase('/issues/:id'), ({ request, params }) =>
+      HttpResponse.json({ ...createEchoResponse(request, { ...baseIssue, id: params.id }, requestLog), comments: [], attachments: [] })
+    ),
+    http.get(withBase('/issues/:id/comments'), ({ request }) =>
+      HttpResponse.json([createEchoResponse(request, { id: 'c-1', text: 'mock comment', attachments: [] }, requestLog)])
+    ),
+    http.get(withBase('/issues/:id/comments/:commentId'), ({ request, params }) =>
+      HttpResponse.json(createEchoResponse(request, { id: params.commentId, text: 'comment detail', attachments: [] }, requestLog))
+    ),
+    http.get(withBase('/issues/:id/attachments'), ({ request }) =>
+      HttpResponse.json([createEchoResponse(request, issueAttachment, requestLog)])
+    ),
+    http.get(withBase('/issues/:id/attachments/:attachmentId'), ({ request, params }) =>
+      HttpResponse.json({
+        ...createEchoResponse(request, { ...issueAttachment, id: params.attachmentId }, requestLog),
+        url: `${baseUrl}/downloads/issues/${params.id}/${params.attachmentId}`,
+      })
+    ),
+    http.get(withBase('/issues/:id/tags'), ({ request }) => HttpResponse.json([createEchoResponse(request, baseTag, requestLog)])),
+    http.get(withBase('/issues/:id/links'), ({ request }) =>
+      HttpResponse.json([createEchoResponse(request, { id: 'link-1', direction: 'OUTWARD' }, requestLog)])
+    ),
+    http.get(withBase('/issues/:id/links/:linkId'), ({ request, params }) =>
+      HttpResponse.json(createEchoResponse(request, { id: params.linkId, direction: 'OUTWARD' }, requestLog))
+    ),
+    http.get(withBase('/issues/:id/links/:linkId/issues'), ({ request }) =>
+      HttpResponse.json([createEchoResponse(request, baseIssue, requestLog)])
+    ),
+    http.get(withBase('/workItems'), ({ request }) => HttpResponse.json([createEchoResponse(request, { id: 'work-1' }, requestLog)])),
+    http.get(withBase('/articles'), ({ request }) => HttpResponse.json([createEchoResponse(request, baseArticle, requestLog)])),
+    http.get(withBase('/articles/:id'), ({ request, params }) =>
+      HttpResponse.json({ ...createEchoResponse(request, { ...baseArticle, id: params.id }, requestLog), comments: [], attachments: [] })
+    ),
+    http.get(withBase('/articles/:id/comments'), ({ request, params }) =>
+      HttpResponse.json([createEchoResponse(request, { id: `ac-${params.id}`, text: 'article comment' }, requestLog)])
+    ),
+    http.get(withBase('/articles/:id/attachments'), ({ request }) =>
+      HttpResponse.json([createEchoResponse(request, articleAttachment, requestLog)])
+    ),
+    http.get(withBase('/articles/:id/attachments/:attachmentId'), ({ request, params }) =>
+      HttpResponse.json({
+        ...createEchoResponse(request, { ...articleAttachment, id: params.attachmentId }, requestLog),
+        url: `data:text/plain;base64,${Buffer.from('article attachment content').toString('base64')}`,
+      })
+    ),
+    http.get(withBase('/tags'), ({ request }) => HttpResponse.json([createEchoResponse(request, baseTag, requestLog)])),
+    http.get(withBase('/tags/:id'), ({ request, params }) =>
+      HttpResponse.json(createEchoResponse(request, { ...baseTag, id: params.id }, requestLog))
+    ),
+    http.get(withBase('/savedQueries'), ({ request }) => HttpResponse.json([createEchoResponse(request, { id: 'q-1' }, requestLog)])),
+    http.get(withBase('/agiles'), ({ request }) => HttpResponse.json([createEchoResponse(request, { id: 'agile-1' }, requestLog)])),
+    http.get(withBase('/agiles/:id'), ({ request, params }) =>
+      HttpResponse.json(createEchoResponse(request, { id: params.id, name: 'Agile Board' }, requestLog))
+    ),
+    http.get(withBase('/agiles/:id/sprints'), ({ request }) =>
+      HttpResponse.json([createEchoResponse(request, { id: 'sprint-1', name: 'Sprint' }, requestLog)])
+    ),
+    http.get(withBase('/users'), ({ request }) => HttpResponse.json([createEchoResponse(request, baseUser, requestLog)])),
+    http.get(withBase('/users/:id'), ({ request, params }) =>
+      HttpResponse.json(createEchoResponse(request, { ...baseUser, id: params.id }, requestLog))
+    ),
+    http.get(withBase('/groups'), ({ request }) =>
+      HttpResponse.json([createEchoResponse(request, { id: 'group-1', name: 'Mock Group' }, requestLog)])
+    ),
+
+    // Activity/history endpoints
+    http.get(withBase('/activities'), ({ request }) => HttpResponse.json([createEchoResponse(request, { id: 'act-1' }, requestLog)])),
+    http.get(withBase('/activities/:id'), ({ request, params }) =>
+      HttpResponse.json(createEchoResponse(request, { id: params.id, category: 'update' }, requestLog))
+    ),
+    http.get(withBase('/activitiesPage'), ({ request }) => HttpResponse.json([createEchoResponse(request, { id: 'page-1' }, requestLog)])),
+    http.get(withBase('/issues/:id/activities'), ({ request }) =>
+      HttpResponse.json([createEchoResponse(request, { id: 'act-issue-1' }, requestLog)])
+    ),
+
+    // Mutations
+    http.post(new RegExp(`${baseUrl}/.*`), async ({ request }) => {
+      const body = await request.json().catch(() => ({}));
+      return HttpResponse.json(createEchoResponse(request, body, requestLog), { status: 201 });
+    }),
+    http.put(new RegExp(`${baseUrl}/.*`), async ({ request }) => {
+      const body = await request.json().catch(() => ({}));
+      return HttpResponse.json(createEchoResponse(request, body, requestLog));
+    }),
+    http.patch(new RegExp(`${baseUrl}/.*`), async ({ request }) => {
+      const body = await request.json().catch(() => ({}));
+      return HttpResponse.json(createEchoResponse(request, body, requestLog));
+    }),
+    http.delete(new RegExp(`${baseUrl}/.*`), ({ request }) => HttpResponse.json(createEchoResponse(request, {}, requestLog))),
+
+    // Download endpoints (for proxy_download operations)
+    http.get(withBase('/downloads/issues/:id/:attachmentId'), () =>
+      HttpResponse.text('issue attachment content', {
+        headers: {
+          'content-type': 'text/plain',
+          'content-length': '24',
+        },
+      })
+    ),
+    http.get(withBase('/downloads/articles/:id/:attachmentId'), () =>
+      HttpResponse.text('article attachment content', {
+        headers: {
+          'content-type': 'text/plain',
+          'content-length': '27',
+        },
+      })
+    ),
+  ];
+
+  // Generic GET fallback to avoid 404s for any missing endpoint
+  handlers.push(
+    http.get(new RegExp(`${baseUrl}/.*`), ({ request }) => HttpResponse.json(createEchoResponse(request, {}, requestLog)))
+  );
+
+  return handlers;
+}
+
+export function createYoutrackMockServer(baseUrl: string = DEFAULT_BASE_URL, requestLog?: RequestLogEntry[]) {
+  const handlers = createYoutrackHandlers(baseUrl, requestLog);
+  return setupServer(...handlers);
+}
+
+export { DEFAULT_BASE_URL as YOU_TRACK_DEFAULT_BASE_URL };

--- a/src/testing/parameter-mapping.test.ts
+++ b/src/testing/parameter-mapping.test.ts
@@ -5,6 +5,7 @@ import { HttpClient } from '../interceptors.js';
 import { OpenAPIParser } from '../openapi-parser.js';
 import { ProfileLoader } from '../profile-loader.js';
 import { ToolGenerator } from '../tool-generator.js';
+import { ValidationError } from '../errors.js';
 import path from 'path';
 import type { Profile } from '../types/profile.js';
 
@@ -164,5 +165,224 @@ describe('Parameter Mapping Integration', () => {
     expect(options.params).toBeDefined();
     expect(options.params['$skip']).toBe('10');
     expect(options.params['$top']).toBe('5');
+  });
+
+  it('should prefer first available alias when multiple aliases are provided', async () => {
+    const profile: Profile = {
+      profile_name: 'test-profile',
+      parameter_aliases: {
+        id: ['issue_id', 'project_id']
+      },
+      tools: [
+        {
+          name: 'get_issue',
+          description: 'Get issue by id',
+          operations: {
+            get: 'getIssue'
+          },
+          parameters: {
+            action: { type: 'string', description: 'Action' },
+            id: { type: 'string', description: 'Id' }
+          }
+        }
+      ]
+    };
+
+    const parser = new OpenAPIParser();
+    vi.spyOn(parser, 'getOperation').mockReturnValue({
+      operationId: 'getIssue',
+      method: 'get',
+      path: '/issues/{id}',
+      parameters: [
+        { name: 'id', in: 'path', schema: { type: 'string' } }
+      ],
+      responses: {},
+    } as any);
+
+    const loader = new ProfileLoader();
+    vi.spyOn(loader, 'load').mockResolvedValue(profile);
+
+    const generator = new ToolGenerator(parser);
+    mockLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    server = new MCPServer(mockLogger as any);
+    (server as any).parser = parser;
+    (server as any).profile = profile;
+    (server as any).toolGenerator = generator;
+
+    vi.spyOn(server as any, 'getHttpClientForSession').mockResolvedValue(new HttpClient('http://test', {} as any));
+
+    await (server as any).executeSimpleTool(
+      profile.tools[0],
+      {
+        action: 'get',
+        issue_id: 'ISS-1',
+        project_id: 'SHOULD-NOT-BE-USED'
+      }
+    );
+
+    const [_, url] = requestSpy.mock.calls[0];
+    expect(url).toContain('/issues/ISS-1');
+    expect(url).not.toContain('SHOULD-NOT-BE-USED');
+  });
+
+  it('should serialize array query params provided through aliases', async () => {
+    const profile: Profile = {
+      profile_name: 'test-profile',
+      parameter_aliases: {
+        fields: ['field_list']
+      },
+      tools: [
+        {
+          name: 'list_items',
+          description: 'List items with fields',
+          operations: {
+            list: 'listItems'
+          },
+          parameters: {
+            action: { type: 'string', description: 'Action' },
+            fields: { type: 'array', description: 'Fields' }
+          }
+        }
+      ]
+    };
+
+    const parser = new OpenAPIParser();
+    vi.spyOn(parser, 'getOperation').mockReturnValue({
+      operationId: 'listItems',
+      method: 'get',
+      path: '/items',
+      parameters: [
+        { name: 'fields', in: 'query', schema: { type: 'array', items: { type: 'string' } } }
+      ],
+      responses: {},
+    } as any);
+
+    const loader = new ProfileLoader();
+    vi.spyOn(loader, 'load').mockResolvedValue(profile);
+
+    const generator = new ToolGenerator(parser);
+    mockLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    server = new MCPServer(mockLogger as any);
+    (server as any).parser = parser;
+    (server as any).profile = profile;
+    (server as any).toolGenerator = generator;
+
+    vi.spyOn(server as any, 'getHttpClientForSession').mockResolvedValue(new HttpClient('http://test', {} as any));
+
+    await (server as any).executeSimpleTool(
+      profile.tools[0],
+      {
+        action: 'list',
+        field_list: ['id', 'name']
+      }
+    );
+
+    const [, , options] = requestSpy.mock.calls[0];
+    expect(options.params.fields).toEqual(['id', 'name']);
+  });
+
+  it('should surface validation error when neither parameter nor aliases are provided', async () => {
+    const profile: Profile = {
+      profile_name: 'test-profile',
+      parameter_aliases: {
+        id: ['issue_id']
+      },
+      tools: [
+        {
+          name: 'get_issue',
+          description: 'Get issue by id',
+          operations: {
+            get: 'getIssue'
+          },
+          parameters: {
+            action: { type: 'string', description: 'Action' },
+            id: { type: 'string', description: 'Id' }
+          }
+        }
+      ]
+    };
+
+    const parser = new OpenAPIParser();
+    vi.spyOn(parser, 'getOperation').mockReturnValue({
+      operationId: 'getIssue',
+      method: 'get',
+      path: '/issues/{id}',
+      parameters: [
+        { name: 'id', in: 'path', schema: { type: 'string' } }
+      ],
+      responses: {},
+    } as any);
+
+    const loader = new ProfileLoader();
+    vi.spyOn(loader, 'load').mockResolvedValue(profile);
+
+    const generator = new ToolGenerator(parser);
+    mockLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    server = new MCPServer(mockLogger as any);
+    (server as any).parser = parser;
+    (server as any).profile = profile;
+    (server as any).toolGenerator = generator;
+
+    vi.spyOn(server as any, 'getHttpClientForSession').mockResolvedValue(new HttpClient('http://test', {} as any));
+
+    await expect(
+      (server as any).executeSimpleTool(profile.tools[0], { action: 'get' })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('should allow direct parameter usage when aliases list is empty', async () => {
+    const profile: Profile = {
+      profile_name: 'test-profile',
+      parameter_aliases: {
+        top: []
+      },
+      tools: [
+        {
+          name: 'list_items',
+          description: 'List items',
+          operations: {
+            list: 'listItems'
+          },
+          parameters: {
+            action: { type: 'string', description: 'Action' },
+            top: { type: 'integer', description: 'Top' }
+          }
+        }
+      ]
+    };
+
+    const parser = new OpenAPIParser();
+    vi.spyOn(parser, 'getOperation').mockReturnValue({
+      operationId: 'listItems',
+      method: 'get',
+      path: '/items',
+      parameters: [
+        { name: 'top', in: 'query', schema: { type: 'integer' } }
+      ],
+      responses: {},
+    } as any);
+
+    const loader = new ProfileLoader();
+    vi.spyOn(loader, 'load').mockResolvedValue(profile);
+
+    const generator = new ToolGenerator(parser);
+    mockLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    server = new MCPServer(mockLogger as any);
+    (server as any).parser = parser;
+    (server as any).profile = profile;
+    (server as any).toolGenerator = generator;
+
+    vi.spyOn(server as any, 'getHttpClientForSession').mockResolvedValue(new HttpClient('http://test', {} as any));
+
+    await (server as any).executeSimpleTool(
+      profile.tools[0],
+      {
+        action: 'list',
+        top: 25
+      }
+    );
+
+    const [, , options] = requestSpy.mock.calls[0];
+    expect(options.params.top).toBe('25');
   });
 });

--- a/src/testing/youtrack-integration.test.ts
+++ b/src/testing/youtrack-integration.test.ts
@@ -54,7 +54,8 @@ describe('YouTrack Integration Tests', () => {
     const profilePath = path.resolve(process.cwd(), 'profiles/youtrack/profile.json');
     const openApiPath = path.resolve(process.cwd(), 'profiles/youtrack/openapi.json');
     
-    // Set env var for token
+    // Set env vars for base URL and token
+    process.env.MCP4_API_BASE_URL = 'http://youtrack.test/api';
     process.env.MCP4_API_TOKEN = 'test-token';
     
     mcpServer = new MCPServer();
@@ -63,6 +64,7 @@ describe('YouTrack Integration Tests', () => {
 
   afterAll(() => {
     server.close();
+    delete process.env.MCP4_API_BASE_URL;
     delete process.env.MCP4_API_TOKEN;
   });
 

--- a/tests/e2e/utils/mock-youtrack-server.ts
+++ b/tests/e2e/utils/mock-youtrack-server.ts
@@ -1,0 +1,61 @@
+import { createServer as createMswServer } from '@mswjs/http-middleware';
+import { Server } from 'http';
+import { AddressInfo } from 'net';
+import { createYoutrackHandlers, type RequestLogEntry } from '../../../src/testing/mock-youtrack-server.js';
+
+export interface YoutrackMockServerInstance {
+  server: Server;
+  port: number;
+  youtrackApiUrl: string;
+  requests: RequestLogEntry[];
+  stop: () => Promise<void>;
+}
+
+export interface YoutrackMockConfig {
+  port?: number;
+  apiBasePath?: string;
+}
+
+export async function startStandaloneYoutrackMockServer(
+  config: YoutrackMockConfig = {}
+): Promise<YoutrackMockServerInstance> {
+  const { port = 0, apiBasePath = '/api' } = config;
+  const tempBaseUrl = `http://localhost${apiBasePath}`;
+  const requests: RequestLogEntry[] = [];
+  const handlers = createYoutrackHandlers(tempBaseUrl, requests);
+  const httpServer = createMswServer(...handlers);
+
+  return new Promise((resolve, reject) => {
+    const server = httpServer.listen(port, '127.0.0.1', () => {
+      const address = server.address() as AddressInfo;
+      const actualPort = address.port;
+      const baseUrl = `http://127.0.0.1:${actualPort}${apiBasePath}`;
+      const finalHandlers = createYoutrackHandlers(baseUrl, requests);
+
+      server.close(() => {
+        const finalServer = createMswServer(...finalHandlers);
+        const newServer = finalServer.listen(actualPort, '127.0.0.1', () => {
+          resolve({
+            server: newServer,
+            port: actualPort,
+            youtrackApiUrl: baseUrl,
+            requests,
+            stop: () =>
+              new Promise<void>((res, rej) => {
+                newServer.close((err) => {
+                  if (err) rej(err);
+                  else res();
+                });
+              }),
+          });
+        });
+
+        newServer.on('error', reject);
+      });
+    });
+
+    server.on('error', reject);
+  });
+}
+
+export { getAvailablePort } from './mock-server.js';

--- a/tests/e2e/utils/profile-loader.ts
+++ b/tests/e2e/utils/profile-loader.ts
@@ -11,9 +11,11 @@ export interface ToolOperation {
   toolName: string;
   action: string;
   operationId: string;
+  operationDef: string | Record<string, unknown>;
   requiredParams: Record<string, unknown>;
   description: string;
   isComposite: boolean;
+  isProxyDownload?: boolean;
 }
 
 interface ProfileTool {
@@ -81,8 +83,8 @@ function getParamValue(
   }
   
   // Specific param name mappings for GitLab mock data
-  const knownValues: Record<string, unknown> = {
-    project_id: '12345',
+    const knownValues: Record<string, unknown> = {
+      project_id: '12345',
     group_id: 'davidruzicka',
     resource_id: 'davidruzicka',
     resource_type: 'project',
@@ -92,7 +94,22 @@ function getParamValue(
     job_id: 1234,
     note_id: 1,
     user_id: 1,
-    branch: 'main',
+    id: 'YT-123',
+    issueCommentId: 'c-1',
+    issueAttachmentId: 'att-1',
+    issueWorkItemId: 'work-1',
+    issueLinkId: 'link-1',
+    issueId: 'YT-124',
+    articleCommentId: 'ac-1',
+    articleAttachmentId: 'aat-1',
+    agile_id: 'agile-1',
+    sprintId: 'sprint-1',
+      tagId: 'tag-1',
+      sprint_id: 'sprint-1',
+      article_id: 'article-1',
+      duration: { minutes: 30 },
+      date: 1700000000000,
+      branch: 'main',
     ref: 'main',
     title: 'Test title',
     body: 'Test comment body',
@@ -116,6 +133,8 @@ function getParamValue(
       return false;
     case 'array':
       return [];
+    case 'object':
+      return {};
     default:
       return 'test-value';
   }
@@ -138,20 +157,27 @@ export function loadProfileOperations(profilePath: string): ToolOperation[] {
         toolName: tool.name,
         action: 'composite',
         operationId: `${tool.name}_composite`,
+        operationDef: tool.steps || [],
         requiredParams: getRequiredParams(tool, 'composite'),
         description: tool.description || '',
         isComposite: true,
       });
     } else if (tool.operations) {
       // Standard tool with multiple operations
-      for (const [action, operationId] of Object.entries(tool.operations)) {
+      for (const [action, operationConfig] of Object.entries(tool.operations)) {
+        const operationId = typeof operationConfig === 'string'
+          ? operationConfig
+          : (operationConfig as Record<string, unknown>).type?.toString() || 'complex_operation';
+
         operations.push({
           toolName: tool.name,
           action,
           operationId,
+          operationDef: operationConfig as any,
           requiredParams: getRequiredParams(tool, action),
           description: tool.description || '',
           isComposite: false,
+          isProxyDownload: typeof operationConfig === 'object' && (operationConfig as any).type === 'proxy_download',
         });
       }
     }

--- a/tests/e2e/youtrack-coverage.test.ts
+++ b/tests/e2e/youtrack-coverage.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { resolve } from 'path';
+import { readFileSync } from 'fs';
+import { McpProcess, JsonRpcResponse } from './utils/mcp-process.js';
+import {
+  startStandaloneYoutrackMockServer,
+  getAvailablePort,
+  YoutrackMockServerInstance,
+} from './utils/mock-youtrack-server.js';
+import { loadProfileOperations, groupOperationsByTool } from './utils/profile-loader.js';
+
+const PROFILE_PATH = resolve(process.cwd(), 'profiles/youtrack/profile.json');
+const OPENAPI_PATH = resolve(process.cwd(), 'profiles/youtrack/openapi.json');
+
+type ToolResult = {
+  content: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+};
+
+const profile = JSON.parse(readFileSync(PROFILE_PATH, 'utf-8')) as {
+  tools: Array<{
+    name: string;
+    response_fields?: Record<string, string[]>;
+    send_response_fields_as_param?: boolean;
+  }>;
+};
+
+function hasResponseFields(toolName: string, action: string): boolean {
+  const tool = profile.tools.find((t) => t.name === toolName);
+  return Boolean(tool?.send_response_fields_as_param && tool.response_fields?.[action]);
+}
+
+function parseResult(response: JsonRpcResponse): any {
+  if (response.error) {
+    // Surface server-side validation details when a call fails
+    // eslint-disable-next-line no-console
+    console.error('YouTrack tool call error', response.error);
+  }
+  expect(response.error).toBeUndefined();
+  const result = response.result as ToolResult;
+  expect(result.content?.length).toBeGreaterThan(0);
+  const payloadText = result.content[0].text;
+  expect(payloadText).toBeDefined();
+  return JSON.parse(payloadText!);
+}
+
+describe('YouTrack Tools Coverage E2E', () => {
+  let mockServer: YoutrackMockServerInstance;
+  let mockServerPort: number;
+  let mcp: McpProcess;
+  let sessionId: string | undefined;
+
+  const operations = loadProfileOperations(PROFILE_PATH);
+  const operationsByTool = groupOperationsByTool(operations);
+
+  beforeAll(async () => {
+    mockServerPort = await getAvailablePort();
+    mockServer = await startStandaloneYoutrackMockServer({ port: mockServerPort });
+  });
+
+  afterAll(async () => {
+    await mockServer.stop();
+  });
+
+  beforeEach(async () => {
+    const httpPort = await getAvailablePort();
+    mcp = new McpProcess({
+      transport: 'http',
+      openapiSpecPath: OPENAPI_PATH,
+      profilePath: PROFILE_PATH,
+      apiBaseUrl: mockServer.youtrackApiUrl,
+      apiToken: 'yt-test-token',
+      httpPort,
+      logLevel: 'ERROR',
+    });
+
+    mcp.on('stderr', (data) => {
+      // eslint-disable-next-line no-console
+      console.error(data);
+    });
+
+    await mcp.start();
+
+    const initResponse = await mcp.initialize();
+    expect(initResponse.error).toBeUndefined();
+    sessionId = undefined;
+  });
+
+  afterEach(async () => {
+    await mcp.stop();
+  });
+
+  for (const [toolName, toolOps] of operationsByTool) {
+    describe(toolName, () => {
+      for (const operation of toolOps) {
+        it(`${operation.action} completes with structured payload`, async () => {
+          const requestCount = mockServer.requests.length;
+          const params = { ...operation.requiredParams };
+          if (operation.action && !operation.isComposite) {
+            params.action = operation.action;
+          }
+
+          const response = await mcp.callTool(toolName, params, sessionId);
+          const newRequests = mockServer.requests.slice(requestCount);
+          let payload: any;
+          try {
+            payload = parseResult(response);
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.error('Captured requests for failed call', newRequests);
+            throw err;
+          }
+
+          if (hasResponseFields(toolName, operation.action)) {
+            const requestWithFields = newRequests.find(r => r.query.fields !== undefined);
+            if (!requestWithFields) {
+              // eslint-disable-next-line no-console
+              console.error('Missing fields parameter in requests', { action: operation.action, requests: newRequests });
+            }
+            expect(requestWithFields?.query.fields).toBeDefined();
+          }
+
+          if (operation.isProxyDownload) {
+            expect(payload.content).toBeDefined();
+            expect(payload.mimeType).toBeDefined();
+            expect(payload.metadata?.url || payload.metadata?.data?.url).toBeDefined();
+          } else if (Array.isArray(payload)) {
+            expect(payload.length).toBeGreaterThan(0);
+          } else {
+            expect(newRequests.length).toBeGreaterThan(0);
+            expect(payload).not.toBeUndefined();
+          }
+        }, 20000);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- remove the hard-coded base URL from the YouTrack profile and OpenAPI spec
- ensure YouTrack integration tests set their own base URL via environment variables

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a7d83fdfc83288ef0e4864a9e8d96)