### PR TITLE
🛡️ Sentinel: [HIGH] Fix Incomplete SSRF Validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -86,3 +86,18 @@ Never trust regex patterns from configuration (profiles) without validation, and
 **Prevention:**
 1.  Enforce a hard cap (e.g., 4096 chars) on input strings validated against any regex, regardless of schema `maxLength`.
 2.  Validate all regex patterns using a `RegexValidator` (checking for nested quantifiers, ambiguous alternation) before usage.
+
+## 2026-02-15 - [MEDIUM] SSRF TOCTOU in Node.js `fetch`
+
+**Vulnerability:**
+The `SSRFValidator` resolves hostnames to verify they are not private IPs, but the subsequent `fetch()` call re-resolves the hostname. This creates a Time-of-Check Time-of-Use (TOCTOU) vulnerability where a DNS rebinding attack can bypass the check.
+
+**Learning:**
+In Node.js 18+ using the native `fetch` (based on `undici`), it is difficult to separate DNS resolution from the connection establishment while maintaining HTTPS certificate verification (SNI). Unlike `http.Agent` which allows custom lookup functions, `fetch` requires complex `Dispatcher` configuration which may not be accessible or exposed in high-level abstractions.
+
+**Prevention:**
+1.  Hardening the `SSRFValidator` to block all non-standard IP ranges (Multicast, Reserved) is a good defense-in-depth, but does not solve TOCTOU.
+2.  True mitigation requires either:
+    -   Using an HTTP client that supports "connect to IP, verify hostname" (e.g., `curl` style).
+    -   Implementing a custom `Dispatcher` for `undici`.
+    -   Disabling DNS rebinding at the resolver level (infrastructure).

--- a/src/security/ssrf-validator.test.ts
+++ b/src/security/ssrf-validator.test.ts
@@ -49,6 +49,8 @@ describe('SSRFValidator', () => {
         'http://169.254.169.254',
         'http://198.18.0.1',
         'http://192.0.0.1',
+        'http://224.0.0.1', // multicast
+        'http://240.0.0.1', // reserved
       ];
 
       for (const ip of privateIps) {
@@ -74,6 +76,7 @@ describe('SSRFValidator', () => {
         'http://[::]',
         'http://[fe80::1]',
         'http://[fc00::1]',
+        'http://[ff02::1]', // multicast
       ];
 
       for (const ip of privateIps) {

--- a/src/security/ssrf-validator.ts
+++ b/src/security/ssrf-validator.ts
@@ -182,6 +182,8 @@ const IPV4_CIDR_BLOCKS: Array<[ipaddr.IPv4, number]> = [
   '192.0.0.0/24', // IETF protocol assignments
   '0.0.0.0/8', // "this network"
   '198.18.0.0/15', // benchmark testing
+  '224.0.0.0/4', // multicast
+  '240.0.0.0/4', // reserved
 ].map(cidr => ipaddr.parseCIDR(cidr) as [ipaddr.IPv4, number]);
 
 const IPV6_CIDR_BLOCKS: Array<[ipaddr.IPv6, number]> = [
@@ -189,4 +191,5 @@ const IPV6_CIDR_BLOCKS: Array<[ipaddr.IPv6, number]> = [
   '::/128', // unspecified
   'fe80::/10', // link-local
   'fc00::/7', // unique local
+  'ff00::/8', // multicast
 ].map(cidr => ipaddr.parseCIDR(cidr) as [ipaddr.IPv6, number]);


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Incomplete SSRF Validation

🚨 Severity: HIGH (Enhancement)
💡 Vulnerability: The SSRF validator allowed access to Multicast (224.0.0.0/4) and Reserved (240.0.0.0/4) IP ranges, which are not valid public targets and could potentially be abused in specific network environments.
🎯 Impact: While less critical than private network access, allowing these ranges increases the attack surface. Blocking them aligns with security best practices for SSRF protection.
🔧 Fix: Updated `src/security/ssrf-validator.ts` to include these CIDR blocks in the deny list.
✅ Verification: Added unit tests in `src/security/ssrf-validator.test.ts` ensuring `224.0.0.1`, `240.0.0.1`, and `[ff02::1]` are blocked. Verified with a reproduction script.

Note: Also documented a known TOCTOU limitation with Node.js `fetch` in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [10674182693203008554](https://jules.google.com/task/10674182693203008554) started by @davidruzicka*