### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS via OAuth Open Redirect

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -101,3 +101,16 @@ In Node.js 18+ using the native `fetch` (based on `undici`), it is difficult to 
     -   Using an HTTP client that supports "connect to IP, verify hostname" (e.g., `curl` style).
     -   Implementing a custom `Dispatcher` for `undici`.
     -   Disabling DNS rebinding at the resolver level (infrastructure).
+
+## 2026-02-18 - [HIGH] XSS via OAuth Open Redirect
+
+**Vulnerability:**
+The `ExternalOAuthProvider` allowed arbitrary schemes in `redirect_uri` (e.g., `javascript://localhost/...`) because `isAllowedRedirectHost` only validated the hostname. Since the internal `mcp-proxy-client` (used for VS Code compatibility) is pre-registered with empty `redirect_uris`, it relies entirely on runtime validation, which was insufficient.
+
+**Learning:**
+URL validation must check BOTH the hostname and the protocol/scheme. `new URL('javascript://localhost')` parses with hostname `localhost`, bypassing hostname-only allowlists.
+
+**Prevention:**
+1.  Explicitly validate `url.protocol` in all URL validation logic.
+2.  Block dangerous schemes like `javascript:`, `vbscript:`, `data:` at the framework level.
+3.  Prefer allowlisting schemes (e.g., `http:`, `https:`, `vscode:`) over blocklisting if possible, though blocklisting is a minimum requirement.

--- a/src/auth/oauth-provider-scheme.test.ts
+++ b/src/auth/oauth-provider-scheme.test.ts
@@ -1,0 +1,83 @@
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ExternalOAuthProvider } from './oauth-provider.js';
+import { PROXY_CREDENTIALS } from '../core/constants.js';
+import { ConsoleLogger } from '../core/logger.js';
+import type { Request, Response } from 'express';
+
+describe('ExternalOAuthProvider Security', () => {
+  let provider: ExternalOAuthProvider;
+  let mockRes: Partial<Response>;
+  const logger = new ConsoleLogger();
+
+  beforeEach(() => {
+    provider = new ExternalOAuthProvider({
+      authorization_endpoint: 'https://auth.example.com/authorize',
+      token_endpoint: 'https://auth.example.com/token',
+      client_id: 'test-client',
+      client_secret: 'test-secret',
+      redirect_uri: 'http://localhost:3000/callback',
+      allowed_redirect_hosts: ['localhost']
+    }, logger);
+
+    mockRes = {
+      redirect: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+  });
+
+  it('should BLOCK javascript: scheme in authorize even if hostname matches allowed host', async () => {
+    const maliciousUri = 'javascript://localhost/%0aalert(1)';
+    const client = await provider.clientsStore.getClient(PROXY_CREDENTIALS.CLIENT_ID);
+
+    expect(client).toBeDefined();
+
+    // Should throw now
+    await expect(provider.authorize(client!, {
+      redirectUri: maliciousUri,
+      responseType: 'code',
+      clientId: PROXY_CREDENTIALS.CLIENT_ID,
+      codeChallenge: 'challenge',
+      codeChallengeMethod: 'S256',
+      state: 'state'
+    }, mockRes as Response)).rejects.toThrow('Redirect URI host not allowed');
+
+    expect(mockRes.redirect).not.toHaveBeenCalled();
+  });
+
+  it('should BLOCK javascript: scheme in callback if state was somehow tampered or stored', async () => {
+    // Manually inject malicious state to simulate bypass or tampering
+    const maliciousUri = 'javascript://localhost/%0aalert(1)';
+    const stateToken = 'tampered-state';
+
+    // Use private stateStore to inject bad state
+    (provider as any).stateStore.set(stateToken, {
+      clientRedirectUri: maliciousUri,
+      clientId: PROXY_CREDENTIALS.CLIENT_ID,
+      createdAt: Date.now()
+    });
+
+    const mockReq = {
+      query: {
+        code: 'auth-code',
+        state: stateToken
+      }
+    } as unknown as Request;
+
+    // Mock token exchange to succeed (if it gets that far)
+    vi.spyOn(provider as any, 'exchangeCodeWithProvider').mockResolvedValue({
+      access_token: 'access-token',
+      token_type: 'Bearer',
+      expires_in: 3600
+    });
+
+    await provider.handleCallback(mockReq, mockRes as Response);
+
+    // Verify it blocked the redirect and returned 400
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockRes.send).toHaveBeenCalledWith('Redirect URI host not allowed');
+    expect(mockRes.redirect).not.toHaveBeenCalled();
+  });
+});

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -319,6 +319,18 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
   private isAllowedRedirectHost(redirectUri: string): boolean {
     try {
       const url = new URL(redirectUri);
+
+      // Block dangerous protocols (XSS)
+      // javascript: and vbscript: can execute code
+      // data: can be used for phishing/XSS
+      if (
+        url.protocol === 'javascript:' ||
+        url.protocol === 'vbscript:' ||
+        url.protocol === 'data:'
+      ) {
+        return false;
+      }
+
       const hostname = url.hostname;
       
       // Default to localhost only if not configured


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS via OAuth Open Redirect

🚨 Severity: HIGH
💡 Vulnerability: The `ExternalOAuthProvider` only validated the hostname of the `redirect_uri` against an allowlist (defaulting to `localhost`). This allowed attackers to bypass the check using schemes like `javascript://localhost/...`, which `new URL()` parses as having the hostname `localhost`. Redirecting to such a URI could execute arbitrary JavaScript in the user's browser (XSS).
🎯 Impact: An attacker could craft a malicious link to the OAuth authorization endpoint that, when clicked by a user, would redirect them to a payload executing malicious scripts, potentially stealing session tokens or performing actions on behalf of the user.
🔧 Fix: Updated `isAllowedRedirectHost` in `src/auth/oauth-provider.ts` to explicitly block `javascript:`, `vbscript:`, and `data:` protocols before checking the hostname.
✅ Verification: Added a new test `src/auth/oauth-provider-scheme.test.ts` that attempts to use a `javascript:` scheme with a whitelisted hostname (`localhost`) and asserts that the request is rejected. Confirmed that existing OAuth flows remain functional via `src/auth/oauth-provider.test.ts`.

---
*PR created automatically by Jules for task [14949671633107540641](https://jules.google.com/task/14949671633107540641) started by @davidruzicka*