### PR TITLE
fix(http): bound profile hint cache growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `express-rate-limit` to `^8.3.1` to remediate the open GitHub Security / Dependabot alert for IPv4-mapped IPv6 rate-limit keying.
 
 ### Fixed
+- Bounded HTTP profile hint cache growth with TTL pruning on access/write and deterministic capacity eviction for long-running servers.
 - Blocked dangerous URI schemes during URI validation to prevent XSS through attacker-controlled links and redirects.
 - Removed raw environment variable values from selected configuration error messages and added regression checks to prevent secret leakage in errors.
 - Hardened MCP Apps resource loading so `file_path` stays inside the profile directory after normalization and symlink resolution, while keeping `resources/read` output shape consistent across inline, file-backed, and fetch-backed resources.

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,6 @@
   - [10. Split HttpTransport into smaller modules](#10-split-httptransport-into-smaller-modules)
   - [11. Reduce usage of any casts in HTTP transport](#11-reduce-usage-of-any-casts-in-http-transport)
   - [12. Avoid HTTP profile hint collisions across shared IPs](#12-avoid-http-profile-hint-collisions-across-shared-ips)
-  - [13. Prevent unbounded growth of HTTP profile hint cache](#13-prevent-unbounded-growth-of-http-profile-hint-cache)
   - [14. Consider strict OAuth redirect scheme allowlist](#14-consider-strict-oauth-redirect-scheme-allowlist)
   - [15. Replace JSON fingerprint auth comparison for tenant collisions](#15-replace-json-fingerprint-auth-comparison-for-tenant-collisions)
   - [16. Extract tenant session lifecycle from HttpTransport](#16-extract-tenant-session-lifecycle-from-httptransport)
@@ -265,22 +264,6 @@ export DEFAULT_PROFILE_EXCLUDE_TAGS="admin,system"
 - `docs/HTTP-TRANSPORT.md` - document new hint mechanism (if user-facing)
 
 **Estimated effort**: 2-4 hours
-
-### 13. Prevent unbounded growth of HTTP profile hint cache
-**Problem**: Profile hints are stored per client but only cleaned up on subsequent lookups, so many one-off clients can cause the cache to grow without bound in long-running servers.
-
-**Goal**: Bound memory usage for profile hint cache.
-
-**Implementation options**:
-- Periodic cleanup timer that removes expired hints.
-- Cap the cache size with LRU eviction.
-- Combine TTL + size cap with logging when evictions occur.
-
-**Files to modify**:
-- `src/http-transport.ts` - add cache eviction or cleanup
-- `README.md` - document any new env vars or limits
-
-**Estimated effort**: 1-2 hours
 
 ### 14. Consider strict OAuth redirect scheme allowlist
 **Current**: `ExternalOAuthProvider` uses a denylist for dangerous redirect URI schemes (`javascript:`, `data:`, `vbscript:`, `file:`, `blob:`, `about:`) while keeping compatibility with custom client schemes.

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -115,6 +115,7 @@ export class HttpTransport {
   private warnedMissingOAuthRedirectEnvVars: Set<string> = new Set();
   private profileHintsByClient: Map<string, { profileId: string; lastSeen: number }> = new Map();
   private static readonly PROFILE_HINT_TTL_MS = 10 * 60 * 1000;
+  private static readonly PROFILE_HINT_MAX_ENTRIES = 1024;
   private profileIndexProvider: (() => Promise<ListedProfileDetails[]>) | null = null;
   private ssrfValidator: SSRFValidator;
   private rawTenantConfig: HttpTenantsConfig | null;
@@ -686,22 +687,42 @@ export class HttpTransport {
     return `${req.ip}|${userAgent}`;
   }
 
+  private pruneExpiredProfileHints(now: number): void {
+    for (const [key, hint] of this.profileHintsByClient.entries()) {
+      if (now - hint.lastSeen > HttpTransport.PROFILE_HINT_TTL_MS) {
+        this.profileHintsByClient.delete(key);
+      }
+    }
+  }
+
+  private evictProfileHintsToCapacity(): void {
+    while (this.profileHintsByClient.size >= HttpTransport.PROFILE_HINT_MAX_ENTRIES) {
+      const oldestKey = this.profileHintsByClient.keys().next().value;
+      if (!oldestKey) {
+        return;
+      }
+      this.profileHintsByClient.delete(oldestKey);
+    }
+  }
+
   private storeProfileHint(req: Request, profileId: string): void {
+    const now = Date.now();
     const key = this.getClientHintKey(req);
-    this.profileHintsByClient.set(key, { profileId, lastSeen: Date.now() });
+
+    this.pruneExpiredProfileHints(now);
+    if (this.profileHintsByClient.has(key)) {
+      this.profileHintsByClient.delete(key);
+    }
+    this.evictProfileHintsToCapacity();
+    this.profileHintsByClient.set(key, { profileId, lastSeen: now });
   }
 
   private resolveProfileIdFromHint(req: Request): string | null {
+    const now = Date.now();
     const key = this.getClientHintKey(req);
-    const hint = this.profileHintsByClient.get(key);
-    if (!hint) {
-      return null;
-    }
-    if (Date.now() - hint.lastSeen > HttpTransport.PROFILE_HINT_TTL_MS) {
-      this.profileHintsByClient.delete(key);
-      return null;
-    }
-    return hint.profileId;
+
+    this.pruneExpiredProfileHints(now);
+    return this.profileHintsByClient.get(key)?.profileId ?? null;
   }
 
   private resolveProfileIdForOriginCheck(req: Request): string | null {

--- a/src/transport/http-transport.unit.test.ts
+++ b/src/transport/http-transport.unit.test.ts
@@ -58,6 +58,57 @@ describe('HttpTransport unit', () => {
     await transport.stop();
   });
 
+  describe('profile hint cache', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('prunes expired profile hints when storing a new hint', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-14T00:00:00.000Z'));
+
+      const storeProfileHint = (transport as any).storeProfileHint.bind(transport);
+      const profileHintsByClient = (transport as any).profileHintsByClient as Map<string, { profileId: string; lastSeen: number }>;
+      const ttlMs = (HttpTransport as any).PROFILE_HINT_TTL_MS as number;
+
+      storeProfileHint(withGet({
+        ip: '10.0.0.1',
+        headers: { 'user-agent': 'agent-a' },
+      }), 'profile-a');
+
+      vi.advanceTimersByTime(ttlMs + 1);
+
+      storeProfileHint(withGet({
+        ip: '10.0.0.2',
+        headers: { 'user-agent': 'agent-b' },
+      }), 'profile-b');
+
+      expect(profileHintsByClient.size).toBe(1);
+      expect(profileHintsByClient.get('10.0.0.1|agent-a')).toBeUndefined();
+      expect(profileHintsByClient.get('10.0.0.2|agent-b')).toEqual({
+        profileId: 'profile-b',
+        lastSeen: Date.now(),
+      });
+    });
+
+    it('evicts the oldest active profile hint when the cache reaches capacity', () => {
+      const storeProfileHint = (transport as any).storeProfileHint.bind(transport);
+      const profileHintsByClient = (transport as any).profileHintsByClient as Map<string, { profileId: string; lastSeen: number }>;
+      const maxEntries = (HttpTransport as any).PROFILE_HINT_MAX_ENTRIES as number;
+
+      for (let index = 0; index < maxEntries + 1; index += 1) {
+        storeProfileHint(withGet({
+          ip: `10.0.0.${index}`,
+          headers: { 'user-agent': `agent-${index}` },
+        }), `profile-${index}`);
+      }
+
+      expect(profileHintsByClient.size).toBe(maxEntries);
+      expect(profileHintsByClient.has('10.0.0.0|agent-0')).toBe(false);
+      expect(profileHintsByClient.get(`10.0.0.${maxEntries}|agent-${maxEntries}`)?.profileId).toBe(`profile-${maxEntries}`);
+    });
+  });
+
   describe('filtering header helpers', () => {
     it('detects unknown message types', () => {
       const messageType = (transport as any).getMessageType(123);


### PR DESCRIPTION
## Summary
- bound HTTP profile hint cache growth with TTL pruning and a deterministic capacity limit
- keep existing profile-hint keying and routing behavior unchanged
- add focused regression tests and remove the completed TODO entry

## Root cause
`HttpTransport` stored profile hints in an unbounded in-memory `Map` and only removed expired entries when the same client key returned later. Distinct one-off client keys could accumulate indefinitely in long-running HTTP deployments.

## Changes made
- added shared profile-hint pruning before reads and writes so expired entries are removed even when the original client never comes back
- added a conservative fixed max-entry guard with deterministic oldest-entry eviction
- refreshed an existing key by deleting and reinserting it before capacity enforcement so active hints stay current
- updated the changelog and removed the completed TODO item

## Test coverage added/updated
- added unit coverage for pruning expired hints during writes
- added unit coverage for deterministic eviction when the cache reaches capacity
- reran the existing profile-hint routing test for OAuth metadata behavior
- ran `npm run typecheck`

## Risk assessment
Low. The change is narrowly scoped to the in-memory profile hint cache lifecycle, preserves existing TTL semantics and key format, and adds focused regression coverage around expiration and bounded growth.

Closes #144
