### PR TITLE
Improve coverage for server utilities

### DIFF
--- a/src/interceptors.test.ts
+++ b/src/interceptors.test.ts
@@ -185,6 +185,21 @@ describe('HttpClient - Auth Interceptors', () => {
   });
 });
 
+describe('HttpClient - accessors', () => {
+  it('should expose baseUrl and interceptor config for diagnostics', () => {
+    const config: InterceptorConfig = {
+      array_format: 'indices',
+      rate_limit: { max_requests_per_minute: 60 },
+    };
+
+    const chain = new InterceptorChain(config);
+    const client = new HttpClient('https://example.test', chain);
+
+    expect(client.getBaseUrl()).toBe('https://example.test');
+    expect(client.getInterceptorsConfig()).toEqual(config);
+  });
+});
+
 describe('InterceptorChain - getAuthCredentials', () => {
   const originalEnv = { ...process.env };
 

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -4,7 +4,7 @@
  * Why: Test server initialization, tool listing, and behavior without profile.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import path from 'path';
 import { MCPServer } from './mcp-server.js';
 import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
@@ -417,6 +417,78 @@ describe('MCPServer', () => {
         await serverWithLogger.stop();
         process.env.MCP4_ALLOWED_ORIGINS = prev;
       }
+    });
+  });
+
+  describe('runHttp configuration', () => {
+    const originalEnv = { ...process.env };
+
+    afterEach(() => {
+      process.env = { ...originalEnv };
+      vi.resetModules();
+      vi.clearAllMocks();
+    });
+
+    it('should derive OAuth redirect hosts and token limits from environment', async () => {
+      const capturedConfigs: any[] = [];
+
+      vi.doMock('./http-transport.js', () => {
+        return {
+          HttpTransport: class {
+            constructor(config: any) {
+              capturedConfigs.push(config);
+            }
+            setMessageHandler() {}
+            onSessionDestroyed() {}
+            async start() {}
+            async stop() {}
+            hasOAuthProvider() { return false; }
+            getSessionToken() { return undefined; }
+            ensureValidSessionToken() { return Promise.resolve(true); }
+          }
+        };
+      });
+
+      const { MCPServer: MockedMCPServer } = await import('./mcp-server.js');
+      const serverWithMock = new MockedMCPServer({
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      } as any);
+
+      (serverWithMock as any).parser = {
+        getBaseUrl: () => 'https://api.test',
+        getResourceMetadata: () => ({ name: 'Test', documentation: 'Docs' })
+      };
+
+      (serverWithMock as any).profile = {
+        profile_name: 'test',
+        description: 'test profile',
+        tools: [],
+        interceptors: {
+          auth: [{
+            type: 'oauth',
+            priority: 1,
+            oauth_config: {
+              issuer: 'https://issuer.test',
+              client_id: 'client-id',
+              redirect_uri: 'https://app.test/callback'
+            }
+          }]
+        }
+      };
+
+      process.env.MCP4_ALLOWED_ORIGINS = 'https://*.allowed.test';
+      process.env.MCP4_TOKEN_MAX_LENGTH = '2048';
+
+      await serverWithMock.runHttp('127.0.0.1', 0);
+      await serverWithMock.stop();
+
+      expect(capturedConfigs).toHaveLength(1);
+      const config = capturedConfigs[0];
+      expect(config.maxTokenLength).toBe(2048);
+      expect(config.oauthConfig?.allowed_redirect_hosts).toEqual(['*.allowed.test']);
     });
   });
 

--- a/src/tool-generator.test.ts
+++ b/src/tool-generator.test.ts
@@ -317,9 +317,26 @@ describe('ToolGenerator', () => {
       const mapOp = generator.mapActionToOperation(toolDef!, {
         action: 'list'
       });
-      
+
       const isMultipart = generator.isMultipartOperation(mapOp!);
       expect(isMultipart).toBe(false);
+    });
+
+    it('should return true for multipart operations', () => {
+      const stubParser: any = {
+        getOperation: () => ({
+          requestBody: {
+            content: {
+              'multipart/form-data': {
+                schema: { type: 'object' }
+              }
+            }
+          }
+        })
+      };
+
+      const multipartGenerator = new ToolGenerator(stubParser);
+      expect(multipartGenerator.isMultipartOperation('uploadOp')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add HttpClient accessor coverage to verify exposed configuration helpers
- test multipart operation detection in tool generator with multipart request bodies
- mock HTTP transport in MCP server tests to assert OAuth redirect host extraction and token limits

## Testing
- npm test -- --run src/interceptors.test.ts src/tool-generator.test.ts src/mcp-server.test.ts --reporter dot

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ae0cd22c48328b0949fd9c3955778)