### PR TITLE
🛡️ Sentinel: [MEDIUM] Enhance Content-Security-Policy

### DIFF
--- a/src/transport/http-transport-security.test.ts
+++ b/src/transport/http-transport-security.test.ts
@@ -133,7 +133,7 @@ describe('HttpTransport security behavior (no listen)', () => {
     const response = await request(app).get('/health');
 
     expect(response.headers['x-powered-by']).toBeUndefined();
-    expect(response.headers['content-security-policy']).toBe("default-src 'self'; frame-ancestors 'none'");
+    expect(response.headers['content-security-policy']).toBe("default-src 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'");
     expect(response.headers['x-content-type-options']).toBe('nosniff');
     expect(response.headers['x-frame-options']).toBe('DENY');
     expect(response.headers['referrer-policy']).toBe('no-referrer');

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -116,7 +116,7 @@ export class HttpTransport {
     // Security: standard headers
     this.app.disable('x-powered-by');
     this.app.use((req: Request, res: Response, next: NextFunction) => {
-      res.setHeader('Content-Security-Policy', "default-src 'self'; frame-ancestors 'none'");
+      res.setHeader('Content-Security-Policy', "default-src 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'");
       res.setHeader('X-Frame-Options', 'DENY');
       res.setHeader('X-Content-Type-Options', 'nosniff');
       res.setHeader('Referrer-Policy', 'no-referrer');


### PR DESCRIPTION
Added `object-src 'none'` and `base-uri 'self'` to CSP to further restrict allowed resources and prevent base hijacking.

Rationale:
- `object-src 'none'`: Prevents the injection of plugins like Flash.
- `base-uri 'self'`: Prevents base tag hijacking which could be used to redirect relative links.

Verification:
- Updated unit tests in `src/transport/http-transport-security.test.ts` to reflect the new header value.
- Ran all tests (`npm test`) to ensure no regressions.

---
*PR created automatically by Jules for task [14615159734002917814](https://jules.google.com/task/14615159734002917814) started by @davidruzicka*