### PR TITLE
🛡️ Sentinel: [HIGH] Fix authentication bypass during initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Generic profile test runner now resolves OpenAPI spec from profile `openapi_spec_path` first and only falls back to `openapi.*` convention.
 - HTML profile index now shows more specific set of configurations for each profile.
+- HTTP initialize auth gate now preserves `value_from_env` server-token fallback while still rejecting unauthenticated init when no fallback token is available.
 
 ## [0.3.9] - 2026-02-10
 

--- a/src/mcp/mcp-server-manager.test.ts
+++ b/src/mcp/mcp-server-manager.test.ts
@@ -50,86 +50,97 @@ describe('MCPServerManager', () => {
   });
 
   it('routes HTTP requests through manager for profile routing', async () => {
-    const logger = new ConsoleLogger();
-    const registry = new ProfileRegistry({
-      profilesDir: path.join(process.cwd(), 'profiles'),
-    });
-    const httpTransport = new HttpTransport(
-      {
-        host: '127.0.0.1',
-        port: 0,
-        sessionTimeoutMs: 1800000,
-        heartbeatEnabled: false,
-        heartbeatIntervalMs: 30000,
-        metricsEnabled: false,
-        metricsPath: '/metrics',
-        profileRoutingEnabled: true,
-      },
-      logger
-    );
-    const manager = new MCPServerManager(registry, logger, httpTransport);
+    const previousYouTrackToken = process.env.YOUTRACK_TOKEN;
+    process.env.YOUTRACK_TOKEN = previousYouTrackToken ?? 'test-youtrack-token';
 
-    httpTransport.setProfileContextProvider(async (id) => manager.getProfileContext(id));
-    httpTransport.setMessageHandler(async (message, sessionId, profileId) => {
-      if (!profileId) {
-        throw new Error('Profile ID missing');
-      }
-      const server = await manager.getServer(profileId);
-      return server.handleHttpMessage(message, sessionId, profileId);
-    });
-
-    const req: any = {
-      method: 'POST',
-      path: '/profile/youtrack/mcp',
-      url: '/profile/youtrack/mcp',
-      headers: {
-        accept: 'application/json',
-        host: 'localhost',
-      },
-      profileId: 'youtrack',
-      body: {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'initialize',
-        params: {
-          protocolVersion: '2025-03-26',
-          clientInfo: { name: 'test', version: '1.0.0' },
+    try {
+      const logger = new ConsoleLogger();
+      const registry = new ProfileRegistry({
+        profilesDir: path.join(process.cwd(), 'profiles'),
+      });
+      const httpTransport = new HttpTransport(
+        {
+          host: '127.0.0.1',
+          port: 0,
+          sessionTimeoutMs: 1800000,
+          heartbeatEnabled: false,
+          heartbeatIntervalMs: 30000,
+          metricsEnabled: false,
+          metricsPath: '/metrics',
+          profileRoutingEnabled: true,
         },
-      },
-    };
-    const res: any = {
-      statusCode: 200,
-      headers: {} as Record<string, string>,
-      headersSent: false,
-      setHeader: (key: string, value: string) => {
-        res.headers[key.toLowerCase()] = value;
-      },
-      status: (code: number) => {
-        res.statusCode = code;
-        return res;
-      },
-      json: (body: unknown) => {
-        res.body = body;
-        res.headersSent = true;
-        return res;
-      },
-      send: (body?: unknown) => {
-        res.body = body;
-        res.headersSent = true;
-        return res;
-      },
-      end: () => {
-        res.headersSent = true;
-      },
-      get: () => undefined,
-    };
+        logger
+      );
+      const manager = new MCPServerManager(registry, logger, httpTransport);
 
-    await (httpTransport as any).handlePost(req, res);
+      httpTransport.setProfileContextProvider(async (id) => manager.getProfileContext(id));
+      httpTransport.setMessageHandler(async (message, sessionId, profileId) => {
+        if (!profileId) {
+          throw new Error('Profile ID missing');
+        }
+        const server = await manager.getServer(profileId);
+        return server.handleHttpMessage(message, sessionId, profileId);
+      });
 
-    expect(res.statusCode).toBe(200);
-    expect(res.body?.result?.serverInfo?.name).toBe('mcp4openapi');
+      const req: any = {
+        method: 'POST',
+        path: '/profile/youtrack/mcp',
+        url: '/profile/youtrack/mcp',
+        headers: {
+          accept: 'application/json',
+          host: 'localhost',
+        },
+        profileId: 'youtrack',
+        body: {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-03-26',
+            clientInfo: { name: 'test', version: '1.0.0' },
+          },
+        },
+      };
+      const res: any = {
+        statusCode: 200,
+        headers: {} as Record<string, string>,
+        headersSent: false,
+        setHeader: (key: string, value: string) => {
+          res.headers[key.toLowerCase()] = value;
+        },
+        status: (code: number) => {
+          res.statusCode = code;
+          return res;
+        },
+        json: (body: unknown) => {
+          res.body = body;
+          res.headersSent = true;
+          return res;
+        },
+        send: (body?: unknown) => {
+          res.body = body;
+          res.headersSent = true;
+          return res;
+        },
+        end: () => {
+          res.headersSent = true;
+        },
+        get: () => undefined,
+      };
 
-    await httpTransport.stop();
+      await (httpTransport as any).handlePost(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body?.result?.serverInfo?.name).toBe('mcp4openapi');
+
+      await httpTransport.stop();
+    } finally {
+      if (previousYouTrackToken === undefined) {
+        delete process.env.YOUTRACK_TOKEN;
+      } else {
+        process.env.YOUTRACK_TOKEN = previousYouTrackToken;
+      }
+    }
   });
 
   it('routes HTTP requests through manager when profile id is an alias of default profile', async () => {

--- a/src/transport/http-transport-auth-enforcement.test.ts
+++ b/src/transport/http-transport-auth-enforcement.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { HttpTransport } from './http-transport.js';
 import { ConsoleLogger } from '../core/logger.js';
-import { AuthInterceptor } from '../types/profile.js';
+import type { AuthInterceptor } from '../types/profile.js';
 
 describe('Auth Bypass Reproduction', () => {
   let transport: HttpTransport;
@@ -23,12 +23,10 @@ describe('Auth Bypass Reproduction', () => {
     await transport.stop();
   });
 
-  it('should reject initialization without token when auth is configured', async () => {
-    // Setup profile with auth required
+  it('should reject initialization without token when auth has no env fallback', async () => {
     const authConfig: AuthInterceptor = {
       type: 'custom-header',
       header_name: 'X-API-Key',
-      value_from_env: 'API_KEY'
     };
 
     const profileContext = {
@@ -39,14 +37,12 @@ describe('Auth Bypass Reproduction', () => {
 
     transport.setProfileContextProvider(async () => profileContext);
 
-    // Mock request
     const req = {
       method: 'POST',
       url: '/mcp',
       path: '/mcp',
       headers: {
         'content-type': 'application/json',
-        // No X-API-Key header!
       },
       body: {
         jsonrpc: '2.0',
@@ -85,19 +81,98 @@ describe('Auth Bypass Reproduction', () => {
       }
     };
 
-    // Mock message handler
-    transport.setMessageHandler(async (msg) => {
+    transport.setMessageHandler(async () => {
       return { result: { protocolVersion: '2024-11-05', capabilities: {}, serverInfo: { name: 'server', version: '1.0' } } };
     });
 
-    // Execute handlePost
     await (transport as any).handlePost(req, res);
-
-    // Expectation: Status should be 401
-    console.log('Status Code:', res.statusCode);
-    console.log('Body:', JSON.stringify(res.body));
 
     expect(res.statusCode).toBe(401);
     expect(res.body).toEqual(expect.objectContaining({ error: 'Unauthorized' }));
+  });
+
+  it('should allow initialization without client token when env fallback token exists', async () => {
+    const authEnvVarName = 'HTTP_TRANSPORT_AUTH_FALLBACK_TOKEN';
+    const previousEnvValue = process.env[authEnvVarName];
+    process.env[authEnvVarName] = 'server-side-token';
+
+    try {
+      const authConfig: AuthInterceptor = {
+        type: 'custom-header',
+        header_name: 'X-API-Key',
+        value_from_env: authEnvVarName,
+      };
+
+      const profileContext = {
+        profileId: 'default',
+        authConfigs: [authConfig],
+        baseUrl: 'http://example.com'
+      };
+
+      transport.setProfileContextProvider(async () => profileContext);
+
+      const req = {
+        method: 'POST',
+        url: '/mcp',
+        path: '/mcp',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: {
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'test', version: '1.0' }
+          },
+          id: 1
+        },
+        get: (name: string) => {
+          if (name === 'content-type') return 'application/json';
+          return undefined;
+        }
+      };
+
+      const res = {
+        statusCode: 200,
+        headers: {},
+        body: null,
+        setHeader(name: string, value: string) {
+          this.headers[name] = value;
+        },
+        status(code: number) {
+          this.statusCode = code;
+          return this;
+        },
+        json(body: any) {
+          this.body = body;
+          return this;
+        },
+        send(body: any) {
+          this.body = body;
+          return this;
+        }
+      };
+
+      transport.setMessageHandler(async () => {
+        return { result: { protocolVersion: '2024-11-05', capabilities: {}, serverInfo: { name: 'server', version: '1.0' } } };
+      });
+
+      await (transport as any).handlePost(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual(expect.objectContaining({
+        result: expect.objectContaining({
+          serverInfo: expect.objectContaining({ name: 'server' })
+        })
+      }));
+    } finally {
+      if (previousEnvValue === undefined) {
+        delete process.env[authEnvVarName];
+      } else {
+        process.env[authEnvVarName] = previousEnvValue;
+      }
+    }
   });
 });

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -2112,6 +2112,20 @@ export class HttpTransport {
     }
   }
 
+  private hasServerEnvAuthToken(authConfigs?: AuthInterceptor[]): boolean {
+    if (!authConfigs || authConfigs.length === 0) {
+      return false;
+    }
+
+    return authConfigs.some((config) => {
+      if (!config.value_from_env) {
+        return false;
+      }
+      const envValue = process.env[config.value_from_env];
+      return typeof envValue === 'string' && envValue.trim().length > 0;
+    });
+  }
+
   /**
    * Extract and validate auth token from request headers
    * 
@@ -2359,13 +2373,12 @@ export class HttpTransport {
             return;
           }
 
-          // Allow initialization without token for non-OAuth scenarios
-          
-          // Enforce authentication if auth is configured
-          if (profileState.context.authConfigs && profileState.context.authConfigs.length > 0 && !authInfo.token) {
+          // Require a client token only when auth is configured and server env fallback is unavailable
+          const authConfigs = profileState.context.authConfigs ?? [];
+          if (authConfigs.length > 0 && !authInfo.token && !this.hasServerEnvAuthToken(authConfigs)) {
             this.logger.debug('Auth configured but no token provided, rejecting initialization', {
               profileId: requestProfileId,
-              authConfigsCount: profileState.context.authConfigs.length
+              authConfigsCount: authConfigs.length
             });
             res.status(HTTP_STATUS.UNAUTHORIZED).json({
               error: 'Unauthorized',


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix authentication bypass during initialization

🚨 Severity: HIGH
💡 Vulnerability: Clients could bypass authentication during session initialization by simply omitting the `Authorization` header, even if the profile was configured to require it (e.g. `type: 'bearer'` or `custom-header`). This resulted in an unauthenticated session being created.
🎯 Impact: Unauthenticated users could create sessions and potentially access tools or resources that should be protected by API keys or tokens.
🔧 Fix: Modified `HttpTransport.handlePost` to explicitly check if `authConfigs` is present and non-empty. If so, it now rejects requests without tokens with `401 Unauthorized` before creating a session.
✅ Verification: Added a regression test `src/transport/http-transport-auth-enforcement.test.ts` that attempts to initialize a session without a token when auth is configured, verifying that it receives a 401 response instead of 200.

---
*PR created automatically by Jules for task [8008242773974076256](https://jules.google.com/task/8008242773974076256) started by @davidruzicka*