### PR TITLE
🛡️ Sentinel: [Medium] Add validation for base64 input

### DIFF
--- a/src/tool-generator.test.ts
+++ b/src/tool-generator.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { ToolGenerator } from './tool-generator.js';
 import { OpenAPIParser } from './openapi-parser.js';
 import { ProfileLoader } from './profile-loader.js';
+import { ValidationError } from './errors.js';
 import type { Profile } from './types/profile.js';
 import path from 'path';
 
@@ -305,6 +306,13 @@ describe('ToolGenerator', () => {
       // No base64Content means FormData stays empty
       const entries = Array.from(formData.entries());
       expect(entries.length).toBe(0);
+    });
+
+    it('should throw ValidationError for invalid base64 content', () => {
+      const args = { base64Content: 'invalid-base64!' };
+      expect(() => {
+        generator.buildFormDataBody(args);
+      }).toThrow(ValidationError);
     });
 
     it('should build FormData with binary content (non-ASCII)', () => {

--- a/src/tool-generator.ts
+++ b/src/tool-generator.ts
@@ -8,6 +8,7 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolDefinition, ParameterDefinition, ParameterType } from './types/profile.js';
 import type { OpenAPIParser } from './openapi-parser.js';
+import { ValidationError } from './errors.js';
 
 export class ToolGenerator {
   constructor(private parser: OpenAPIParser) {}
@@ -206,7 +207,12 @@ export class ToolGenerator {
     
     if (base64Content) {
       // Convert base64 to Blob
-      const binaryString = atob(base64Content);
+      let binaryString: string;
+      try {
+        binaryString = atob(base64Content);
+      } catch (error) {
+        throw new ValidationError('Invalid base64 content');
+      }
       const bytes = new Uint8Array(binaryString.length);
       for (let i = 0; i < binaryString.length; i++) {
         bytes[i] = binaryString.charCodeAt(i);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Invalid base64 input to tools was causing 500 Internal Server Error (via uncaught DOMException from atob) instead of 400 Bad Request.
🎯 Impact: Improved error handling, reduced log noise, and prevents potential DoS vectors related to error handling overhead.
🔧 Fix: Wrapped `atob` in `src/tool-generator.ts` in a try-catch block to catch `InvalidCharacterError` and re-throw it as a `ValidationError`.
✅ Verification: Added a new unit test in `src/tool-generator.test.ts` to verify that invalid base64 input results in a `ValidationError`.

---
*PR created automatically by Jules for task [22243574345634943](https://jules.google.com/task/22243574345634943) started by @davidruzicka*