### PR TITLE
🛡️ Sentinel: [HIGH] Fix OAuth client store DoS vulnerability

### DIFF
--- a/src/auth/oauth-provider-dos.test.ts
+++ b/src/auth/oauth-provider-dos.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { InMemoryClientsStore } from './oauth-provider.js';
+import type { OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
+
+describe('InMemoryClientsStore DoS', () => {
+  let store: InMemoryClientsStore;
+
+  beforeEach(() => {
+    store = new InMemoryClientsStore();
+  });
+
+  it('should enforce max clients limit', async () => {
+    // 1. Register static clients (like VS Code proxy)
+    const staticClient: OAuthClientInformationFull = {
+      client_id: 'mcp-proxy-client',
+      redirect_uris: [],
+      grant_types: ['authorization_code'],
+      response_types: ['code'],
+    };
+    await store.registerClient(staticClient);
+
+    // 2. Register 2000 dynamic clients
+    for (let i = 0; i < 2000; i++) {
+      const dynamicClient: OAuthClientInformationFull = {
+        client_id: `mcp-client-${i}`,
+        redirect_uris: [],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      };
+      await store.registerClient(dynamicClient);
+    }
+
+    // Size should be capped at 1000
+    expect((store as any).clients.size).toBe(1000);
+
+    // Verify static client is still there (not evicted)
+    const retrievedStatic = await store.getClient('mcp-proxy-client');
+    expect(retrievedStatic).toBeDefined();
+
+    // Verify oldest dynamic clients are evicted
+    // mcp-client-0 should be evicted
+    const oldClient = await store.getClient('mcp-client-0');
+    expect(oldClient).toBeUndefined();
+
+    // Verify newest dynamic clients are present
+    // mcp-client-1999 should be present
+    const newClient = await store.getClient('mcp-client-1999');
+    expect(newClient).toBeDefined();
+  });
+
+  it('should evict oldest client if all are static (fallback)', async () => {
+     // Register 1001 static clients
+    for (let i = 0; i < 1001; i++) {
+      const client: OAuthClientInformationFull = {
+        client_id: `static-client-${i}`,
+        redirect_uris: [],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      };
+      await store.registerClient(client);
+    }
+
+    expect((store as any).clients.size).toBe(1000);
+
+    // oldest should be evicted
+    const oldClient = await store.getClient('static-client-0');
+    expect(oldClient).toBeUndefined();
+
+    // newest should be present
+    const newClient = await store.getClient('static-client-1000');
+    expect(newClient).toBeDefined();
+  });
+});

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -39,12 +39,36 @@ import { parseOAuthMetadataEndpoints } from './oauth-metadata.js';
  */
 export class InMemoryClientsStore implements OAuthRegisteredClientsStore {
   private clients = new Map<string, OAuthClientInformationFull>();
+  private readonly MAX_CLIENTS = 1000;
 
   async getClient(clientId: string): Promise<OAuthClientInformationFull | undefined> {
     return this.clients.get(clientId);
   }
 
   async registerClient(clientMetadata: OAuthClientInformationFull): Promise<OAuthClientInformationFull> {
+    // Only enforce limit for new clients
+    if (!this.clients.has(clientMetadata.client_id)) {
+      // Prevent unbounded growth (DoS protection)
+      if (this.clients.size >= this.MAX_CLIENTS) {
+        // Evict oldest dynamic client (prefixed with mcp-client-)
+        // Static clients (mcp-proxy-client, configured client_id) should be preserved
+        let evicted = false;
+        for (const [id] of this.clients) {
+          if (id.startsWith('mcp-client-')) {
+            this.clients.delete(id);
+            evicted = true;
+            break;
+          }
+        }
+
+        // If no dynamic client found to evict (unlikely), force evict oldest to respect limit
+        if (!evicted && this.clients.size >= this.MAX_CLIENTS) {
+          const firstKey = this.clients.keys().next().value;
+          if (firstKey) this.clients.delete(firstKey);
+        }
+      }
+    }
+
     this.clients.set(clientMetadata.client_id, clientMetadata);
     return clientMetadata;
   }


### PR DESCRIPTION
**Vulnerability:** The `InMemoryClientsStore` used by `ExternalOAuthProvider` allowed registering an unlimited number of OAuth clients via `POST /oauth/register`. This could be exploited to cause memory exhaustion (DoS).

**Fix:** Enforced a hard limit of 1000 clients. When the limit is reached, the store evicts the oldest *dynamic* client (identified by `mcp-client-` prefix) to make room for the new one. This ensures that static/configured clients (like `mcp-proxy-client`) are preserved while preventing unbounded growth.

**Verification:** A new test `src/auth/oauth-provider-dos.test.ts` confirms that the store size is capped at 1000 and that static clients are not evicted when dynamic clients flood the store.

---
*PR created automatically by Jules for task [5175571558182838266](https://jules.google.com/task/5175571558182838266) started by @davidruzicka*