### PR TITLE
Add global and session tool filtering (env + X-Mcp4-Tools) with validation, metrics, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,23 @@ export MCP4_TOOLNAME_WARN_ONLY=false
 export MCP4_TOOLNAME_MAX=30
 ```
 
+### Optional - Tool Filtering
+Filter tools globally at startup and per session for HTTP transport.
+
+- `MCP4_TOOL_FILTER_ALLOW_LIST`: Comma-separated tool names to allow (exact match)
+- `MCP4_TOOL_FILTER_ALLOW_REGEX`: Regex pattern to allow tool names (auto-anchored unless already anchored)
+- `MCP4_TOOL_FILTER_DENY_LIST`: Comma-separated tool names to deny (exact match)
+- `MCP4_TOOL_FILTER_DENY_REGEX`: Regex pattern to deny tool names (auto-anchored unless already anchored)
+- `MCP4_TOOL_FILTER_ALLOW_COMPOSITES`: Allow composite list or read tools without explicit naming (`_allow_list`, `_allow_read`)
+- `MCP4_TOOL_FILTER_SESSION_MAX_TOOLS`: Max tool entries in `X-Mcp4-Tools` header (default: `100`)
+- `MCP4_TOOL_FILTER_WARN_THRESHOLD_PCT`: Warn if filtered tools exceed this percentage (default: `90`)
+
+**Example**: Allow only read tools and composite list operations
+```bash
+export MCP4_TOOL_FILTER_ALLOW_REGEX=get_.*
+export MCP4_TOOL_FILTER_ALLOW_COMPOSITES=_allow_list
+```
+
 ### Optional - HTTP Transport
 - `MCP4_HOST`: Bind address (default: `127.0.0.1`)
 - `MCP4_PORT`: Port (default: `3003`)

--- a/docs/HTTP-TRANSPORT.md
+++ b/docs/HTTP-TRANSPORT.md
@@ -99,6 +99,7 @@ Source: https://modelcontextprotocol.io/specification/2025-03-26/basic/transport
   - Supports various token formats: GitLab (`glpat-...`), YouTrack (`perm:...`), generic tokens
   - Flexible whitespace handling (extra spaces are trimmed)
 - `X-Mcp4-Filtering: <filter>` (optional, initialization only)
+- `X-Mcp4-Tools: <tools>` (optional, initialization only)
 
 **Filtering header format**:
 - Comma-separated list of `key=value` items
@@ -109,6 +110,19 @@ Source: https://modelcontextprotocol.io/specification/2025-03-26/basic/transport
 **Example**:
 ```
 X-Mcp4-Filtering: project_id=123, project_id=456, _allow_read
