### PR TITLE
🛡️ Sentinel: Add HSTS and X-XSS-Protection headers

### DIFF
--- a/src/transport/http-transport-headers.test.ts
+++ b/src/transport/http-transport-headers.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { HttpTransport } from './http-transport.js';
+import { ConsoleLogger } from '../core/logger.js';
+
+function createTransport(config?: Partial<any>) {
+  return new HttpTransport(
+    {
+      host: '127.0.0.1',
+      port: 0,
+      sessionTimeoutMs: 1800000,
+      heartbeatEnabled: false,
+      heartbeatIntervalMs: 30000,
+      metricsEnabled: false,
+      metricsPath: '/metrics',
+      ...config,
+    } as any,
+    new ConsoleLogger()
+  );
+}
+
+describe('HttpTransport security headers', () => {
+  it('should include Strict-Transport-Security header', async () => {
+    const transport = createTransport();
+    const app = (transport as any).app;
+
+    const response = await request(app).get('/health');
+
+    // HSTS should be present
+    expect(response.headers['strict-transport-security']).toBeDefined();
+    expect(response.headers['strict-transport-security']).toBe('max-age=63072000; includeSubDomains');
+    await transport.stop();
+  });
+
+  it('should include X-XSS-Protection header', async () => {
+    const transport = createTransport();
+    const app = (transport as any).app;
+
+    const response = await request(app).get('/health');
+
+    // X-XSS-Protection should be 0 to disable legacy auditors
+    expect(response.headers['x-xss-protection']).toBe('0');
+    await transport.stop();
+  });
+});

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -160,6 +160,8 @@ export class HttpTransport {
       res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
       res.setHeader('X-Permitted-Cross-Domain-Policies', 'none');
       res.setHeader('X-DNS-Prefetch-Control', 'off');
+      res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
+      res.setHeader('X-XSS-Protection', '0');
 
       next();
     });


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

Added missing security headers to `HttpTransport`:
- `Strict-Transport-Security` (HSTS) to enforce HTTPS.
- `X-XSS-Protection: 0` to disable legacy XSS auditors in favor of CSP.

This addresses a gap in the defense-in-depth strategy.
Verified by `src/transport/http-transport-headers.test.ts`.

---
*PR created automatically by Jules for task [15402497648054665389](https://jules.google.com/task/15402497648054665389) started by @davidruzicka*