### PR TITLE
🛡️ Sentinel: [MEDIUM] Remove environment variable leakage in filtering error message

### DIFF
--- a/src/core/filtering.ts
+++ b/src/core/filtering.ts
@@ -193,7 +193,7 @@ export function getFilterMaxValues(): number {
   const parsed = parseInt(raw, 10);
   if (Number.isNaN(parsed) || parsed <= 0) {
     throw new ValidationError(
-      `Invalid MCP4_FILTER_MAX_VALUES: expected positive integer, got '${raw}'.`
+      'Invalid MCP4_FILTER_MAX_VALUES: expected positive integer.'
     );
   }
   return parsed;


### PR DESCRIPTION
Remove raw environment variable value `raw` from `ValidationError` thrown when `MCP4_FILTER_MAX_VALUES` is not a positive integer. This prevents potential leakage of secrets if a sensitive value is accidentally mapped to this config via the environment.

---
*PR created automatically by Jules for task [15181252552431206699](https://jules.google.com/task/15181252552431206699) started by @davidruzicka*