### PR TITLE
🛡️ Sentinel: [security improvement] Add HSTS header

### DIFF
--- a/src/transport/http-transport-hsts.test.ts
+++ b/src/transport/http-transport-hsts.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { HttpTransport } from './http-transport.js';
+import { ConsoleLogger } from '../core/logger.js';
+import { CAN_LISTEN } from '../testing/listen-support.js';
+
+function createTransport(config?: Partial<any>) {
+  return new HttpTransport(
+    {
+      host: '127.0.0.1',
+      port: 0,
+      sessionTimeoutMs: 1800000,
+      heartbeatEnabled: false,
+      heartbeatIntervalMs: 30000,
+      metricsEnabled: false,
+      metricsPath: '/metrics',
+      ...config,
+    } as any,
+    new ConsoleLogger()
+  );
+}
+
+describe('HttpTransport HSTS Header', () => {
+  (CAN_LISTEN ? it : it.skip)('sets Strict-Transport-Security header', async () => {
+    const transport = createTransport();
+    const app = (transport as any).app;
+
+    const response = await request(app).get('/health');
+
+    // This expectation should fail initially
+    expect(response.headers['strict-transport-security']).toBe('max-age=63072000; includeSubDomains');
+
+    await transport.stop();
+  });
+});

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -140,6 +140,7 @@ export class HttpTransport {
     // Security: standard headers
     this.app.disable('x-powered-by');
     this.app.use((req: Request, res: Response, next: NextFunction) => {
+      res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
       res.setHeader('Content-Security-Policy', "default-src 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'");
       res.setHeader('X-Frame-Options', 'DENY');
       res.setHeader('X-Content-Type-Options', 'nosniff');


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

Added `Strict-Transport-Security` (HSTS) header to the HTTP transport middleware.
This header tells browsers to only access the server over HTTPS for the specified duration (2 years), preventing protocol downgrade attacks and cookie hijacking.

Header value: `max-age=63072000; includeSubDomains`

**Verification:**
Added a new test `src/transport/http-transport-hsts.test.ts` which verifies that the header is present in the response from the `/health` endpoint.
Ran `npm test` to ensure no regressions.

---
*PR created automatically by Jules for task [1514849107308225392](https://jules.google.com/task/1514849107308225392) started by @davidruzicka*