### PR TITLE
Add proxy download env for specifying maximum download file sizee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Documented proxy download size override precedence and profile configuration.
+
 ## [0.2.4] - 2025-12-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -343,6 +343,17 @@ npm start
 
 **Note**: If OpenAPI spec has `security` defined, it takes precedence over force auth settings.
 
+### Optional - Proxy download size limits
+- `MCP4_PROXY_MAX_BYTES`: Global override for proxy download size limit (bytes). Must be a positive integer.
+- Profile-specific env vars can take precedence when defined by the profile via `max_size_bytes_from_env` on a `proxy_download` operation.
+
+**Precedence**: profile-specific env override → `MCP4_PROXY_MAX_BYTES` → profile `max_size_bytes` → built-in default (10MB).
+
+**Example**: Cap proxy downloads to 2MB globally
+```bash
+export MCP4_PROXY_MAX_BYTES=2097152
+```
+
 ### Optional - Tool Name Shortening
 When generating tools from OpenAPI without a profile, long operation IDs may exceed limits. Configure automatic shortening:
 

--- a/docs/PROFILE-GUIDE.md
+++ b/docs/PROFILE-GUIDE.md
@@ -166,6 +166,43 @@ Chains multiple API calls and returns aggregated results.
 - `store_as`: JSON path where to store result (e.g., `issue.comments`)
 - **Parameter aliases**: Composite tools automatically use `parameter_aliases` from profile to map parameters in `call` steps. For example, if your tool accepts `project_id` but the OpenAPI path uses `{id}`, the alias mapping will resolve it correctly.
 
+### 3. Proxy download tool
+
+Use `proxy_download` operations when an API returns a URL for binary content that still requires authentication (e.g., attachment downloads). The server fetches metadata, validates limits, downloads the file, and returns base64 content.
+
+**Example: proxying an attachment download**
+
+```json
+{
+  "name": "download_issue_attachment",
+  "description": "Download an issue attachment with validation",
+  "operations": {
+    "download_issue_attachment": {
+      "type": "proxy_download",
+      "metadata_endpoint": "get_/issues/{id}/attachments/{attachmentId}",
+      "url_field": "url",
+      "skip_auth": true,
+      "max_size_bytes": 10485760,
+      "max_size_bytes_from_env": "MYAPP_PROXY_MAX_BYTES"
+    }
+  }
+}
+```
+
+**Key fields**
+
+- `metadata_endpoint` (required): Operation ID that returns the URL to download.
+- `url_field` (optional): Dot-notation path to the URL inside the metadata response (default: `"url"`).
+- `max_size_bytes` (optional): Download size limit in bytes (default: 10 MB).
+- `max_size_bytes_from_env` (optional): Environment variable name that overrides `max_size_bytes` (e.g., `CUSTOM_PROXY_MAX_BYTES`).
+- `timeout_ms` (optional): Download timeout in milliseconds (default: 30000).
+- `allowed_mime_types` (optional): Whitelist of allowed MIME types (supports wildcards such as `image/*`).
+- `skip_auth` (optional): When `true`, skips auth for the final download URL (useful for pre-signed links).
+
+**Download size precedence**
+
+`max_size_bytes_from_env` → `MCP4_PROXY_MAX_BYTES` → `max_size_bytes` → default (10 MB). Invalid env values raise a `ValidationError`.
+
 ## Parameters
 
 ### Basic Parameter

--- a/profile-schema.json
+++ b/profile-schema.json
@@ -570,6 +570,10 @@
           "default": 10485760,
           "minimum": 1
         },
+        "max_size_bytes_from_env": {
+          "type": "string",
+          "description": "Environment variable that overrides max_size_bytes when set"
+        },
         "timeout_ms": {
           "type": "number",
           "description": "Timeout for download in milliseconds",

--- a/profiles/youtrack/profile.json
+++ b/profiles/youtrack/profile.json
@@ -44,8 +44,7 @@
           "type": "proxy_download",
           "metadata_endpoint": "get_/issues/{id}/attachments/{issueAttachmentId}",
           "url_field": "url",
-          "skip_auth": true,
-          "max_size_bytes": 10485760
+          "skip_auth": true
         },
         "list_issue_tags": "get_/issues/{id}/tags",
         "list_issue_links": "get_/issues/{id}/links",
@@ -63,8 +62,7 @@
           "type": "proxy_download",
           "metadata_endpoint": "get_/articles/{id}/attachments/{articleAttachmentId}",
           "url_field": "url",
-          "skip_auth": true,
-          "max_size_bytes": 10485760
+          "skip_auth": true
         },
         "list_tags": "get_/tags",
         "get_tag": "get_/tags/{id}",

