### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,16 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2026-03-10 - [MEDIUM] Missing HTTP Security Headers
+
+**Vulnerability:**
+The HTTP transport layer lacked standard security headers for Strict-Transport-Security (HSTS) and X-XSS-Protection. The absence of HSTS means that browsers may not be forced to use HTTPS for subsequent connections, leaving them vulnerable to downgrade attacks. Although X-XSS-Protection is largely deprecated by modern browsers in favor of CSP, it should explicitly be set to '0' to disable legacy XSS auditors which themselves can introduce side-channel vulnerabilities.
+
+**Learning:**
+While several security headers were configured (such as CSP, X-Frame-Options, and Cross-Origin-Opener-Policy), defense-in-depth requires a complete set of standard headers. Specifically, relying on default Express behavior omits critical HTTP security best practices.
+
+**Prevention:**
+1. Include `Strict-Transport-Security` header with `max-age=63072000; includeSubDomains` in Express middleware.
+2. Explicitly set `X-XSS-Protection: 0` in Express middleware.
+3. Assert the presence of all required security headers in automated integration tests (`src/transport/http-transport-security.test.ts`).

--- a/src/transport/http-transport-security.test.ts
+++ b/src/transport/http-transport-security.test.ts
@@ -143,6 +143,8 @@ describe('HttpTransport security behavior (no listen)', () => {
     expect(response.headers['x-content-type-options']).toBe('nosniff');
     expect(response.headers['x-frame-options']).toBe('DENY');
     expect(response.headers['referrer-policy']).toBe('no-referrer');
+    expect(response.headers['strict-transport-security']).toBe('max-age=63072000; includeSubDomains');
+    expect(response.headers['x-xss-protection']).toBe('0');
     expect(response.headers['cross-origin-opener-policy']).toBe('same-origin');
     expect(response.headers['cross-origin-resource-policy']).toBe('same-origin');
     expect(response.headers['x-permitted-cross-domain-policies']).toBe('none');

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -156,6 +156,8 @@ export class HttpTransport {
       res.setHeader('Permissions-Policy', 'geolocation=(), microphone=(), camera=(), payment=()');
 
       // Additional security headers
+      res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
+      res.setHeader('X-XSS-Protection', '0');
       res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
       res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
       res.setHeader('X-Permitted-Cross-Domain-Policies', 'none');


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add HTTP security headers

**🚨 Severity:** MEDIUM
**💡 Vulnerability:** The HTTP transport layer lacked standard security headers for Strict-Transport-Security (HSTS) and X-XSS-Protection. The absence of HSTS means that browsers may not be forced to use HTTPS for subsequent connections, leaving them vulnerable to downgrade attacks. Although X-XSS-Protection is largely deprecated by modern browsers in favor of CSP, it should explicitly be set to '0' to disable legacy XSS auditors which themselves can introduce side-channel vulnerabilities.
**🎯 Impact:** Weakened defense-in-depth against network downgrade attacks and potential side-channels from legacy browser XSS filters.
**🔧 Fix:** Added `Strict-Transport-Security` and `X-XSS-Protection` headers to the main Express middleware in `src/transport/http-transport.ts`.
**✅ Verification:** Updated existing security header tests in `src/transport/http-transport-security.test.ts` to assert the presence of these new headers. Ran full test suite to ensure no regressions. Appended learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [282740093737445840](https://jules.google.com/task/282740093737445840) started by @davidruzicka*