### PR TITLE
fix(deps): bump hono to remediate OSV alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4003,9 +4003,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.4.tgz",
-      "integrity": "sha512-ooiZW1Xy8rQ4oELQ++otI2T9DsKpV0M6c6cO6JGx4RTfav9poFFLlet9UMXHZnoM1yG0HWGlQLswBGX3RZmHtg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   },
   "overrides": {
     "@hono/node-server": "1.19.10",
-    "hono": "4.12.4",
+    "hono": "4.12.7",
     "minimatch": "10.2.3"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- bump the pinned hono override from 4.12.4 to 4.12.7
- refresh package-lock.json to remove GHSA-v8w9-8mx6-g223 from main

## Validation
- npm audit --json
- npm test
- npm run typecheck