### PR TITLE
fix(http): replace tenant auth fingerprint comparator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened MCP Apps resource loading so `file_path` stays inside the profile directory after normalization and symlink resolution, while keeping `resources/read` output shape consistent across inline, file-backed, and fetch-backed resources.
 - Fixed HTTP single-profile startup to carry `enterprise_authorization` into transport runtime so enterprise JWT bearer exchange and authenticated initialization work outside profile-routing mode, with dedicated E2E coverage.
 - Clarified and locked runtime enterprise authorization behavior so `required` mode enforces trusted enterprise-issued bearer tokens, `optional` mode stays backward-compatible, tool-category policy covers both listing and execution, and invalid env-backed values fail during profile loading.
+- Replaced serialization-based tenant auth collision checks with an explicit comparator so equivalent nested OAuth configs no longer depend on object property insertion order.
 
 ## [0.5.7] - 2026-03-03
 

--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,6 @@
   - [12. Avoid HTTP profile hint collisions across shared IPs](#12-avoid-http-profile-hint-collisions-across-shared-ips)
   - [13. Prevent unbounded growth of HTTP profile hint cache](#13-prevent-unbounded-growth-of-http-profile-hint-cache)
   - [14. Consider strict OAuth redirect scheme allowlist](#14-consider-strict-oauth-redirect-scheme-allowlist)
-  - [15. Replace JSON fingerprint auth comparison for tenant collisions](#15-replace-json-fingerprint-auth-comparison-for-tenant-collisions)
   - [16. Extract tenant session lifecycle from HttpTransport](#16-extract-tenant-session-lifecycle-from-httptransport)
 
 ## P2: Nice-to-Have
@@ -299,29 +298,6 @@ export DEFAULT_PROFILE_EXCLUDE_TAGS="admin,system"
 - `docs/OAUTH.md` and `README.md` - configuration guidance
 
 **Estimated effort**: 2-4 hours
-
-### 15. Replace JSON fingerprint auth comparison for tenant collisions
-**Current**: `authFingerprint` in `src/transport/http-tenant-config.ts` compares tenant auth compatibility via `JSON.stringify` over mapped auth config objects.
-
-**Analysis**:
-- Relevance is medium: current mapping to known keys reduces top-level key-order risks, so this is not an immediate correctness bug.
-- Residual fragility remains for nested structures (for example `oauth_config`) and long-term readability/maintainability.
-- A semantic comparator communicates intended equality rules better than string fingerprinting.
-
-**Goal**: Replace serialization-based comparison with explicit deterministic auth config comparison.
-
-**Implementation options**:
-- Introduce dedicated utility (for example `areAuthConfigsEquivalent(left, right)`).
-- Define explicit semantics for array order (sensitive vs insensitive) and document the choice.
-- Perform field-level comparison for known auth interceptor properties, including nested `oauth_config`.
-- Reuse comparator in tenant collision checks where `authFingerprint(...)` is currently used.
-- Add focused tests for equivalent configs, non-equivalent configs, and nested OAuth config differences.
-
-**Files to modify**:
-- `src/transport/http-tenant-config.ts`
-- `src/transport/http-tenant-config.test.ts`
-
-**Estimated effort**: 1-2 hours
 
 ### 16. Extract tenant session lifecycle from HttpTransport
 **Problem**: `HttpTransport` currently combines routing, auth, filtering, SSE/session control, and tenant-specific session state/lifecycle (`tenantOAuthProvidersBySessionId`, tenant selector consistency checks, tenant context hydration). This concentration increases coupling and regression risk.

--- a/src/transport/http-tenant-config.test.ts
+++ b/src/transport/http-tenant-config.test.ts
@@ -460,6 +460,100 @@ describe('http-tenant-config', () => {
     }
   });
 
+  it('allows duplicate base URL for equivalent oauth config with different property insertion order and warns', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const raw = {
+      version: 1,
+      tenants: [
+        {
+          tenant_id: 'team-a',
+          profile_ids: ['default'],
+          api_base_url: 'https://same.example.com/api',
+          auth_mode: 'oauth' as const,
+          auth: {
+            type: 'oauth' as const,
+            oauth_config: {
+              authorization_endpoint: 'https://auth.example.com/oauth/authorize',
+              token_endpoint: 'https://auth.example.com/oauth/token',
+              client_id: 'shared-client',
+              scopes: ['read', 'write'],
+              allowed_redirect_hosts: ['localhost', '127.0.0.1'],
+            },
+          },
+        },
+        {
+          tenant_id: 'team-b',
+          profile_ids: ['default'],
+          api_base_url: 'https://same.example.com/api/',
+          auth_mode: 'oauth' as const,
+          auth: {
+            type: 'oauth' as const,
+            oauth_config: {
+              allowed_redirect_hosts: ['localhost', '127.0.0.1'],
+              scopes: ['read', 'write'],
+              client_id: 'shared-client',
+              token_endpoint: 'https://auth.example.com/oauth/token',
+              authorization_endpoint: 'https://auth.example.com/oauth/authorize',
+            },
+          },
+        },
+      ],
+    };
+
+    try {
+      const index = buildTenantIndexForProfile(raw as any, profileContext, logger);
+      expect(index.byTenantId.size).toBe(2);
+      expect(index.byBaseUrl.size).toBe(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Multiple tenants share the same api_base_url and auth config',
+        expect.objectContaining({
+          profileId: 'default',
+          tenantIds: ['team-a', 'team-b'],
+        }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('fails when same base URL has oauth config that differs in a nested field', () => {
+    const raw = {
+      version: 1,
+      tenants: [
+        {
+          tenant_id: 'team-a',
+          profile_ids: ['default'],
+          api_base_url: 'https://same.example.com/api',
+          auth_mode: 'oauth' as const,
+          auth: {
+            type: 'oauth' as const,
+            oauth_config: {
+              authorization_endpoint: 'https://auth.example.com/oauth/authorize',
+              token_endpoint: 'https://auth.example.com/oauth/token',
+              client_id: 'shared-client',
+            },
+          },
+        },
+        {
+          tenant_id: 'team-b',
+          profile_ids: ['default'],
+          api_base_url: 'https://same.example.com/api/',
+          auth_mode: 'oauth' as const,
+          auth: {
+            type: 'oauth' as const,
+            oauth_config: {
+              authorization_endpoint: 'https://auth.example.com/oauth/authorize',
+              token_endpoint: 'https://auth.example.com/oauth/token',
+              client_id: 'different-client',
+            },
+          },
+        },
+      ],
+    };
+
+    expect(() => buildTenantIndexForProfile(raw as any, profileContext, logger)).toThrow(/collision/i);
+  });
+
   it('resolves mask tenant from concrete base URL and requires concrete URL for tenant id selector', () => {
     const raw = {
       version: 1,

--- a/src/transport/http-tenant-config.ts
+++ b/src/transport/http-tenant-config.ts
@@ -317,15 +317,109 @@ function buildResolvedContext(
   };
 }
 
-function authFingerprint(authConfigs: AuthInterceptor[]): string {
-  return JSON.stringify(authConfigs.map((entry) => ({
-    type: entry.type,
-    header_name: entry.header_name,
-    value_from_env: entry.value_from_env,
-    priority: entry.priority,
-    validation_endpoint: entry.validation_endpoint,
-    oauth_config: entry.type === 'oauth' ? entry.oauth_config : undefined,
-  })));
+function arePrimitiveArraysEqual(left: readonly string[] | readonly number[] | undefined, right: readonly string[] | readonly number[] | undefined): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (!left || !right || left.length !== right.length) {
+    return false;
+  }
+  return left.every((value, index) => value === right[index]);
+}
+
+function areStringRecordsEqual(
+  left: Record<string, string> | undefined,
+  right: Record<string, string> | undefined,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (!left || !right) {
+    return false;
+  }
+
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  if (!arePrimitiveArraysEqual(leftKeys, rightKeys)) {
+    return false;
+  }
+
+  return leftKeys.every((key) => left[key] === right[key]);
+}
+
+function areOAuthConfigsEquivalent(left: OAuthConfig | undefined, right: OAuthConfig | undefined): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (!left || !right) {
+    return false;
+  }
+
+  return left.issuer === right.issuer
+    && left.authorization_endpoint === right.authorization_endpoint
+    && left.token_endpoint === right.token_endpoint
+    && left.client_id === right.client_id
+    && left.client_secret === right.client_secret
+    && arePrimitiveArraysEqual(left.scopes, right.scopes)
+    && left.redirect_uri === right.redirect_uri
+    && left.registration_endpoint === right.registration_endpoint
+    && left.introspection_endpoint === right.introspection_endpoint
+    && left.revocation_endpoint === right.revocation_endpoint
+    && arePrimitiveArraysEqual(left.allowed_redirect_hosts, right.allowed_redirect_hosts);
+}
+
+function areSessionCookieConfigsEquivalent(
+  left: AuthInterceptor['session_cookie_config'],
+  right: AuthInterceptor['session_cookie_config'],
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (!left || !right) {
+    return false;
+  }
+
+  return left.login_endpoint === right.login_endpoint
+    && left.login_method === right.login_method
+    && left.login_content_type === right.login_content_type
+    && left.username_field === right.username_field
+    && left.username_from_env === right.username_from_env
+    && left.password_field === right.password_field
+    && left.password_from_env === right.password_from_env
+    && areStringRecordsEqual(left.login_static_headers, right.login_static_headers)
+    && areStringRecordsEqual(left.login_static_body, right.login_static_body)
+    && arePrimitiveArraysEqual(left.cookie_names, right.cookie_names)
+    && arePrimitiveArraysEqual(left.login_allowed_hosts, right.login_allowed_hosts)
+    && arePrimitiveArraysEqual(left.reauth_on_statuses, right.reauth_on_statuses)
+    && left.failure_backoff_ms === right.failure_backoff_ms
+    && left.expiry_skew_ms === right.expiry_skew_ms;
+}
+
+function areAuthInterceptorsEquivalent(left: AuthInterceptor, right: AuthInterceptor): boolean {
+  return left.type === right.type
+    && left.priority === right.priority
+    && left.header_name === right.header_name
+    && left.query_param === right.query_param
+    && left.value_from_env === right.value_from_env
+    && left.validation_endpoint === right.validation_endpoint
+    && left.validation_method === right.validation_method
+    && left.validation_timeout_ms === right.validation_timeout_ms
+    && arePrimitiveArraysEqual(left.validation_allowed_hosts, right.validation_allowed_hosts)
+    && areOAuthConfigsEquivalent(left.oauth_config, right.oauth_config)
+    && areSessionCookieConfigsEquivalent(left.session_cookie_config, right.session_cookie_config)
+    && left.oauth_rate_limit?.max_requests === right.oauth_rate_limit?.max_requests
+    && left.oauth_rate_limit?.window_ms === right.oauth_rate_limit?.window_ms;
+}
+
+function areAuthConfigsEquivalent(left: AuthInterceptor[], right: AuthInterceptor[]): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((entry, index) => areAuthInterceptorsEquivalent(entry, right[index]));
 }
 
 function maskMatchesBaseUrl(selector: TenantMaskSelector, normalizedBaseUrl: string): boolean {
@@ -473,8 +567,9 @@ export function buildTenantIndexForProfile(
     if (built.selectorType === 'exact') {
       const existingByBaseUrl = byBaseUrl.get(resolved.tenantBaseUrl);
       if (existingByBaseUrl) {
-        const sameAuth = authFingerprint(existingByBaseUrl.tenantAuthConfigs) === authFingerprint(resolved.tenantAuthConfigs);
-        if (!sameAuth || existingByBaseUrl.tenantAuthMode !== resolved.tenantAuthMode) {
+        const sameAuth = existingByBaseUrl.tenantAuthMode === resolved.tenantAuthMode
+          && areAuthConfigsEquivalent(existingByBaseUrl.tenantAuthConfigs, resolved.tenantAuthConfigs);
+        if (!sameAuth) {
           throw new ValidationError(
             `Tenant base URL collision for '${resolved.tenantBaseUrl}' with different auth configuration (${existingByBaseUrl.tenantId}, ${resolved.tenantId}).`,
           );


### PR DESCRIPTION
## Summary
- replace JSON fingerprint comparison in tenant base-URL collision checks with explicit auth comparator helpers
- cover nested OAuth config equivalence when object property insertion order differs
- remove the completed TODO item and document the fix in the changelog

## Root cause
`buildTenantIndexForProfile()` decided duplicate-base-url auth compatibility by serializing projected auth configs with `JSON.stringify`. Nested OAuth config objects with the same semantic values but different property insertion order produced different fingerprints, so equivalent tenant auth could be rejected as a collision.

## Changes made
- replaced `authFingerprint(...)` with explicit comparator helpers for auth interceptors, OAuth config, session-cookie config, ordered arrays, and string records
- kept duplicate-base-url auth comparison order-sensitive for auth interceptor arrays while making nested object comparison semantic instead of serialization-based
- reused the comparator directly in the tenant collision branch for exact selectors
- removed the completed TODO entry and added an Unreleased changelog note

## Test coverage added/updated
- added a regression test proving equivalent nested OAuth configs are accepted even when property insertion order differs
- added a focused nested OAuth difference test to preserve collision rejection for meaningful auth changes
- ran `npm run typecheck`
- ran `npx vitest run src/transport/http-tenant-config.test.ts`

## Risk assessment
Low. The change is narrowly scoped to tenant duplicate-base-url validation, preserves existing auth-mode gating and interceptor-array order semantics, and adds focused regression coverage around the previously brittle nested OAuth comparison path.

Closes #146