+```
+
+**Tool filter header format**:
+- Comma-separated list of tool names or regex patterns
+- Regex entries use the `regex:` prefix (auto-anchored unless already anchored)
+- Composite keywords: `_allow_list`, `_allow_read`
+- Max entries default: 100 (configurable via `MCP4_TOOL_FILTER_SESSION_MAX_TOOLS`)
+- Max entry length: 255 characters
+- Regex patterns are validated for safety and length limits
+
+**Example**:
+```
+X-Mcp4-Tools: manage_projects, regex:list_.*, _allow_read
 ```
 
 **Request Body**:

--- a/env.example
+++ b/env.example
@@ -189,6 +189,31 @@ MCP4_PROFILE_PATH=profiles/gitlab/developer-profile-oauth.json
 #MCP4_TOOLNAME_MIN_LENGTH=20
 
 # =============================================================================
+# TOOL FILTER CONFIGURATION
+# =============================================================================
+
+# Comma-separated list of tool names to allow (exact match)
+#MCP4_TOOL_FILTER_ALLOW_LIST=get_user,list_users
+
+# Regex pattern to allow tool names (auto-anchored unless already anchored)
+#MCP4_TOOL_FILTER_ALLOW_REGEX=get_.*
+
+# Comma-separated list of tool names to deny (exact match)
+#MCP4_TOOL_FILTER_DENY_LIST=delete_user
+
+# Regex pattern to deny tool names (auto-anchored unless already anchored)
+#MCP4_TOOL_FILTER_DENY_REGEX=delete_.*
+
+# Allow composite list or read tools without explicit naming: _allow_list,_allow_read
+#MCP4_TOOL_FILTER_ALLOW_COMPOSITES=_allow_list
+
+# Max number of tool entries in X-Mcp4-Tools header (default: 100)
+#MCP4_TOOL_FILTER_SESSION_MAX_TOOLS=100
+
+# Warn when filtered tools exceed this percentage (default: 90)
+#MCP4_TOOL_FILTER_WARN_THRESHOLD_PCT=90
+
+# =============================================================================
 # LOGGING CONFIGURATION
 # =============================================================================
 

--- a/src/http-transport.test.ts
+++ b/src/http-transport.test.ts
@@ -62,6 +62,14 @@ describeIfListen('HttpTransport', () => {
       );
     });
 
+    it('handles tools header arrays', () => {
+      const getToolsHeaderValue = (transport as any).getToolsHeaderValue.bind(transport);
+      expect(getToolsHeaderValue({ headers: { 'x-mcp4-tools': [] } })).toBeUndefined();
+      expect(() =>
+        getToolsHeaderValue({ headers: { 'x-mcp4-tools': ['a', 'b'] } })
+      ).toThrow();
+    });
+
     it('exposes session filtering values', () => {
       const sessionId = (transport as any).createSession(
         undefined,
@@ -101,6 +109,79 @@ describeIfListen('HttpTransport', () => {
 
       expect(response.status).toBe(400);
       expect(response.body.message).toContain('X-Mcp4-Filtering header mismatch');
+    });
+  });
+
+  describe('tools header mismatch', () => {
+    it('rejects mismatched tools header on existing session', async () => {
+      transport.setMessageHandler(async () => ({ result: 'ok' }));
+      const sessionId = (transport as any).createSession(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { originalHeader: 'manage_projects', allowNames: ['manage_projects'], allowRegex: [], allowComposite: { allowList: false, allowRead: false } }
+      );
+
+      const response = await request(app)
+        .post('/mcp')
+        .set('Accept', 'application/json')
+        .set('Content-Type', 'application/json')
+        .set('Mcp-Session-Id', sessionId)
+        .set('X-Mcp4-Tools', 'manage_issues')
+        .send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain('X-Mcp4-Tools header mismatch');
+    });
+  });
+
+  describe('tools header validation', () => {
+    it('rejects too many tool entries', async () => {
+      transport.setMessageHandler(async () => ({ result: 'ok' }));
+      const entries = Array.from({ length: 101 }, (_, i) => `tool_${i}`).join(',');
+
+      const response = await request(app)
+        .post('/mcp')
+        .set('Accept', 'application/json')
+        .set('Content-Type', 'application/json')
+        .set('X-Mcp4-Tools', entries)
+        .send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain('X-Mcp4-Tools contains too many entries');
+    });
+
+    it('rejects tool entries exceeding length limit', async () => {
+      transport.setMessageHandler(async () => ({ result: 'ok' }));
+      const longEntry = 'a'.repeat(256);
+
+      const response = await request(app)
+        .post('/mcp')
+        .set('Accept', 'application/json')
+        .set('Content-Type', 'application/json')
+        .set('X-Mcp4-Tools', longEntry)
+        .send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain('X-Mcp4-Tools entry exceeds 255 chars');
+    });
+
+    it('rejects invalid regex entries', async () => {
+      transport.setMessageHandler(async () => ({ result: 'ok' }));
+
+      const response = await request(app)
+        .post('/mcp')
+        .set('Accept', 'application/json')
+        .set('Content-Type', 'application/json')
+        .set('X-Mcp4-Tools', 'regex:(a+)+b')
+        .send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain('X-Mcp4-Tools');
     });
   });
 

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -39,6 +39,12 @@ import {
   generateCorrelationId,
 } from './errors.js';
 import { parseFilteringHeader, normalizeFilteringHeaderValue } from './filtering.js';
+import {
+  parseSessionToolFilterHeader,
+  getSessionToolFilterMaxEntries,
+  type SessionToolFilterRequest,
+  type SessionToolFilterState
+} from './tool-filter.js';
 
 // Default maximum token length (1000 characters)
 const DEFAULT_MAX_TOKEN_LENGTH = 1000;
@@ -1191,6 +1197,13 @@ export class HttpTransport {
       const body = req.body;
       const filteringHeader = normalizeFilteringHeaderValue(this.getFilteringHeaderValue(req));
       const parsedFiltering = filteringHeader ? parseFilteringHeader(filteringHeader) : undefined;
+      const toolsHeaderValue = this.getToolsHeaderValue(req);
+      const toolFilterRequest = toolsHeaderValue !== undefined
+        ? parseSessionToolFilterHeader(toolsHeaderValue, {
+            maxEntries: getSessionToolFilterMaxEntries(),
+            maxEntryLength: 255,
+          })
+        : undefined;
 
       // Validate Accept header per MCP Streamable HTTP specification
       const accept = req.headers.accept || '';
@@ -1233,6 +1246,13 @@ export class HttpTransport {
         if (filteringHeader !== undefined) {
           if (!session.filteringHeader || session.filteringHeader !== filteringHeader) {
             throw new ValidationError('X-Mcp4-Filtering header mismatch for existing session.');
+          }
+        }
+        if (toolsHeaderValue !== undefined) {
+          if (!session.toolFilterRequest?.originalHeader || session.toolFilterRequest.originalHeader !== toolsHeaderValue.trim()) {
+            throw new ValidationError(
+              `X-Mcp4-Tools header mismatch for existing session. Expected: ${session.toolFilterRequest?.originalHeader ?? ''}, Got: ${toolsHeaderValue.trim()}.`
+            );
           }
         }
         this.updateSessionActivity(sessionId);
@@ -1348,7 +1368,8 @@ export class HttpTransport {
             scopes,
             oauthClientId,
             parsedFiltering?.filtering,
-            parsedFiltering?.normalizedHeader
+            parsedFiltering?.normalizedHeader,
+            toolFilterRequest
           );
         }
 
@@ -1699,6 +1720,20 @@ export class HttpTransport {
     return headerValue;
   }
 
+  private getToolsHeaderValue(req: Request): string | undefined {
+    const headerValue = req.headers['x-mcp4-tools'];
+    if (Array.isArray(headerValue)) {
+      if (headerValue.length === 0) {
+        return undefined;
+      }
+      if (headerValue.length > 1) {
+        throw new ValidationError('Invalid X-Mcp4-Tools header. Expected a single header value.');
+      }
+      return headerValue[0];
+    }
+    return headerValue;
+  }
+
   /**
    * Create new session
    *
@@ -1711,7 +1746,8 @@ export class HttpTransport {
     scopes?: string[],
     oauthClientId?: string,
     filtering?: Record<string, string[]>,
-    filteringHeader?: string
+    filteringHeader?: string,
+    toolFilterRequest?: SessionToolFilterRequest
   ): string {
     // Validate token if provided (defense in depth)
     if (authToken) {
@@ -1731,6 +1767,7 @@ export class HttpTransport {
       oauthClientId,
       filtering,
       filteringHeader,
+      toolFilterRequest,
     };
     this.sessions.set(sessionId, session);
     this.logger.info('Session created', { 
@@ -1919,6 +1956,53 @@ export class HttpTransport {
   public getSessionFilteringHeader(sessionId: string): string | undefined {
     const session = this.sessions.get(sessionId);
     return session?.filteringHeader;
+  }
+
+  public getSessionToolFilterRequest(sessionId: string): SessionToolFilterRequest | undefined {
+    const session = this.sessions.get(sessionId);
+    return session?.toolFilterRequest;
+  }
+
+  public getSessionToolFilter(sessionId: string): SessionToolFilterState | undefined {
+    const session = this.sessions.get(sessionId);
+    return session?.toolFilter;
+  }
+
+  public setSessionToolFilter(sessionId: string, toolFilter: SessionToolFilterState): void {
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      session.toolFilter = toolFilter;
+    }
+  }
+
+  public recordGlobalToolFilterMetrics(metrics: {
+    originalCount: number;
+    filteredCount: number;
+    removedCount: number;
+    patterns: Record<string, number>;
+  }): void {
+    if (!this.metrics) {
+      return;
+    }
+
+    this.metrics.recordToolFilterTotals(metrics.originalCount, metrics.filteredCount);
+    for (const [type, count] of Object.entries(metrics.patterns)) {
+      this.metrics.recordToolFilterPatternCount(type, count);
+    }
+  }
+
+  public recordSessionToolCount(sessionId: string, count: number): void {
+    if (!this.metrics) {
+      return;
+    }
+    this.metrics.recordSessionToolCount(sessionId, count);
+  }
+
+  public recordToolFilterRejection(tool: string, source: 'env' | 'session'): void {
+    if (!this.metrics) {
+      return;
+    }
+    this.metrics.recordToolFilterRejection(tool, source);
   }
 
   /**

--- a/src/mcp-server-http-transport-coverage.test.ts
+++ b/src/mcp-server-http-transport-coverage.test.ts
@@ -11,6 +11,12 @@ vi.mock('./http-transport.js', () => {
     public getServerUrl = vi.fn(() => 'http://127.0.0.1:0');
     public ensureValidSessionToken = vi.fn(async () => true);
     public getSessionToken = vi.fn((_sessionId: string) => undefined);
+    public getSessionToolFilterRequest = vi.fn(() => undefined);
+    public getSessionToolFilter = vi.fn(() => undefined);
+    public setSessionToolFilter = vi.fn((_sessionId: string, _filter: any) => {});
+    public recordSessionToolCount = vi.fn((_sessionId: string, _count: number) => {});
+    public recordToolFilterRejection = vi.fn((_tool: string, _source: string) => {});
+    public recordGlobalToolFilterMetrics = vi.fn((_metrics: any) => {});
 
     constructor(public config: any, public logger: any) {}
   }

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -20,6 +20,7 @@ import {
   OperationNotFoundError,
   ConfigurationError
 } from './errors.js';
+import { parseSessionToolFilterHeader } from './tool-filter.js';
 
 describe('MCPServer', () => {
   let server: MCPServer;
@@ -103,6 +104,142 @@ describe('MCPServer', () => {
       await expect((server as any).getHttpClientForSession()).rejects.toThrow(
         /HasEnvToken\(MCP4_API_TOKEN\): false/
       );
+    });
+  });
+
+  describe('global tool filtering', () => {
+    const specPath = path.join(process.cwd(), 'profiles/gitlab/openapi.yaml');
+    const profilePath = path.join(process.cwd(), 'profiles/gitlab/developer-profile-oauth.json');
+    const envKeys = [
+      'MCP4_TOOL_FILTER_ALLOW_LIST',
+      'MCP4_TOOL_FILTER_ALLOW_REGEX',
+      'MCP4_TOOL_FILTER_DENY_LIST',
+      'MCP4_TOOL_FILTER_DENY_REGEX',
+      'MCP4_TOOL_FILTER_ALLOW_COMPOSITES',
+      'MCP4_TOOL_FILTER_WARN_THRESHOLD_PCT',
+    ];
+    const envSnapshot = new Map<string, string | undefined>();
+
+    beforeEach(() => {
+      for (const key of envKeys) {
+        envSnapshot.set(key, process.env[key]);
+        delete process.env[key];
+      }
+    });
+
+    afterEach(() => {
+      for (const key of envKeys) {
+        const value = envSnapshot.get(key);
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    });
+
+    it('should apply allow list filtering', async () => {
+      process.env.MCP4_TOOL_FILTER_ALLOW_LIST = 'manage_projects';
+
+      await server.initialize(specPath, profilePath);
+
+      expect(server['profile']!.tools).toHaveLength(1);
+      expect(server['profile']!.tools[0].name).toBe('manage_projects');
+    });
+
+    it('should reject no-op filter configurations', async () => {
+      process.env.MCP4_TOOL_FILTER_ALLOW_REGEX = '.*';
+
+      await expect(server.initialize(specPath, profilePath)).rejects.toThrow(ConfigurationError);
+    });
+
+    it('should reject filters that remove every tool', async () => {
+      process.env.MCP4_TOOL_FILTER_ALLOW_LIST = 'nonexistent_tool';
+
+      await expect(server.initialize(specPath, profilePath)).rejects.toThrow(ConfigurationError);
+    });
+  });
+
+  describe('session tool filtering', () => {
+    const specPath = path.join(process.cwd(), 'profiles/gitlab/openapi.yaml');
+    const profilePath = path.join(process.cwd(), 'profiles/gitlab/developer-profile-oauth.json');
+
+    beforeEach(async () => {
+      await server.initialize(specPath, profilePath);
+    });
+
+    afterEach(() => {
+      (server as any).httpTransport = null;
+    });
+
+    it('filters tools/list responses for sessions', async () => {
+      const toolFilterState = {
+        originalHeader: 'manage_projects',
+        allowNames: ['manage_projects'],
+        allowRegex: [],
+        allowComposite: { allowList: false, allowRead: false },
+        allowedToolNames: new Set(['manage_projects']),
+      };
+
+      (server as any).httpTransport = {
+        getSessionToolFilter: () => toolFilterState,
+        hasOAuthProvider: () => false,
+      };
+
+      const message = { jsonrpc: '2.0', id: 1, method: 'tools/list' };
+      const response = await (server as any).handleOtherRequest(message, 'session-1');
+
+      expect(response.result.tools).toHaveLength(1);
+      expect(response.result.tools[0].name).toBe('manage_projects');
+    });
+
+    it('blocks tool calls not allowed by session filter', async () => {
+      const toolFilterState = {
+        originalHeader: 'manage_projects',
+        allowNames: ['manage_projects'],
+        allowRegex: [],
+        allowComposite: { allowList: false, allowRead: false },
+        allowedToolNames: new Set(['manage_projects']),
+      };
+
+      (server as any).httpTransport = {
+        getSessionToolFilter: () => toolFilterState,
+        hasOAuthProvider: () => false,
+        recordToolFilterRejection: vi.fn(),
+      };
+
+      const message = {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'manage_merge_requests',
+          arguments: {},
+        },
+      };
+
+      const response = await (server as any).handleToolCall(message, 'session-1');
+      expect(response.error.code).toBe(-32002);
+      expect(response.error.message).toContain('X-Mcp4-Tools');
+    });
+
+    it('rejects no-op session filters during initialization', () => {
+      const request = parseSessionToolFilterHeader('', { maxEntries: 100, maxEntryLength: 255 });
+
+      (server as any).httpTransport = {
+        getSessionToolFilterRequest: () => request,
+        setSessionToolFilter: vi.fn(),
+        recordSessionToolCount: vi.fn(),
+      };
+
+      const message = {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {},
+      };
+
+      expect(() => (server as any).handleInitialize(message, 'session-1')).toThrow(ValidationError);
     });
   });
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -14,6 +14,15 @@ import {
 
 import { OpenAPIParser } from './openapi-parser.js';
 import { ProfileLoader } from './profile-loader.js';
+import {
+  parseToolFilterConfig,
+  applyToolFilter,
+  applySessionToolFilter,
+  normalizeToolName,
+  type ToolFilterConfig,
+  type SessionToolFilterRequest,
+  type SessionToolFilterState
+} from './tool-filter.js';
 import { ToolGenerator } from './tool-generator.js';
 import { normalizeArguments } from './argument-normalizer.js';
 import { CompositeExecutor } from './composite-executor.js';
@@ -54,6 +63,18 @@ export class MCPServer {
   private logger: Logger;
   private httpTransport: any = null;
   private stdioFiltering?: FilteringRules;
+  private globalToolFilter: {
+    removedToolNames: Set<string>;
+    config: ToolFilterConfig;
+    originalCount: number;
+    filteredCount: number;
+  } | null = null;
+  private pendingToolFilterMetrics: {
+    originalCount: number;
+    filteredCount: number;
+    removedCount: number;
+    patterns: Record<string, number>;
+  } | null = null;
 
   /**
    * Execute a tools/call request via the JSON-RPC handler.
@@ -314,6 +335,8 @@ export class MCPServer {
       this.checkToolNameLengths();
     }
 
+    this.applyGlobalToolFiltering();
+
     // Re-create logger with auth config for token redaction
     const authConfigs = this.getAuthConfigs();
     if (authConfigs.length > 0) {
@@ -348,6 +371,107 @@ export class MCPServer {
       baseUrl,
       toolCount: this.profile.tools.length,
     });
+  }
+
+  private applyGlobalToolFiltering(): void {
+    if (!this.profile) {
+      return;
+    }
+
+    const config = parseToolFilterConfig(process.env);
+    if (!config) {
+      return;
+    }
+
+    const originalCount = this.profile.tools.length;
+    const result = applyToolFilter(this.profile.tools, config);
+    const filteredCount = result.allowed.length;
+    const removedCount = result.removed.length;
+
+    if (removedCount === 0) {
+      throw new ConfigurationError(
+        `Tool filter configuration has no effect. Original tool count: ${originalCount}, filtered: ${filteredCount}. Check MCP4_TOOL_FILTER_* patterns.`
+      );
+    }
+
+    if (filteredCount === 0) {
+      const sources = new Set<string>();
+      for (const reason of result.reasons.values()) {
+        const source = reason.split(':')[0];
+        sources.add(source);
+      }
+      throw new ConfigurationError(
+        `All tools filtered out (original: ${originalCount}). Check MCP4_TOOL_FILTER_* settings. Removed by: ${Array.from(sources).join(', ')}.`
+      );
+    }
+
+    this.profile.tools = result.allowed;
+    this.globalToolFilter = {
+      removedToolNames: new Set(result.removed.map(tool => tool.name)),
+      config,
+      originalCount,
+      filteredCount,
+    };
+
+    this.logger.debug('Global tool filter applied', {
+      originalCount,
+      filteredCount,
+      removedCount,
+      allowList: config.allowList,
+      allowRegex: config.allowRegex.map(rule => rule.pattern),
+      denyList: config.denyList,
+      denyRegex: config.denyRegex.map(rule => rule.pattern),
+      allowComposite: config.allowComposite,
+      survivingTools: result.allowed.map(tool => tool.name),
+    });
+
+    for (const tool of result.removed) {
+      this.logger.debug('Tool filtered', {
+        filter_source: 'env',
+        filter_type: result.reasons.get(tool.name),
+        tool: tool.name,
+        action: 'removed',
+      });
+    }
+
+    const warnThreshold = this.getToolFilterWarnThreshold();
+    const percentFiltered = ((originalCount - filteredCount) / originalCount) * 100;
+    if (percentFiltered >= warnThreshold) {
+      this.logger.warn('Tool filter removed high percentage of tools', {
+        original: originalCount,
+        surviving: filteredCount,
+        threshold_pct: warnThreshold,
+        removed_count: originalCount - filteredCount,
+        removed_pct: percentFiltered,
+      });
+    }
+
+    this.pendingToolFilterMetrics = {
+      originalCount,
+      filteredCount,
+      removedCount,
+      patterns: {
+        allow_list: config.allowList.length,
+        allow_regex: config.allowRegex.length,
+        deny_list: config.denyList.length,
+        deny_regex: config.denyRegex.length,
+        allow_composites: Number(config.allowComposite.allowList) + Number(config.allowComposite.allowRead),
+      },
+    };
+  }
+
+  private getToolFilterWarnThreshold(): number {
+    const raw = process.env.MCP4_TOOL_FILTER_WARN_THRESHOLD_PCT;
+    if (raw === undefined) {
+      return 90;
+    }
+    const parsed = parseFloat(raw);
+    if (Number.isNaN(parsed) || parsed < 0 || parsed > 100) {
+      throw new ConfigurationError(
+        `Invalid MCP4_TOOL_FILTER_WARN_THRESHOLD_PCT: expected 0-100, got '${raw}'.`
+      );
+    }
+    return parsed;
   }
 
   /**
@@ -1084,6 +1208,10 @@ export class MCPServer {
     });
 
     await this.httpTransport.start();
+
+    if (this.pendingToolFilterMetrics) {
+      this.httpTransport.recordGlobalToolFilterMetrics(this.pendingToolFilterMetrics);
+    }
     
     this.logger.info('MCP server running on HTTP', { host, port });
   }
@@ -1120,6 +1248,10 @@ export class MCPServer {
       }
       const parsed = parseFilteringHeader(params.filtering);
       this.stdioFiltering = parsed.filtering;
+    }
+
+    if (this.httpTransport && sessionId) {
+      this.applySessionToolFilter(sessionId);
     }
 
     const result: any = {
@@ -1178,11 +1310,7 @@ export class MCPServer {
     }
 
     try {
-      // Find tool definition
-      const toolDef = this.profile?.tools.find(t => t.name === toolName);
-      if (!toolDef) {
-        throw new OperationNotFoundError(toolName);
-      }
+      const toolDef = this.getToolDefinitionForSession(toolName, sessionId);
 
       const filtering = this.getFilteringForSession(sessionId);
       if (filtering) {
@@ -1319,9 +1447,8 @@ export class MCPServer {
 
     // Handle tools/list
     if (req.method === 'tools/list') {
-      const tools = this.profile?.tools.map(toolDef =>
-        this.toolGenerator!.generateTool(toolDef)
-      ) || [];
+      const toolDefinitions = this.filterToolsForSession(this.profile?.tools || [], sessionId);
+      const tools = toolDefinitions.map(toolDef => this.toolGenerator!.generateTool(toolDef));
 
       return {
         jsonrpc: '2.0',
@@ -1341,6 +1468,100 @@ export class MCPServer {
         message: `Method not found: ${req.method}`,
       },
     };
+  }
+
+  private applySessionToolFilter(sessionId: string): void {
+    if (!this.httpTransport || !this.profile) {
+      return;
+    }
+
+    const request = this.httpTransport.getSessionToolFilterRequest(sessionId) as SessionToolFilterRequest | undefined;
+    if (!request) {
+      return;
+    }
+
+    const result = applySessionToolFilter(this.profile.tools, request);
+    const originalCount = this.profile.tools.length;
+    const filteredCount = result.allowedTools.length;
+
+    if (!result.hasEffect) {
+      throw new ValidationError(
+        `X-Mcp4-Tools filter has no effect for this session. Available tools: ${originalCount}, after filter: ${filteredCount}. Check patterns.`
+      );
+    }
+
+    if (filteredCount === 0) {
+      throw new ValidationError(
+        `X-Mcp4-Tools filtered out all tools (original: ${originalCount}). Removed by: allow_rules. Check session filter configuration.`
+      );
+    }
+
+    const toolFilterState: SessionToolFilterState = {
+      ...request,
+      allowedToolNames: result.allowedToolNames,
+    };
+
+    this.httpTransport.setSessionToolFilter(sessionId, toolFilterState);
+
+    this.logger.info('Session tool filter applied', {
+      sessionId,
+      originalCount,
+      filteredCount,
+      allowNames: request.allowNames,
+      allowRegex: request.allowRegex.map(rule => rule.pattern),
+      allowComposite: request.allowComposite,
+    });
+
+    this.httpTransport.recordSessionToolCount(sessionId, filteredCount);
+  }
+
+  private filterToolsForSession(tools: ToolDefinition[], sessionId?: string): ToolDefinition[] {
+    if (!this.httpTransport || !sessionId) {
+      return tools;
+    }
+    const toolFilter = this.httpTransport.getSessionToolFilter(sessionId);
+    if (!toolFilter) {
+      return tools;
+    }
+
+    return tools.filter(tool => toolFilter.allowedToolNames.has(tool.name));
+  }
+
+  private getToolDefinitionForSession(toolName: string, sessionId?: string): ToolDefinition {
+    if (!this.profile) {
+      throw new ConfigurationError('Profile not initialized.');
+    }
+
+    const normalizedName = normalizeToolName(toolName);
+    const toolDef = this.profile.tools.find(tool => tool.name === normalizedName);
+    if (!toolDef) {
+      if (this.globalToolFilter?.removedToolNames.has(normalizedName)) {
+        this.httpTransport?.recordToolFilterRejection(normalizedName, 'env');
+      }
+      throw new OperationNotFoundError(normalizedName);
+    }
+
+    if (this.httpTransport && sessionId) {
+      const toolFilter = this.httpTransport.getSessionToolFilter(sessionId) as SessionToolFilterState | undefined;
+      if (toolFilter && !toolFilter.allowedToolNames.has(normalizedName)) {
+        this.httpTransport.recordToolFilterRejection(normalizedName, 'session');
+        const allowList = toolFilter.allowNames.length > 0 ? toolFilter.allowNames.join(', ') : 'none';
+        const allowRegex = toolFilter.allowRegex.length > 0
+          ? toolFilter.allowRegex.map(rule => rule.pattern).join(', ')
+          : 'none';
+        const compositeFlags = [
+          toolFilter.allowComposite.allowList ? '_allow_list' : null,
+          toolFilter.allowComposite.allowRead ? '_allow_read' : null,
+        ].filter(Boolean).join(', ');
+        const compositeDetail = compositeFlags ? ` Composite keywords: ${compositeFlags}.` : '';
+
+        throw new AuthorizationError(
+          `Tool '${normalizedName}' not allowed in this session. Filter source: X-Mcp4-Tools. Allowed names: ${allowList}. Allowed regex: ${allowRegex}.${compositeDetail}`
+        );
+      }
+    }
+
+    return toolDef;
   }
 
   /**

--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -107,6 +107,49 @@ describe('MetricsCollector', () => {
     });
   });
 
+  describe('Tool Filter Metrics', () => {
+    it('should record tool filter totals', async () => {
+      metrics.recordToolFilterTotals(10, 7);
+
+      const output = await metrics.getMetrics();
+
+      expect(output).toContain('test_tools_total');
+      expect(output).toContain('source="profile"');
+      expect(output).toContain('test_tools_filtered');
+      expect(output).toContain('action="allowed"');
+      expect(output).toContain('action="denied"');
+    });
+
+    it('should record tool filter pattern counts', async () => {
+      metrics.recordToolFilterPatternCount('allow_regex', 2);
+
+      const output = await metrics.getMetrics();
+
+      expect(output).toContain('test_tool_filter_patterns');
+      expect(output).toContain('type="allow_regex"');
+      expect(output).toContain(' 2');
+    });
+
+    it('should record session tool counts', async () => {
+      metrics.recordSessionToolCount('session-1', 3);
+
+      const output = await metrics.getMetrics();
+
+      expect(output).toContain('test_tools_session');
+      expect(output).toContain('session_id="session-1"');
+    });
+
+    it('should record tool filter rejections', async () => {
+      metrics.recordToolFilterRejection('manage_projects', 'session');
+
+      const output = await metrics.getMetrics();
+
+      expect(output).toContain('test_tool_filter_rejections_total');
+      expect(output).toContain('source="session"');
+      expect(output).toContain('tool="manage_projects"');
+    });
+  });
+
   describe('API Call Metrics', () => {
     it('should record API calls', async () => {
       metrics.recordApiCall('get_project_badges', 200, 0.2);
@@ -245,4 +288,3 @@ describe('MetricsCollector', () => {
     });
   });
 });
-

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -34,6 +34,13 @@ export class MetricsCollector {
   private mcpToolCallsTotal: Counter;
   private mcpToolCallDuration: Histogram;
   private mcpToolCallErrors: Counter;
+
+  // Tool filter metrics
+  private toolsTotal: Gauge;
+  private toolsFiltered: Gauge;
+  private toolsSession: Gauge;
+  private toolFilterRejectionsTotal: Counter;
+  private toolFilterPatterns: Gauge;
   
   // API metrics (calls to backend API)
   private apiCallsTotal: Counter;
@@ -101,6 +108,41 @@ export class MetricsCollector {
       name: `${prefix}tool_call_errors_total`,
       help: 'Total number of MCP tool call errors',
       labelNames: ['tool', 'error_type'],
+      registers: [this.registry],
+    });
+
+    this.toolsTotal = new Gauge({
+      name: `${prefix}tools_total`,
+      help: 'Total number of tools',
+      labelNames: ['source'],
+      registers: [this.registry],
+    });
+
+    this.toolsFiltered = new Gauge({
+      name: `${prefix}tools_filtered`,
+      help: 'Tool filtering results',
+      labelNames: ['source', 'action'],
+      registers: [this.registry],
+    });
+
+    this.toolsSession = new Gauge({
+      name: `${prefix}tools_session`,
+      help: 'Tools available per session',
+      labelNames: ['session_id'],
+      registers: [this.registry],
+    });
+
+    this.toolFilterRejectionsTotal = new Counter({
+      name: `${prefix}tool_filter_rejections_total`,
+      help: 'Tool filter rejections',
+      labelNames: ['tool', 'source'],
+      registers: [this.registry],
+    });
+
+    this.toolFilterPatterns = new Gauge({
+      name: `${prefix}tool_filter_patterns`,
+      help: 'Active tool filter patterns',
+      labelNames: ['type'],
       registers: [this.registry],
     });
 
@@ -186,6 +228,28 @@ export class MetricsCollector {
     this.mcpToolCallErrors.inc({ tool, error_type: errorType });
   }
 
+  recordToolFilterTotals(originalCount: number, survivingCount: number): void {
+    if (!this.enabled) return;
+    this.toolsTotal.set({ source: 'profile' }, originalCount);
+    this.toolsFiltered.set({ source: 'global_env', action: 'allowed' }, survivingCount);
+    this.toolsFiltered.set({ source: 'global_env', action: 'denied' }, originalCount - survivingCount);
+  }
+
+  recordToolFilterPatternCount(type: string, count: number): void {
+    if (!this.enabled) return;
+    this.toolFilterPatterns.set({ type }, count);
+  }
+
+  recordSessionToolCount(sessionId: string, count: number): void {
+    if (!this.enabled) return;
+    this.toolsSession.set({ session_id: sessionId }, count);
+  }
+
+  recordToolFilterRejection(tool: string, source: 'env' | 'session'): void {
+    if (!this.enabled) return;
+    this.toolFilterRejectionsTotal.inc({ tool, source });
+  }
+
   /**
    * Record API call to backend
    */
@@ -260,4 +324,3 @@ export class MetricsCollector {
     return 'unknown';
   }
 }
-

--- a/src/profile-loader.ts
+++ b/src/profile-loader.ts
@@ -51,7 +51,8 @@ export class ProfileLoader {
 
     // Validate with Zod - throws detailed error if invalid
     const profile = enhancedProfileSchema.parse(json) as Profile;
-    
+
+    this.normalizeToolNames(profile);
     this.validateLogic(profile);
     
     return profile;
@@ -209,6 +210,22 @@ export class ProfileLoader {
       if (tool.composite && tool.steps) {
         this.validateCompositeStepsDAG(tool.name, tool.steps);
       }
+    }
+  }
+
+  private normalizeToolNames(profile: Profile): void {
+    const seen = new Set<string>();
+
+    for (const tool of profile.tools) {
+      const normalized = tool.name.normalize('NFC');
+      if (seen.has(normalized)) {
+        throw new ValidationError(
+          `Duplicate tool name after normalization: '${normalized}'.`,
+          { toolName: normalized }
+        );
+      }
+      seen.add(normalized);
+      tool.name = normalized;
     }
   }
 

--- a/src/tool-filter.test.ts
+++ b/src/tool-filter.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ToolDefinition } from './types/profile.js';
+import {
+  applyToolFilter,
+  applySessionToolFilter,
+  parseToolFilterConfig,
+  parseSessionToolFilterHeader,
+  detectListReadOperations,
+  normalizeToolName
+} from './tool-filter.js';
+import { ConfigurationError, ValidationError } from './errors.js';
+
+const baseParameters = {
+  action: {
+    type: 'string',
+    description: 'Action',
+    enum: ['list', 'get', 'delete'],
+  },
+  resource_type: {
+    type: 'string',
+    description: 'Resource type',
+    enum: ['user'],
+  },
+};
+
+const tools: ToolDefinition[] = [
+  {
+    name: 'get_user',
+    description: 'Get user',
+    operations: { get: 'getUser' },
+    parameters: baseParameters,
+  },
+  {
+    name: 'list_users',
+    description: 'List users',
+    operations: { list: 'listUsers' },
+    parameters: baseParameters,
+  },
+  {
+    name: 'delete_user',
+    description: 'Delete user',
+    operations: { delete: 'deleteUser' },
+    parameters: baseParameters,
+  },
+  {
+    name: 'composite_list_users',
+    description: 'Composite list users',
+    composite: true,
+    steps: [{ call: 'GET /users', store_as: 'users' }],
+    parameters: baseParameters,
+  },
+];
+
+const unicodeTool: ToolDefinition = {
+  name: 'cafe\u0301_tool',
+  description: 'Unicode tool',
+  operations: { get: 'getCafe' },
+  parameters: baseParameters,
+};
+
+describe('tool filtering', () => {
+  it('applies allow and deny lists with deny precedence', () => {
+    const config = {
+      allowList: ['get_user', 'list_users'],
+      allowRegex: [],
+      denyList: ['get_user'],
+      denyRegex: [],
+      allowComposite: { allowList: false, allowRead: false },
+    };
+
+    const result = applyToolFilter(tools, config);
+    const names = result.allowed.map(tool => tool.name);
+
+    expect(names).toEqual(['list_users']);
+  });
+
+  it('auto-anchors regex patterns', () => {
+    const env = {
+      MCP4_TOOL_FILTER_ALLOW_REGEX: 'get.*',
+    } as NodeJS.ProcessEnv;
+    const config = parseToolFilterConfig(env);
+    expect(config).not.toBeNull();
+
+    const result = applyToolFilter(tools, config!);
+    const names = result.allowed.map(tool => tool.name);
+
+    expect(names).toEqual(['get_user']);
+  });
+
+  it('rejects unsafe regex patterns', () => {
+    const env = {
+      MCP4_TOOL_FILTER_ALLOW_REGEX: '(a+)+b',
+    } as NodeJS.ProcessEnv;
+
+    expect(() => parseToolFilterConfig(env)).toThrow(ConfigurationError);
+  });
+
+  it('keeps case sensitivity for tool names', () => {
+    const config = {
+      allowList: ['Get_User'],
+      allowRegex: [],
+      denyList: [],
+      denyRegex: [],
+      allowComposite: { allowList: false, allowRead: false },
+    };
+
+    const result = applyToolFilter(tools, config);
+    expect(result.allowed).toHaveLength(0);
+  });
+
+  it('allows composite tools via allow keywords', () => {
+    const config = {
+      allowList: [],
+      allowRegex: [],
+      denyList: [],
+      denyRegex: [],
+      allowComposite: { allowList: true, allowRead: false },
+    };
+
+    const result = applyToolFilter(tools, config);
+    expect(result.allowed.map(tool => tool.name)).toEqual(['composite_list_users']);
+  });
+
+  it('normalizes unicode tool names for matching', () => {
+    const config = {
+      allowList: [normalizeToolName('café_tool')],
+      allowRegex: [],
+      denyList: [],
+      denyRegex: [],
+      allowComposite: { allowList: false, allowRead: false },
+    };
+
+    const result = applyToolFilter([unicodeTool], config);
+    expect(result.allowed).toHaveLength(1);
+  });
+});
+
+describe('session tool filtering', () => {
+  it('parses allow list and regex entries', () => {
+    const request = parseSessionToolFilterHeader('get_user, regex:list_.*', {
+      maxEntries: 100,
+      maxEntryLength: 255,
+    });
+
+    expect(request.allowNames).toEqual(['get_user']);
+    expect(request.allowRegex).toHaveLength(1);
+  });
+
+  it('rejects oversized entries', () => {
+    const longEntry = 'a'.repeat(256);
+    expect(() =>
+      parseSessionToolFilterHeader(longEntry, { maxEntries: 100, maxEntryLength: 255 })
+    ).toThrow(ValidationError);
+  });
+
+  it('applies session allow rules', () => {
+    const request = parseSessionToolFilterHeader('get_user, regex:list_.*', {
+      maxEntries: 100,
+      maxEntryLength: 255,
+    });
+
+    const result = applySessionToolFilter(tools, request);
+    expect(result.allowedToolNames.has('get_user')).toBe(true);
+    expect(result.allowedToolNames.has('list_users')).toBe(true);
+    expect(result.allowedToolNames.has('delete_user')).toBe(false);
+  });
+});
+
+describe('list/read detection', () => {
+  it('detects list and read actions', () => {
+    const composite = tools[3];
+    const detection = detectListReadOperations(composite);
+    expect(detection.isList).toBe(true);
+    expect(detection.isRead).toBe(true);
+  });
+});

--- a/src/tool-filter.ts
+++ b/src/tool-filter.ts
@@ -1,0 +1,397 @@
+import type { ToolDefinition } from './types/profile.js';
+import { ConfigurationError, ValidationError } from './errors.js';
+
+const MAX_REGEX_LENGTH = 100;
+
+export interface ToolFilterRegexRule {
+  pattern: string;
+  regex: RegExp;
+}
+
+export interface ToolFilterConfig {
+  allowList: string[];
+  allowRegex: ToolFilterRegexRule[];
+  denyList: string[];
+  denyRegex: ToolFilterRegexRule[];
+  allowComposite: {
+    allowList: boolean;
+    allowRead: boolean;
+  };
+}
+
+export interface ToolFilterResult {
+  allowed: ToolDefinition[];
+  removed: ToolDefinition[];
+  reasons: Map<string, string>;
+}
+
+export interface SessionToolFilterRequest {
+  originalHeader: string;
+  allowNames: string[];
+  allowRegex: ToolFilterRegexRule[];
+  allowComposite: {
+    allowList: boolean;
+    allowRead: boolean;
+  };
+}
+
+export interface SessionToolFilterState extends SessionToolFilterRequest {
+  allowedToolNames: Set<string>;
+}
+
+export interface SessionToolFilterResult {
+  allowedTools: ToolDefinition[];
+  removedTools: ToolDefinition[];
+  allowedToolNames: Set<string>;
+  reasons: Map<string, string>;
+  hasEffect: boolean;
+}
+
+export function normalizeToolName(name: string): string {
+  return name.normalize('NFC');
+}
+
+export function parseToolFilterConfig(env: NodeJS.ProcessEnv): ToolFilterConfig | null {
+  const allowList = parseCommaList(env.MCP4_TOOL_FILTER_ALLOW_LIST).map(normalizeToolName);
+  const allowRegex = parseRegexList(env.MCP4_TOOL_FILTER_ALLOW_REGEX, 'MCP4_TOOL_FILTER_ALLOW_REGEX');
+  const denyList = parseCommaList(env.MCP4_TOOL_FILTER_DENY_LIST).map(normalizeToolName);
+  const denyRegex = parseRegexList(env.MCP4_TOOL_FILTER_DENY_REGEX, 'MCP4_TOOL_FILTER_DENY_REGEX');
+  const allowComposite = parseAllowComposites(env.MCP4_TOOL_FILTER_ALLOW_COMPOSITES);
+
+  if (
+    allowList.length === 0 &&
+    allowRegex.length === 0 &&
+    denyList.length === 0 &&
+    denyRegex.length === 0 &&
+    !allowComposite.allowList &&
+    !allowComposite.allowRead
+  ) {
+    return null;
+  }
+
+  return {
+    allowList,
+    allowRegex,
+    denyList,
+    denyRegex,
+    allowComposite,
+  };
+}
+
+export function parseSessionToolFilterHeader(
+  headerValue: string,
+  options: { maxEntries: number; maxEntryLength: number }
+): SessionToolFilterRequest {
+  const normalizedHeader = headerValue.trim();
+  const allowNames: string[] = [];
+  const allowRegex: ToolFilterRegexRule[] = [];
+  const allowComposite = {
+    allowList: false,
+    allowRead: false,
+  };
+
+  const entries = normalizedHeader.length > 0 ? normalizedHeader.split(',') : [''];
+  const trimmedEntries = entries
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0);
+
+  if (trimmedEntries.length > options.maxEntries) {
+    throw new ValidationError(
+      `X-Mcp4-Tools contains too many entries (${trimmedEntries.length} > ${options.maxEntries}). Reduce to ${options.maxEntries} or configure MCP4_TOOL_FILTER_SESSION_MAX_TOOLS.`
+    );
+  }
+
+  for (const entry of trimmedEntries) {
+    if (entry.length > options.maxEntryLength) {
+      throw new ValidationError(
+        `X-Mcp4-Tools entry exceeds ${options.maxEntryLength} chars: '${entry}' (${entry.length} chars).`
+      );
+    }
+
+    if (entry === '_allow_list') {
+      allowComposite.allowList = true;
+      continue;
+    }
+
+    if (entry === '_allow_read') {
+      allowComposite.allowRead = true;
+      continue;
+    }
+
+    if (entry.startsWith('regex:')) {
+      const rawPattern = entry.slice('regex:'.length).trim();
+      if (!rawPattern) {
+        throw new ValidationError('X-Mcp4-Tools regex entry must include a pattern.');
+      }
+      const anchored = autoAnchorPattern(rawPattern.normalize('NFC'));
+      allowRegex.push(compileSessionRegexRule(anchored, 'X-Mcp4-Tools'));
+      continue;
+    }
+
+    allowNames.push(normalizeToolName(entry));
+  }
+
+  return {
+    originalHeader: normalizedHeader,
+    allowNames,
+    allowRegex,
+    allowComposite,
+  };
+}
+
+export function applyToolFilter(tools: ToolDefinition[], config: ToolFilterConfig): ToolFilterResult {
+  const allowed: ToolDefinition[] = [];
+  const removed: ToolDefinition[] = [];
+  const reasons = new Map<string, string>();
+
+  const hasAllowRules =
+    config.allowList.length > 0 ||
+    config.allowRegex.length > 0 ||
+    config.allowComposite.allowList ||
+    config.allowComposite.allowRead;
+
+  const allowListSet = new Set(config.allowList);
+  const denyListSet = new Set(config.denyList);
+
+  for (const tool of tools) {
+    const toolName = normalizeToolName(tool.name);
+    let allowedByAllowRules = !hasAllowRules;
+    if (!allowedByAllowRules) {
+      if (allowListSet.has(toolName) || matchesRegex(toolName, config.allowRegex)) {
+        allowedByAllowRules = true;
+      } else if (tool.composite) {
+        const { isList, isRead } = detectListReadOperations(tool);
+        if (config.allowComposite.allowList && isList) {
+          allowedByAllowRules = true;
+        }
+        if (config.allowComposite.allowRead && isRead) {
+          allowedByAllowRules = true;
+        }
+      }
+    }
+
+    if (!allowedByAllowRules) {
+      removed.push(tool);
+      reasons.set(toolName, 'allow_rules');
+      continue;
+    }
+
+    if (denyListSet.has(toolName)) {
+      removed.push(tool);
+      reasons.set(toolName, 'deny_list');
+      continue;
+    }
+
+    const denyPattern = findMatchingPattern(toolName, config.denyRegex);
+    if (denyPattern) {
+      removed.push(tool);
+      reasons.set(toolName, `deny_regex:${denyPattern}`);
+      continue;
+    }
+
+    allowed.push(tool);
+  }
+
+  return { allowed, removed, reasons };
+}
+
+export function applySessionToolFilter(
+  tools: ToolDefinition[],
+  request: SessionToolFilterRequest
+): SessionToolFilterResult {
+  const allowedTools: ToolDefinition[] = [];
+  const removedTools: ToolDefinition[] = [];
+  const reasons = new Map<string, string>();
+  const allowedToolNames = new Set<string>();
+
+  const hasAllowRules =
+    request.allowNames.length > 0 ||
+    request.allowRegex.length > 0 ||
+    request.allowComposite.allowList ||
+    request.allowComposite.allowRead;
+
+  const allowNameSet = new Set(request.allowNames);
+
+  for (const tool of tools) {
+    const toolName = normalizeToolName(tool.name);
+    let allowed = !hasAllowRules;
+
+    if (!allowed) {
+      if (allowNameSet.has(toolName) || matchesRegex(toolName, request.allowRegex)) {
+        allowed = true;
+      } else if (tool.composite) {
+        const { isList, isRead } = detectListReadOperations(tool);
+        if (request.allowComposite.allowList && isList) {
+          allowed = true;
+        }
+        if (request.allowComposite.allowRead && isRead) {
+          allowed = true;
+        }
+      }
+    }
+
+    if (allowed) {
+      allowedTools.push(tool);
+      allowedToolNames.add(toolName);
+    } else {
+      removedTools.push(tool);
+      reasons.set(toolName, 'allow_rules');
+    }
+  }
+
+  return {
+    allowedTools,
+    removedTools,
+    allowedToolNames,
+    reasons,
+    hasEffect: removedTools.length > 0,
+  };
+}
+
+export function detectListReadOperations(tool: ToolDefinition): { isList: boolean; isRead: boolean } {
+  const actionNames = new Set<string>();
+
+  if (tool.parameters?.action?.enum) {
+    for (const action of tool.parameters.action.enum) {
+      actionNames.add(action.toLowerCase());
+    }
+  }
+
+  if (tool.operations) {
+    for (const key of Object.keys(tool.operations)) {
+      const [actionPart] = key.split('_');
+      if (actionPart) {
+        actionNames.add(actionPart.toLowerCase());
+      }
+    }
+  }
+
+  return {
+    isList: actionNames.has('list') || actionNames.has('search'),
+    isRead: actionNames.has('get') || actionNames.has('read'),
+  };
+}
+
+export function validateRegexPattern(pattern: string, maxLength: number = MAX_REGEX_LENGTH): { valid: boolean; error?: string } {
+  if (pattern.length > maxLength) {
+    return { valid: false, error: `Regex pattern too long (max ${maxLength} chars).` };
+  }
+
+  if (containsNestedQuantifier(pattern)) {
+    return { valid: false, error: 'Regex pattern contains nested quantifiers.' };
+  }
+
+  try {
+    new RegExp(pattern);
+  } catch (error) {
+    return { valid: false, error: `Regex syntax error: ${(error as Error).message}` };
+  }
+
+  return { valid: true };
+}
+
+export function getSessionToolFilterMaxEntries(): number {
+  const raw = process.env.MCP4_TOOL_FILTER_SESSION_MAX_TOOLS;
+  if (raw === undefined) {
+    return 100;
+  }
+  const parsed = parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    throw new ValidationError(
+      `Invalid MCP4_TOOL_FILTER_SESSION_MAX_TOOLS: expected positive integer, got '${raw}'.`
+    );
+  }
+  return parsed;
+}
+
+function parseCommaList(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0);
+}
+
+function parseAllowComposites(value: string | undefined): { allowList: boolean; allowRead: boolean } {
+  const entries = parseCommaList(value);
+  const allowList = entries.includes('_allow_list');
+  const allowRead = entries.includes('_allow_read');
+
+  for (const entry of entries) {
+    if (entry !== '_allow_list' && entry !== '_allow_read') {
+      throw new ConfigurationError(
+        `Invalid MCP4_TOOL_FILTER_ALLOW_COMPOSITES entry '${entry}'. Expected _allow_list or _allow_read.`
+      );
+    }
+  }
+
+  return { allowList, allowRead };
+}
+
+function parseRegexList(value: string | undefined, envName: string): ToolFilterRegexRule[] {
+  const entries = parseCommaList(value);
+  if (entries.length === 0) {
+    return [];
+  }
+
+  return entries.map(entry => {
+    const anchored = autoAnchorPattern(entry.normalize('NFC'));
+    return compileRegexRule(anchored, envName);
+  });
+}
+
+function compileRegexRule(pattern: string, source: string): ToolFilterRegexRule {
+  const validation = validateRegexPattern(pattern);
+  if (!validation.valid) {
+    throw new ConfigurationError(`${source} regex validation failed for '${pattern}': ${validation.error}`);
+  }
+
+  return {
+    pattern,
+    regex: new RegExp(pattern),
+  };
+}
+
+function compileSessionRegexRule(pattern: string, source: string): ToolFilterRegexRule {
+  const validation = validateRegexPattern(pattern);
+  if (!validation.valid) {
+    throw new ValidationError(`${source} regex validation failed for '${pattern}': ${validation.error}`);
+  }
+
+  return {
+    pattern,
+    regex: new RegExp(pattern),
+  };
+}
+
+function autoAnchorPattern(pattern: string): string {
+  const hasStart = pattern.startsWith('^');
+  const hasEnd = pattern.endsWith('$');
+
+  let anchored = pattern;
+  if (!hasStart) {
+    anchored = `^${anchored}`;
+  }
+  if (!hasEnd) {
+    anchored = `${anchored}$`;
+  }
+
+  return anchored;
+}
+
+function matchesRegex(name: string, rules: ToolFilterRegexRule[]): boolean {
+  return rules.some(rule => rule.regex.test(name));
+}
+
+function findMatchingPattern(name: string, rules: ToolFilterRegexRule[]): string | undefined {
+  const match = rules.find(rule => rule.regex.test(name));
+  return match?.pattern;
+}
+
+function containsNestedQuantifier(pattern: string): boolean {
+  const nestedQuantifier = /\((?:[^()\\]|\\.)*(?:\+|\*|\?|\{\d+(?:,\d*)?\})(?:[^()\\]|\\.)*\)(?:\+|\*|\?|\{\d+(?:,\d*)?\})/;
+  return nestedQuantifier.test(pattern);
+}

--- a/src/types/http-transport.ts
+++ b/src/types/http-transport.ts
@@ -7,6 +7,7 @@
 
 import type { Request as ExpressRequest, Response } from 'express';
 import type { OAuthConfig, AuthInterceptor } from './profile.js';
+import type { SessionToolFilterRequest, SessionToolFilterState } from '../tool-filter.js';
 
 export interface SessionData {
   id: string;
@@ -20,6 +21,8 @@ export interface SessionData {
   oauthClientId?: string; // OAuth client ID for debugging/validation
   filtering?: Record<string, string[]>;
   filteringHeader?: string;
+  toolFilterRequest?: SessionToolFilterRequest;
+  toolFilter?: SessionToolFilterState;
 }
 
 export interface SSEStreamState {


### PR DESCRIPTION
### Motivation

- Provide server-side control to restrict which tools are exposed globally via environment variables and per-session via an HTTP header.  
- Protect against unsafe regex usage (ReDoS) and enforce sane limits for session filters.  
- Ensure filters are applied early (profile load / session init) and failures surface as actionable configuration errors.  
- Add observability for filtering activity via structured logging and Prometheus metrics.

### Description

- Added a new `src/tool-filter.ts` module that parses env vars and `X-Mcp4-Tools` headers, auto-anchors patterns, validates regex safety (`validateRegexPattern`), detects composite `list`/`read` semantics, and exposes `applyToolFilter` / `applySessionToolFilter`.  
- Integrated global filtering during profile load in `MCPServer.initialize()` by calling `parseToolFilterConfig` and `applyToolFilter`, rejecting no-op or all-filtered configurations and logging/metric hooks.  
- Implemented session-scoped parsing and enforcement in `HttpTransport.handlePost()` and `MCPServer` so `X-Mcp4-Tools` is parsed at initialization, stored on `SessionData`, enforced on `tools/list` and `tools/call`, and rejects header mismatches for existing sessions.  
- Added metrics support (`src/metrics.ts`) and recording points in `HttpTransport`/`MCPServer` for `tools_total`, `tools_filtered`, per-session `tools_session`, pattern counts and rejection counters, and documented env vars and header format in `README.md` and `docs/HTTP-TRANSPORT.md`.

### Testing

- Added unit tests `src/tool-filter.test.ts` (regex safety, anchoring, composites, unicode normalization) plus updates to `src/http-transport.test.ts`, `src/mcp-server.test.ts`, and `src/metrics.test.ts` covering header parsing, mismatch handling, validation limits, server integration, and metrics; tests exercise positive and negative cases.  
- Ran `npm run typecheck` (TypeScript) and `npm test` (full Vitest suite); both completed successfully in CI-like run.  
- Existing integration and profile tests were re-run and passed alongside the new tests (full test run reported all tests passing).  
- Manual assertions in tests verify error conditions: no-op filters, all-tools-filtered, header immutability, too-many/too-long entries, and unsafe regex rejection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960291f24d0832894f463ba0557fbc5)