### PR TITLE
🛡️ Sentinel: [Security Enhancement] Add HSTS and X-XSS-Protection headers

### DIFF
--- a/src/transport/http-transport-headers.test.ts
+++ b/src/transport/http-transport-headers.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import request from 'supertest';
+import { HttpTransport } from './http-transport.js';
+import { ConsoleLogger } from '../core/logger.js';
+
+// Mock dependecies
+vi.mock('../core/metrics.js', () => ({
+  MetricsCollector: class {
+    recordHttpRequest() {}
+  }
+}));
+
+describe('HttpTransport Security Headers', () => {
+  function createTransport() {
+    return new HttpTransport(
+      {
+        host: '127.0.0.1',
+        port: 0, // Random port
+        metricsEnabled: false,
+        heartbeatEnabled: false,
+        heartbeatIntervalMs: 1000,
+        sessionTimeoutMs: 60000,
+      } as any,
+      new ConsoleLogger()
+    );
+  }
+
+  it('should include Strict-Transport-Security header', async () => {
+    const transport = createTransport();
+    const app = (transport as any).app;
+
+    const response = await request(app).get('/health');
+
+    // HSTS should be enabled with long duration and include subdomains
+    expect(response.headers['strict-transport-security']).toBe('max-age=63072000; includeSubDomains');
+  });
+
+  it('should include X-XSS-Protection header', async () => {
+    const transport = createTransport();
+    const app = (transport as any).app;
+
+    const response = await request(app).get('/health');
+
+    // X-XSS-Protection should be disabled (0) in favor of CSP
+    expect(response.headers['x-xss-protection']).toBe('0');
+  });
+});

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -160,6 +160,8 @@ export class HttpTransport {
       res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
       res.setHeader('X-Permitted-Cross-Domain-Policies', 'none');
       res.setHeader('X-DNS-Prefetch-Control', 'off');
+      res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
+      res.setHeader('X-XSS-Protection', '0');
 
       next();
     });


### PR DESCRIPTION
**Vulnerability:** Missing critical security headers (`Strict-Transport-Security` and `X-XSS-Protection`) in the HTTP transport layer left the application potentially vulnerable to protocol downgrade attacks and legacy browser XSS auditor bugs.

**Fix:** Added the missing headers to the security middleware in `src/transport/http-transport.ts`.
- `Strict-Transport-Security` enforces HTTPS for 2 years (63072000s) and includes subdomains.
- `X-XSS-Protection` is set to `0` to disable deprecated XSS auditors that can introduce cross-site leak vulnerabilities, relying instead on the existing CSP.

**Verification:** Added a new test file `src/transport/http-transport-headers.test.ts` which asserts the presence and correct values of these headers on the `/health` endpoint. Verified that all tests pass.

---
*PR created automatically by Jules for task [16505127549524546296](https://jules.google.com/task/16505127549524546296) started by @davidruzicka*