--- a/src/generated-schemas.ts
+++ b/src/generated-schemas.ts
@@ -26,6 +26,7 @@ export const proxyDownloadOperationSchema = z.object({
     metadata_endpoint: z.string(),
     url_field: z.string().optional(),
     max_size_bytes: z.number().optional(),
+    max_size_bytes_from_env: z.string().optional(),
     timeout_ms: z.number().optional(),
     allowed_mime_types: z.array(z.string()).optional(),
     skip_auth: z.boolean().optional()

--- a/src/proxy-executor.test.ts
+++ b/src/proxy-executor.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ProxyDownloadExecutor } from './proxy-executor.js';
+import { ValidationError } from './errors.js';
 import type { ProxyDownloadOperation } from './types/profile.js';
 import type { AuthCredentials } from './interceptors.js';
 
@@ -857,6 +858,110 @@ describe('ProxyDownloadExecutor - skip_auth option', () => {
     ).rejects.toThrow(
       "MIME type 'application/x-msdownload' not in whitelist: image/jpeg, image/png, application/pdf"
     );
+  });
+});
+
+describe('ProxyDownloadExecutor - env overrides', () => {
+  const mockHttpClient = { request: vi.fn() };
+  let originalFetch: typeof fetch;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env = { ...originalEnv };
+  });
+
+  it('should honor env override when enforcing size', async () => {
+    process.env.MCP4_PROXY_MAX_BYTES = '2048';
+
+    mockHttpClient.request.mockResolvedValue({
+      status: 200,
+      headers: {},
+      body: {
+        url: 'https://example.com/file',
+        mimeType: 'application/octet-stream',
+      },
+    });
+
+    const oversizedBuffer = new ArrayBuffer(4096);
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ 'content-length': '4096' }),
+      arrayBuffer: () => Promise.resolve(oversizedBuffer),
+    });
+
+    const executor = new ProxyDownloadExecutor(mockHttpClient as any);
+    const operation: ProxyDownloadOperation = {
+      type: 'proxy_download',
+      metadata_endpoint: 'get_/file',
+      url_field: 'url',
+      max_size_bytes_from_env: 'MCP4_PROXY_MAX_BYTES',
+    };
+
+    await expect(
+      executor.execute(operation, '/file', { headers: {} })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('should throw ValidationError for invalid env override value', async () => {
+    process.env.MCP4_PROXY_MAX_BYTES = 'abc';
+
+    mockHttpClient.request.mockResolvedValue({
+      status: 200,
+      headers: {},
+      body: {
+        url: 'https://example.com/file',
+        mimeType: 'application/octet-stream',
+      },
+    });
+
+    const executor = new ProxyDownloadExecutor(mockHttpClient as any);
+    const operation: ProxyDownloadOperation = {
+      type: 'proxy_download',
+      metadata_endpoint: 'get_/file',
+      url_field: 'url',
+    };
+
+    await expect(
+      executor.execute(operation, '/file', { headers: {} })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('should fall back to operation max_size_bytes when env override is absent', async () => {
+    delete process.env.MCP4_PROXY_MAX_BYTES;
+
+    mockHttpClient.request.mockResolvedValue({
+      status: 200,
+      headers: {},
+      body: {
+        url: 'https://example.com/file',
+        mimeType: 'application/octet-stream',
+      },
+    });
+
+    const oversizedBuffer = new ArrayBuffer(8192);
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({}),
+      arrayBuffer: () => Promise.resolve(oversizedBuffer),
+    });
+
+    const executor = new ProxyDownloadExecutor(mockHttpClient as any);
+    const operation: ProxyDownloadOperation = {
+      type: 'proxy_download',
+      metadata_endpoint: 'get_/file',
+      url_field: 'url',
+      max_size_bytes: 4096,
+    };
+
+    await expect(
+      executor.execute(operation, '/file', { headers: {} })
+    ).rejects.toThrow('exceeds maximum');
   });
 });
 

--- a/src/proxy-executor.ts
+++ b/src/proxy-executor.ts
@@ -56,7 +56,7 @@ export class ProxyDownloadExecutor {
     path: string,
     authCredentials: AuthCredentials
   ): Promise<ProxyDownloadResult> {
-    const maxSize = operation.max_size_bytes ?? DEFAULT_MAX_SIZE;
+    const maxSize = this.resolveMaxSize(operation);
     const timeout = operation.timeout_ms ?? DEFAULT_TIMEOUT;
     const urlField = operation.url_field ?? 'url';
 
@@ -107,6 +107,31 @@ export class ProxyDownloadExecutor {
       size,
       fileName: metadata['name'] as string | undefined,
     };
+  }
+
+  private resolveMaxSize(operation: ProxyDownloadOperation): number {
+    const envKeys = [operation.max_size_bytes_from_env, 'MCP4_PROXY_MAX_BYTES'].filter(
+      Boolean
+    ) as string[];
+
+    for (const key of envKeys) {
+      const rawValue = process.env[key];
+      if (rawValue !== undefined) {
+        const parsed = Number(rawValue);
+        if (!Number.isInteger(parsed) || parsed <= 0) {
+          throw new ValidationError(
+            `Invalid max size from env ${key}: expected positive integer, got '${rawValue}'`
+          );
+        }
+        return parsed;
+      }
+    }
+
+    if (operation.max_size_bytes !== undefined) {
+      return operation.max_size_bytes;
+    }
+
+    return DEFAULT_MAX_SIZE;
   }
 
   /**

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -78,6 +78,9 @@ export interface ProxyDownloadOperation {
   
   /** Maximum file size in bytes (default: 10MB = 10485760) */
   max_size_bytes?: number;
+
+  /** Optional environment variable that overrides max_size_bytes (e.g., 'CUSTOM_PROXY_MAX_BYTES') */
+  max_size_bytes_from_env?: string;
   
   /** Timeout for download in milliseconds (default: 30000) */
   timeout_ms?: number;


### PR DESCRIPTION
## Summary
- add proxy download env MCP4_PROXY_MAX_BYTES for specifying maximum file size download for proxy downloader
- update documentation and type comments to reference generic proxy download env overrides
- align proxy download tests with the global env override behavior

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b4e77ab64832889a50c14164557fc)