### PR TITLE
Restrict CLI env overrides to known MCP4 variables

### DIFF
--- a/src/cli-config.test.ts
+++ b/src/cli-config.test.ts
@@ -51,4 +51,12 @@ describe('cli-config', () => {
     expect(process.env.MCP4_PROFILE).toBe('gitlab');
     expect(process.env.MCP4_PROFILES_DIR).toBe('profiles');
   });
+
+  it('skips CLI args without known MCP4 env mappings', () => {
+    const parsed = parseCliArgs(['--help', '--unknown-flag', 'value', '--profile', 'gitlab']);
+    applyCliEnvOverrides(parsed);
+    expect(process.env.MCP4_HELP).toBeUndefined();
+    expect(process.env.MCP4_UNKNOWN_FLAG).toBeUndefined();
+    expect(process.env.MCP4_PROFILE).toBe('gitlab');
+  });
 });

--- a/src/cli-config.ts
+++ b/src/cli-config.ts
@@ -8,6 +8,65 @@ export function flagToEnvVar(flag: string): string {
   return `MCP4_${flag.replace(/-/g, '_').toUpperCase()}`;
 }
 
+const KNOWN_ENV_VARS = new Set([
+  'MCP4_ALLOWED_ORIGINS',
+  'MCP4_API_BASE_URL',
+  'MCP4_API_TOKEN',
+  'MCP4_AUTH_ENV_VAR',
+  'MCP4_AUTH_FORCE',
+  'MCP4_AUTH_HEADER_NAME',
+  'MCP4_AUTH_QUERY_PARAM',
+  'MCP4_AUTH_TYPE',
+  'MCP4_FILTER_MAX_VALUES',
+  'MCP4_HEARTBEAT_ENABLED',
+  'MCP4_HEARTBEAT_INTERVAL_MS',
+  'MCP4_HOST',
+  'MCP4_HTTP_PROFILE_ROUTING',
+  'MCP4_HTTP_RATE_LIMIT_ENABLED',
+  'MCP4_HTTP_RATE_LIMIT_MAX_REQUESTS',
+  'MCP4_HTTP_RATE_LIMIT_METRICS_MAX',
+  'MCP4_HTTP_RATE_LIMIT_WINDOW_MS',
+  'MCP4_LOG_FORMAT',
+  'MCP4_LOG_LEVEL',
+  'MCP4_METRICS_ENABLED',
+  'MCP4_METRICS_PATH',
+  'MCP4_OAUTH_AUTHORIZATION_URL',
+  'MCP4_OAUTH_CLIENT_ID',
+  'MCP4_OAUTH_CLIENT_SECRET',
+  'MCP4_OAUTH_ISSUER',
+  'MCP4_OAUTH_RATE_LIMIT_MAX',
+  'MCP4_OAUTH_RATE_LIMIT_WINDOW_MS',
+  'MCP4_OAUTH_REDIRECT_URI',
+  'MCP4_OAUTH_REFRESH_THRESHOLD_MS',
+  'MCP4_OAUTH_SESSION_TIMEOUT_MS',
+  'MCP4_OAUTH_TOKEN_URL',
+  'MCP4_OPENAPI_SPEC_PATH',
+  'MCP4_PORT',
+  'MCP4_PROFILE',
+  'MCP4_PROFILE_PATH',
+  'MCP4_PROFILES_DIR',
+  'MCP4_PROXY_MAX_BYTES',
+  'MCP4_SESSION_TIMEOUT_MS',
+  'MCP4_SSL_CERT_FILE',
+  'MCP4_SSL_KEY_FILE',
+  'MCP4_TOKEN_MAX_LENGTH',
+  'MCP4_TOOL_FILTER_ALLOW_CATEGORIES',
+  'MCP4_TOOL_FILTER_ALLOW_NAME_REGEX',
+  'MCP4_TOOL_FILTER_ALLOW_NAMES',
+  'MCP4_TOOL_FILTER_DENY_NAME_REGEX',
+  'MCP4_TOOL_FILTER_DENY_NAMES',
+  'MCP4_TOOL_FILTER_SESSION_MAX_TOOLS',
+  'MCP4_TOOL_FILTER_WARN_THRESHOLD_PCT',
+  'MCP4_TOOLNAME_MAX',
+  'MCP4_TOOLNAME_MIN_LENGTH',
+  'MCP4_TOOLNAME_MIN_PARTS',
+  'MCP4_TOOLNAME_SIMILARITY_THRESHOLD',
+  'MCP4_TOOLNAME_SIMILAR_TOP',
+  'MCP4_TOOLNAME_STRATEGY',
+  'MCP4_TOOLNAME_WARN_ONLY',
+  'MCP4_TRANSPORT',
+]);
+
 export function parseCliArgs(argv: string[]): Record<string, string> {
   const args: Record<string, string> = {};
   for (let i = 0; i < argv.length; i += 1) {
@@ -36,6 +95,9 @@ export function parseCliArgs(argv: string[]): Record<string, string> {
 export function applyCliEnvOverrides(args: Record<string, string>): void {
   for (const [key, value] of Object.entries(args)) {
     const envVar = flagToEnvVar(key);
+    if (!KNOWN_ENV_VARS.has(envVar)) {
+      continue;
+    }
     process.env[envVar] = value;
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent accidental or unexpected environment variable overrides by applying CLI-to-env mappings only for recognized MCP4 variables.

### Description
- Add a `KNOWN_ENV_VARS` allowlist in `src/cli-config.ts` and update `applyCliEnvOverrides` to skip any CLI flag that maps to an unknown env var.
- Add a unit test in `src/cli-config.test.ts` that verifies known flags set env vars and unknown flags are ignored.

### Testing
- Ran `npm run typecheck` which completed without errors.
- Ran `npm test -- -t "cli-config"` which exercised the `cli-config` tests and passed (the `cli-config` suite passed with 8 tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f92885e08328a13a73fed2120f66)