### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Timing Attack in PKCE Verification & Weak RNG

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -37,3 +37,16 @@ Logging untrusted input to a text-based stream (like console/file) requires sani
 **Prevention:**
 1.  Sanitize all log messages in text-based loggers by escaping newlines (e.g., replacing `\n` with `\\n`).
 2.  Prefer structured logging (JSON) in production environments where log integrity is critical.
+
+## 2026-02-06 - [MEDIUM] Timing Attack in PKCE Verification
+
+**Vulnerability:**
+The PKCE code challenge verification used a simple string comparison (`hash !== codeChallenge`) which is susceptible to timing attacks (CWE-208). Additionally, `randomUUID()` was used for generating security-critical tokens (OAuth state, authorization codes), which leaks structure bits and is not intended for high-entropy secrets.
+
+**Learning:**
+Security-critical comparisons (hashes, signatures, secrets) must always be constant-time to prevent side-channel timing attacks. `randomUUID()` should be reserved for identifiers, not secrets.
+
+**Prevention:**
+1.  Use `crypto.timingSafeEqual` for all secret comparisons.
+2.  Ensure buffers being compared have equal lengths before calling `timingSafeEqual`.
+3.  Use `crypto.randomBytes(n).toString('hex')` for generating high-entropy secrets.

--- a/src/oauth-pkce-security.test.ts
+++ b/src/oauth-pkce-security.test.ts
@@ -1,0 +1,205 @@
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ExternalOAuthProvider } from './oauth-provider.js';
+import type { OAuthConfig } from './types/profile.js';
+import type { Logger } from './logger.js';
+import type { Response } from 'express';
+import type { OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
+import { createHash } from 'node:crypto';
+
+describe('ExternalOAuthProvider Security', () => {
+  let provider: ExternalOAuthProvider;
+  let mockLogger: Logger;
+  let config: OAuthConfig;
+
+  beforeEach(() => {
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    config = {
+      authorization_endpoint: 'https://oauth.example.com/authorize',
+      token_endpoint: 'https://oauth.example.com/token',
+      client_id: 'test-client-id',
+      client_secret: 'test-client-secret',
+      scopes: ['api'],
+      redirect_uri: 'http://localhost:3003/oauth/callback',
+    };
+
+    provider = new ExternalOAuthProvider(config, mockLogger);
+
+    // Mock fetch for token exchange
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expires_in: 3600,
+      }),
+    });
+  });
+
+  describe('Random Token Generation', () => {
+    it('should use high-entropy hex string for state token instead of UUID', async () => {
+      const client: OAuthClientInformationFull = {
+        client_id: 'mcp-client',
+        redirect_uris: ['http://localhost:3003/oauth/callback'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      };
+
+      const mockRes = {
+        redirect: vi.fn(),
+      } as unknown as Response;
+
+      await provider.authorize(client, {
+        redirectUri: 'http://localhost:3003/oauth/callback',
+        codeChallenge: 'challenge',
+        scopes: ['api'],
+      }, mockRes);
+
+      const redirectUrl = (mockRes.redirect as any).mock.calls[0][0];
+      const url = new URL(redirectUrl);
+      const state = url.searchParams.get('state');
+
+      expect(state).toBeDefined();
+      // UUID has dashes: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+      // Hex string (randomBytes) does not have dashes
+      // We expect NO dashes for our new secure implementation
+      // NOTE: This test will FAIL until we implement the fix
+      // But we can check for length > 36 (UUID is 36 chars)
+      // randomBytes(32).toString('hex') is 64 chars.
+
+      // For now, let's just log it to verify manually or check against regex
+      // If we haven't applied the fix yet, this expects UUID format.
+      // After fix, it should be hex string.
+      // Let's assert it is a non-empty string for now, and refine after fix?
+      // No, I want to verify the fix works.
+
+      // This assertion assumes the FIX IS APPLIED.
+      // Since I am writing the test first, I will comment out the strict check or expect it to fail if I ran it now.
+      // But I will run this AFTER applying changes in step 4.
+      // So I can write the expectation for the FIX.
+
+      expect(state).toMatch(/^[0-9a-f]{64}$/); // 32 bytes hex = 64 chars
+    });
+  });
+
+  describe('PKCE Verification', () => {
+    it('should verify correct code verifier', async () => {
+      const client: OAuthClientInformationFull = {
+        client_id: 'mcp-client',
+        redirect_uris: ['http://localhost:3003/oauth/callback'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      };
+
+      // 1. Authorize to generate state and code challenge
+      const verifier = 'secure-random-verifier-string';
+      const challenge = createHash('sha256').update(verifier).digest('base64url');
+
+      const mockRes = { redirect: vi.fn() } as unknown as Response;
+
+      await provider.authorize(client, {
+        redirectUri: 'http://localhost:3003/oauth/callback',
+        codeChallenge: challenge,
+        scopes: ['api'],
+      }, mockRes);
+
+      const redirectUrl = (mockRes.redirect as any).mock.calls[0][0];
+      const url = new URL(redirectUrl);
+      const state = url.searchParams.get('state')!;
+
+      // 2. Handle callback to generate internal code
+      const mockReq = {
+        query: { code: 'external-code', state },
+      } as any;
+      const mockResCallback = {
+        status: vi.fn().mockReturnThis(),
+        redirect: vi.fn(),
+        send: vi.fn(),
+      } as any;
+
+      // Register client so handleCallback can find it
+      await provider.clientsStore.registerClient(client);
+
+      // Access private method or simulate callback handling?
+      // authorize() puts it in stateStore.
+      // handleCallback() moves it to authorizationCodes.
+
+      await provider.handleCallback(mockReq, mockResCallback);
+
+      const callbackRedirectUrl = (mockResCallback.redirect as any).mock.calls[0][0];
+      const callbackUrl = new URL(callbackRedirectUrl);
+      const internalCode = callbackUrl.searchParams.get('code')!;
+
+      // 3. Exchange internal code
+      const tokens = await provider.exchangeAuthorizationCode(
+        client,
+        internalCode,
+        verifier,
+        'http://localhost:3003/oauth/callback'
+      );
+
+      expect(tokens).toBeDefined();
+      expect(tokens.access_token).toBe('access-token');
+    });
+
+    it('should reject incorrect code verifier', async () => {
+      const client: OAuthClientInformationFull = {
+        client_id: 'mcp-client',
+        redirect_uris: ['http://localhost:3003/oauth/callback'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      };
+
+      // 1. Authorize
+      const verifier = 'secure-random-verifier-string';
+      const challenge = createHash('sha256').update(verifier).digest('base64url');
+
+      const mockRes = { redirect: vi.fn() } as unknown as Response;
+
+      await provider.authorize(client, {
+        redirectUri: 'http://localhost:3003/oauth/callback',
+        codeChallenge: challenge,
+        scopes: ['api'],
+      }, mockRes);
+
+      const redirectUrl = (mockRes.redirect as any).mock.calls[0][0];
+      const url = new URL(redirectUrl);
+      const state = url.searchParams.get('state')!;
+
+      // 2. Handle callback
+      const mockReq = {
+        query: { code: 'external-code', state },
+      } as any;
+      const mockResCallback = {
+        status: vi.fn().mockReturnThis(),
+        redirect: vi.fn(),
+        send: vi.fn(),
+      } as any;
+
+      // Register client so handleCallback can find it
+      await provider.clientsStore.registerClient(client);
+
+      await provider.handleCallback(mockReq, mockResCallback);
+
+      const callbackRedirectUrl = (mockResCallback.redirect as any).mock.calls[0][0];
+      const callbackUrl = new URL(callbackRedirectUrl);
+      const internalCode = callbackUrl.searchParams.get('code')!;
+
+      // 3. Exchange with WRONG verifier
+      await expect(
+        provider.exchangeAuthorizationCode(
+          client,
+          internalCode,
+          'wrong-verifier',
+          'http://localhost:3003/oauth/callback'
+        )
+      ).rejects.toThrow('Invalid code_verifier');
+    });
+  });
+});

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -13,7 +13,7 @@
  *   4. Client -> MCP (Token) -> MCP returns stored tokens
  */
 
-import { randomUUID, createHash } from 'node:crypto';
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 import { isIP } from 'node:net';
 import { Request, Response } from 'express';
 import type {
@@ -566,7 +566,7 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
       throw new Error('Redirect URI host not allowed');
     }
 
-    const stateToken = randomUUID();
+    const stateToken = randomBytes(32).toString('hex');
     
     this.stateStore.set(stateToken, {
       clientRedirectUri: params.redirectUri,
@@ -661,7 +661,7 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
         );
 
         // Generate Internal Code
-        const internalCode = randomUUID();
+        const internalCode = randomBytes(32).toString('hex');
 
         // Store Internal Code -> Tokens mapping
         const client = await this._clientsStore.getClient(storedState.clientId);
@@ -785,9 +785,12 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
         throw new Error('code_verifier is required for PKCE');
       }
       
-      // Verify code challenge (S256 method)
+      // Verify code challenge (S256 method) with constant-time comparison
       const hash = createHash('sha256').update(codeVerifier).digest('base64url');
-      if (hash !== codeData.params.codeChallenge) {
+      const hashBuffer = Buffer.from(hash);
+      const challengeBuffer = Buffer.from(codeData.params.codeChallenge);
+
+      if (hashBuffer.length !== challengeBuffer.length || !timingSafeEqual(hashBuffer, challengeBuffer)) {
         throw new Error('Invalid code_verifier');
       }
     }


### PR DESCRIPTION
Replaced `randomUUID` with `crypto.randomBytes` for high-entropy secrets (OAuth state, internal codes) to avoid leaking structure bits.
Implemented constant-time comparison for PKCE code challenge verification using `crypto.timingSafeEqual` to prevent side-channel timing attacks.
Added new test `src/oauth-pkce-security.test.ts` to verify security logic.

---
*PR created automatically by Jules for task [3024436534295043329](https://jules.google.com/task/3024436534295043329) started by @davidruzicka*