### PR TITLE
🛡️ Sentinel: [HIGH] Fix Missing security headers

### DIFF
--- a/src/transport/http-transport-security.test.ts
+++ b/src/transport/http-transport-security.test.ts
@@ -147,6 +147,8 @@ describe('HttpTransport security behavior (no listen)', () => {
     expect(response.headers['cross-origin-resource-policy']).toBe('same-origin');
     expect(response.headers['x-permitted-cross-domain-policies']).toBe('none');
     expect(response.headers['x-dns-prefetch-control']).toBe('off');
+    expect(response.headers['strict-transport-security']).toBe('max-age=63072000; includeSubDomains');
+    expect(response.headers['x-xss-protection']).toBe('0');
     await transport.stop();
   });
 

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -154,6 +154,8 @@ export class HttpTransport {
       res.setHeader('X-Content-Type-Options', 'nosniff');
       res.setHeader('Referrer-Policy', 'no-referrer');
       res.setHeader('Permissions-Policy', 'geolocation=(), microphone=(), camera=(), payment=()');
+      res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
+      res.setHeader('X-XSS-Protection', '0');
 
       // Additional security headers
       res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Missing security headers

🚨 Severity: HIGH
💡 Vulnerability: Missing `Strict-Transport-Security` (HSTS) and `X-XSS-Protection` headers.
🎯 Impact: Lack of HSTS allows SSL stripping attacks. Lack of explicit `X-XSS-Protection: 0` relies on browser defaults which might be inconsistent, although CSP is present.
🔧 Fix: Added the headers to the security middleware in `src/transport/http-transport.ts`.
✅ Verification: Updated `src/transport/http-transport-security.test.ts` to assert the presence of these headers. Verified all tests pass.

---
*PR created automatically by Jules for task [4111953844809324302](https://jules.google.com/task/4111953844809324302) started by @davidruzicka*