### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent Environment Variable Leakage in Error Messages

### DIFF
--- a/src/core/index-utils.test.ts
+++ b/src/core/index-utils.test.ts
@@ -113,7 +113,14 @@ describe('index helpers', () => {
   it('resolveHttpHostPort throws on invalid port', () => {
     process.env.MCP4_PORT = 'abc';
 
-    expect(() => resolveHttpHostPort()).toThrow('Invalid MCP4_PORT');
+    let error: Error | undefined;
+    try {
+      resolveHttpHostPort();
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error?.message).toContain('Invalid MCP4_PORT');
+    expect(error?.message).not.toContain('abc');
   });
 
   it('resolveHttpHostPort uses custom host and port', () => {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -79,7 +79,7 @@ export function resolveHttpHostPort(): { host: string; port: number } {
   const port = parseInt(process.env.MCP4_PORT || '3003', 10);
 
   if (Number.isNaN(port)) {
-    throw new Error(`Invalid MCP4_PORT: ${process.env.MCP4_PORT}`);
+    throw new Error(`Invalid MCP4_PORT`);
   }
 
   return { host, port };

--- a/src/tool-filter/config/header-config-parser.test.ts
+++ b/src/tool-filter/config/header-config-parser.test.ts
@@ -78,6 +78,7 @@ describe('HeaderConfigParser - MCP4_TOOL_FILTER_SESSION_MAX_TOOLS', () => {
     
     expect(() => parser.parse('get_user')).toThrow(ConfigurationError);
     expect(() => parser.parse('get_user')).toThrow(/must be positive integer/);
+    expect(() => parser.parse('get_user')).not.toThrow(/invalid/);
   });
 
   it('throws on negative value', () => {

--- a/src/tool-filter/config/header-config-parser.ts
+++ b/src/tool-filter/config/header-config-parser.ts
@@ -116,7 +116,7 @@ export class HeaderConfigParser {
     const parsed = parseInt(raw, 10);
     if (Number.isNaN(parsed) || parsed <= 0) {
       throw new ConfigurationError(
-        `Invalid MCP4_TOOL_FILTER_SESSION_MAX_TOOLS: '${raw}' (must be positive integer)`
+        `Invalid MCP4_TOOL_FILTER_SESSION_MAX_TOOLS (must be positive integer)`
       );
     }
 

--- a/src/transport/cache-policy-resolver.test.ts
+++ b/src/transport/cache-policy-resolver.test.ts
@@ -64,12 +64,19 @@ describe('CachePolicyResolver', () => {
   it('throws on invalid max_memory_bytes_from_env value', () => {
     process.env.CUSTOM_CACHE_LIMIT = 'invalid';
 
-    expect(() => CachePolicyResolver.resolve({
-      cacheConfig: {
-        max_memory_bytes_from_env: 'CUSTOM_CACHE_LIMIT',
-      },
-      hasAuth: false,
-    })).toThrow(ConfigurationError);
+    let error: Error | undefined;
+    try {
+      CachePolicyResolver.resolve({
+        cacheConfig: {
+          max_memory_bytes_from_env: 'CUSTOM_CACHE_LIMIT',
+        },
+        hasAuth: false,
+      });
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error).toBeInstanceOf(ConfigurationError);
+    expect(error?.message).not.toContain('invalid');
   });
 
   it('throws on partially numeric max_memory_bytes_from_env value', () => {

--- a/src/transport/cache-policy-resolver.ts
+++ b/src/transport/cache-policy-resolver.ts
@@ -48,14 +48,14 @@ export class CachePolicyResolver {
         const trimmedValue = rawValue.trim();
         if (!/^[0-9]+$/.test(trimmedValue)) {
           throw new ConfigurationError(
-            `Invalid ${envVar}: '${rawValue}' (must be positive integer for cache max_memory_bytes)`
+            `Invalid ${envVar} (must be positive integer for cache max_memory_bytes)`
           );
         }
 
         const parsed = Number(trimmedValue);
         if (!Number.isSafeInteger(parsed) || parsed <= 0) {
           throw new ConfigurationError(
-            `Invalid ${envVar}: '${rawValue}' (must be positive integer for cache max_memory_bytes)`
+            `Invalid ${envVar} (must be positive integer for cache max_memory_bytes)`
           );
         }
         return parsed;

--- a/src/transport/http-transport-config.test.ts
+++ b/src/transport/http-transport-config.test.ts
@@ -101,11 +101,25 @@ describe('buildHttpTransportBaseConfig', () => {
 
   it('throws on invalid oauth session timeout', () => {
     process.env.MCP4_OAUTH_SESSION_TIMEOUT_MS = 'invalid';
-    expect(() => buildHttpTransportBaseConfig('127.0.0.1', 3003)).toThrow(ConfigurationError);
+    let error: Error | undefined;
+    try {
+      buildHttpTransportBaseConfig('127.0.0.1', 3003);
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error).toBeInstanceOf(ConfigurationError);
+    expect(error?.message).not.toContain('invalid');
   });
 
   it('throws on invalid oauth refresh threshold', () => {
     process.env.MCP4_OAUTH_REFRESH_THRESHOLD_MS = 'invalid';
-    expect(() => buildHttpTransportBaseConfig('127.0.0.1', 3003)).toThrow(ConfigurationError);
+    let error: Error | undefined;
+    try {
+      buildHttpTransportBaseConfig('127.0.0.1', 3003);
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error).toBeInstanceOf(ConfigurationError);
+    expect(error?.message).not.toContain('invalid');
   });
 });

--- a/src/transport/http-transport-config.ts
+++ b/src/transport/http-transport-config.ts
@@ -47,7 +47,7 @@ export function buildHttpTransportBaseConfig(host: string, port: number): HttpTr
       const parsed = parseInt(process.env.MCP4_OAUTH_SESSION_TIMEOUT_MS, 10);
       if (Number.isNaN(parsed)) {
         throw new ConfigurationError(
-          `Invalid MCP4_OAUTH_SESSION_TIMEOUT_MS: expected integer milliseconds, got '${process.env.MCP4_OAUTH_SESSION_TIMEOUT_MS}'`
+          `Invalid MCP4_OAUTH_SESSION_TIMEOUT_MS: expected integer milliseconds`
         );
       }
       return parsed;
@@ -57,7 +57,7 @@ export function buildHttpTransportBaseConfig(host: string, port: number): HttpTr
       const parsed = parseInt(process.env.MCP4_OAUTH_REFRESH_THRESHOLD_MS, 10);
       if (Number.isNaN(parsed)) {
         throw new ConfigurationError(
-          `Invalid MCP4_OAUTH_REFRESH_THRESHOLD_MS: expected integer milliseconds, got '${process.env.MCP4_OAUTH_REFRESH_THRESHOLD_MS}'`
+          `Invalid MCP4_OAUTH_REFRESH_THRESHOLD_MS: expected integer milliseconds`
         );
       }
       return parsed;


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Configuration errors were throwing exceptions that included the raw values of environment variables. If a user configured settings (like timeout or cache limits) with a sensitive environment variable (e.g., an API key by mistake), the secret value would be exposed in the error message.
🎯 **Impact:** Potential exposure of secrets or API keys through logged configuration errors.
🔧 **Fix:** Removed the reflection of raw input values from `ConfigurationError` and `Error` messages in `src/transport/http-transport-config.ts`, `src/transport/cache-policy-resolver.ts`, and `src/core/index.ts`. Also updated corresponding tests.
✅ **Verification:** Confirmed error messages no longer include the value. Ran full test suite and lint checks.

---
*PR created automatically by Jules for task [10234615445436923447](https://jules.google.com/task/10234615445436923447) started by @davidruzicka*