### PR TITLE
Add IP validation coverage for OAuth provider

### DIFF
--- a/src/oauth-provider.test.ts
+++ b/src/oauth-provider.test.ts
@@ -102,6 +102,24 @@ describe('ExternalOAuthProvider', () => {
         );
       });
 
+      it('rejects CIDR ranges with mismatched versions or non-numeric masks', () => {
+        const matcher = (provider as any).matchCIDR.bind(provider);
+
+        expect(matcher('192.168.1.1', '2001:db8::/32')).toBe(false);
+        expect(matcher('::1', '10.0.0.0/8')).toBe(false);
+        expect(matcher('10.0.0.1', '10.0.0.0/not-a-number')).toBe(false);
+      });
+
+      it('logs warning for invalid IPv6 CIDR mask bits', () => {
+        const matcher = (provider as any).matchCIDR.bind(provider);
+
+        expect(matcher('2001:db8::1', '2001:db8::/200')).toBe(false);
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'Invalid IPv6 CIDR mask bits for redirect host allowlist',
+          { cidr: '2001:db8::/200' }
+        );
+      });
+
       it('converts IPv4 to integer and validates octets', () => {
         const toInt = (provider as any).ipv4ToInt.bind(provider);
 


### PR DESCRIPTION
## Summary
- add additional CIDR validation tests covering IPv4/IPv6 mask edge cases and version mismatches

## Testing
- npm test -- oauth-provider.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d2df6333483289cc818efc2a418d3)