### PR TITLE
fix(http): bound profile-routed MCP server cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,8 @@ export MCP4_TOOLNAME_MAX=30
 - `MCP4_HTTP_PROFILE_INDEX`: Enable profile index on `GET /` for routed profiles.
 - `MCP4_ALLOW_PROFILES`: Comma-separated profile ids/names/aliases allowed for routed profiles.
 - `MCP4_ALLOW_PROFILES_REGEX`: Regex for allowed profile ids/names/aliases (applies only when routing is enabled).
+- `MCP4_PROFILE_SERVER_CACHE_MAX`: Max number of lazily initialized profile-routed MCP servers kept in memory (default: `32`).
+- `MCP4_PROFILE_SERVER_CACHE_TTL_MS`: Idle TTL for inactive profile-routed MCP servers in memory (default: `900000` = 15min, `0` disables TTL eviction).
 - `MCP4_HTTP_TENANTS_FILE`: Path to tenant selector config JSON.
 - `MCP4_HTTP_TENANTS_JSON`: Inline tenant selector config JSON.
 - `MCP4_HTTP_TENANTS_ALLOW_HTTP`: Allow `http` tenant selectors (default is `https` only).

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,6 @@
   - [3. OpenAPI Operation Filter for Default Profile](#3-openapi-operation-filter-for-default-profile)
   - [4. Harden query parameter redaction canonicalization](#4-harden-query-parameter-redaction-canonicalization)
   - [7. Strengthen ReDoS Protection in Regex Compiler](#7-strengthen-redos-protection-in-regex-compiler)
-  - [8. Limit HTTP profile server cache growth](#8-limit-http-profile-server-cache-growth)
   - [9. Break MCPServer-HttpTransport circular dependency](#9-break-mcpserver-httptransport-circular-dependency)
   - [10. Split HttpTransport into smaller modules](#10-split-httptransport-into-smaller-modules)
   - [11. Reduce usage of any casts in HTTP transport](#11-reduce-usage-of-any-casts-in-http-transport)
@@ -180,23 +179,6 @@ export DEFAULT_PROFILE_EXCLUDE_TAGS="admin,system"
 - `src/tool-filter/regex/regex-compiler.test.ts` - add timeout and edge case tests
 
 **Estimated effort**: 2-3 hours (timeout implementation) + 1-2 hours (expanded validation)
-
-### 8. Limit HTTP profile server cache growth
-**Problem**: HTTP profile routing keeps every requested profile's MCPServer initialized indefinitely. With many large OpenAPI specs, this can exhaust memory.
-
-**Goal**: Add basic eviction or caps for profile server instances to bound memory usage.
-
-**Implementation options**:
-- TTL eviction: expire inactive profiles after `MCP4_PROFILE_CACHE_TTL_MS`.
-- Max size: cap servers to `MCP4_PROFILE_CACHE_MAX` with LRU eviction.
-- Combine TTL + max size with soft warnings when evicting.
-
-**Files to modify**:
-- `src/mcp-server-manager.ts` - eviction logic and tracking
-- `src/index.ts` - pass env config into manager/registry
-- `README.md` - document new env vars
-
-**Estimated effort**: 2-4 hours
 
 ### 9. Break MCPServer-HttpTransport circular dependency
 **Problem**: MCPServer holds a reference to HttpTransport (typed as any), creating a circular dependency and weaker type safety.

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -14,7 +14,7 @@ import { OAUTH_PATHS } from './constants.js';
 import { applyCliEnvOverrides, parseCliArgs } from './cli-config.js';
 import { buildHttpTransportBaseConfig } from '../transport/http-transport-config.js';
 import { ProfileRegistry } from '../profile/profile-registry.js';
-import { MCPServerManager } from '../mcp/mcp-server-manager.js';
+import { MCPServerManager, buildMCPServerManagerConfigFromEnv } from '../mcp/mcp-server-manager.js';
 import { getHttpProfileRoutingErrorMessage } from '../profile/startup-validation.js';
 import { listProfiles } from '../profile/profile-resolver.js';
 import { resolveStartupProfile } from '../profile/startup-profile.js';
@@ -302,7 +302,13 @@ export async function main() {
         specPathOverride: hasExplicitSpecPath ? specPathOverride : undefined,
         allowlist: profileAllowlistConfig,
       });
-      const manager = new MCPServerManager(registry, logger, httpTransport, globalFiltering);
+      const manager = new MCPServerManager(
+        registry,
+        logger,
+        httpTransport,
+        globalFiltering,
+        buildMCPServerManagerConfigFromEnv()
+      );
 
       httpTransport.setProfileContextProvider(async (id) => manager.getProfileContext(id));
       httpTransport.setProfileIndexProvider(async () => registry.listProfilesForIndex());
@@ -311,14 +317,12 @@ export async function main() {
         if (!profileId) {
           throw new Error('Profile ID is required for HTTP routing.');
         }
-        const server = await manager.getServer(profileId);
-        return server.handleHttpMessage(message, sessionId, profileId);
+        return manager.handleHttpMessage(message, sessionId, profileId);
       });
 
       httpTransport.onSessionDestroyed(async (profileId, sessionId) => {
         try {
-          const server = await manager.getServer(profileId);
-          server.handleSessionDestroyed(profileId, sessionId);
+          await manager.handleSessionDestroyed(profileId, sessionId);
         } catch (error) {
           logger.error('Session cleanup failed', error as Error, { profileId, sessionId });
         }

--- a/src/mcp/mcp-server-manager-config.test.ts
+++ b/src/mcp/mcp-server-manager-config.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildMCPServerManagerConfigFromEnv } from './mcp-server-manager.js';
+
+const ENV_KEYS = [
+  'MCP4_PROFILE_SERVER_CACHE_MAX',
+  'MCP4_PROFILE_SERVER_CACHE_TTL_MS',
+] as const;
+
+describe('buildMCPServerManagerConfigFromEnv', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    for (const key of ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses safe defaults when env vars are not set', () => {
+    expect(buildMCPServerManagerConfigFromEnv()).toEqual({
+      cacheMaxEntries: 32,
+      cacheTtlMs: 900000,
+    });
+  });
+
+  it('reads env overrides when provided', () => {
+    process.env.MCP4_PROFILE_SERVER_CACHE_MAX = '12';
+    process.env.MCP4_PROFILE_SERVER_CACHE_TTL_MS = '45000';
+
+    expect(buildMCPServerManagerConfigFromEnv()).toEqual({
+      cacheMaxEntries: 12,
+      cacheTtlMs: 45000,
+    });
+  });
+
+  it('rejects invalid cache max values', () => {
+    process.env.MCP4_PROFILE_SERVER_CACHE_MAX = '0';
+
+    expect(() => buildMCPServerManagerConfigFromEnv()).toThrow(
+      /Invalid MCP4_PROFILE_SERVER_CACHE_MAX/
+    );
+  });
+
+  it('rejects invalid cache ttl values', () => {
+    process.env.MCP4_PROFILE_SERVER_CACHE_TTL_MS = '-1';
+
+    expect(() => buildMCPServerManagerConfigFromEnv()).toThrow(
+      /Invalid MCP4_PROFILE_SERVER_CACHE_TTL_MS/
+    );
+  });
+});

--- a/src/mcp/mcp-server-manager.test.ts
+++ b/src/mcp/mcp-server-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import path from 'path';
 import fs from 'node:fs/promises';
 import os from 'node:os';
@@ -179,8 +179,7 @@ describe('MCPServerManager', () => {
       if (!profileId) {
         throw new Error('Profile ID missing');
       }
-      const server = await manager.getServer(profileId);
-      return server.handleHttpMessage(message, sessionId, profileId);
+      return manager.handleHttpMessage(message, sessionId, profileId);
     });
 
     const req: any = {
@@ -235,6 +234,128 @@ describe('MCPServerManager', () => {
     expect(res.body?.result?.serverInfo?.name).toBe('mcp4openapi');
 
     await httpTransport.stop();
+  });
+
+  it('evicts the least recently used inactive server when the cache reaches max size', async () => {
+    const logger = new ConsoleLogger();
+    const resolveProfile = vi.fn(async (profileId: string) => ({
+      profileId,
+      profileName: profileId,
+      profilePath: `/tmp/${profileId}.json`,
+      specPath: `/tmp/${profileId}.yaml`,
+    }));
+    const registry = { resolveProfile } as unknown as ProfileRegistry;
+    const createdServers = new Map<string, Array<{ profileId: string; handleHttpMessage: ReturnType<typeof vi.fn>; handleSessionDestroyed: ReturnType<typeof vi.fn> }>>();
+    const nowValues = [1, 2, 3, 4, 5, 6];
+    const manager = new MCPServerManager(registry, logger, undefined, undefined, {
+      cacheMaxEntries: 2,
+      now: () => nowValues.shift() ?? 99,
+      serverFactory: async (profileId: string) => {
+        const server = {
+          profileId,
+          handleHttpMessage: vi.fn(async () => ({ profileId })),
+          handleSessionDestroyed: vi.fn(),
+          getHttpProfileContext: vi.fn(() => ({ profileId })),
+        };
+        const existing = createdServers.get(profileId) ?? [];
+        existing.push(server);
+        createdServers.set(profileId, existing);
+        return server as any;
+      },
+    });
+
+    const alpha = await manager.getServer('alpha');
+    const beta = await manager.getServer('beta');
+    await manager.getServer('gamma');
+    const alphaAfterEviction = await manager.getServer('alpha');
+    const betaAfterEviction = await manager.getServer('beta');
+
+    expect(alphaAfterEviction).not.toBe(alpha);
+    expect(betaAfterEviction).not.toBe(beta);
+    expect(createdServers.get('alpha')).toHaveLength(2);
+    expect(createdServers.get('beta')).toHaveLength(2);
+    expect(createdServers.get('gamma')).toHaveLength(1);
+  });
+
+  it('keeps active-session servers resident when evicting inactive profiles', async () => {
+    const logger = new ConsoleLogger();
+    const registry = {
+      resolveProfile: vi.fn(async (profileId: string) => ({
+        profileId,
+        profileName: profileId,
+        profilePath: `/tmp/${profileId}.json`,
+        specPath: `/tmp/${profileId}.yaml`,
+      })),
+    } as unknown as ProfileRegistry;
+    const createdServers = new Map<string, Array<{ profileId: string; handleHttpMessage: ReturnType<typeof vi.fn>; handleSessionDestroyed: ReturnType<typeof vi.fn> }>>();
+    const nowValues = [10, 20, 30, 40, 50, 60, 70, 80];
+    const manager = new MCPServerManager(registry, logger, undefined, undefined, {
+      cacheMaxEntries: 2,
+      now: () => nowValues.shift() ?? 999,
+      serverFactory: async (profileId: string) => {
+        const server = {
+          profileId,
+          handleHttpMessage: vi.fn(async () => ({ ok: true, profileId })),
+          handleSessionDestroyed: vi.fn(),
+          getHttpProfileContext: vi.fn(() => ({ profileId })),
+        };
+        const existing = createdServers.get(profileId) ?? [];
+        existing.push(server);
+        createdServers.set(profileId, existing);
+        return server as any;
+      },
+    });
+
+    const activeAlpha = await manager.handleHttpMessage({ jsonrpc: '2.0', id: 1, method: 'initialize' }, 'session-1', 'alpha');
+    expect(activeAlpha).toEqual({ ok: true, profileId: 'alpha' });
+    const beta = await manager.getServer('beta');
+    await manager.getServer('gamma');
+
+    const alphaServer = await manager.getServer('alpha');
+    const betaAfterEviction = await manager.getServer('beta');
+
+    expect((createdServers.get('alpha') ?? [])).toHaveLength(1);
+    expect(alphaServer).toBe(createdServers.get('alpha')?.[0]);
+    expect(betaAfterEviction).not.toBe(beta);
+    expect(createdServers.get('beta')).toHaveLength(2);
+  });
+
+  it('evicts expired inactive servers before creating new entries and skips recreating them during cleanup', async () => {
+    const logger = new ConsoleLogger();
+    const resolveProfile = vi.fn(async (profileId: string) => ({
+      profileId,
+      profileName: profileId,
+      profilePath: `/tmp/${profileId}.json`,
+      specPath: `/tmp/${profileId}.yaml`,
+    }));
+    const registry = { resolveProfile } as unknown as ProfileRegistry;
+    const destroyedSessions: Array<{ profileId: string; sessionId: string }> = [];
+    let currentTime = 100;
+    const manager = new MCPServerManager(registry, logger, undefined, undefined, {
+      cacheMaxEntries: 4,
+      cacheTtlMs: 10,
+      now: () => currentTime,
+      serverFactory: async (profileId: string) => ({
+        handleHttpMessage: vi.fn(async () => ({ ok: true, profileId })),
+        handleSessionDestroyed: vi.fn((destroyedProfileId: string, sessionId: string) => {
+          destroyedSessions.push({ profileId: destroyedProfileId, sessionId });
+        }),
+        getHttpProfileContext: vi.fn(() => ({ profileId })),
+      } as any),
+    });
+
+    await manager.getServer('stale');
+    currentTime = 200;
+    await manager.getServer('fresh');
+    await manager.handleSessionDestroyed('stale', 'session-1');
+    const staleAfterEviction = await manager.getServer('stale');
+
+    expect(resolveProfile).toHaveBeenCalledTimes(3);
+    expect(resolveProfile).toHaveBeenNthCalledWith(1, 'stale');
+    expect(resolveProfile).toHaveBeenNthCalledWith(2, 'fresh');
+    expect(resolveProfile).toHaveBeenNthCalledWith(3, 'stale');
+    expect(destroyedSessions).toEqual([]);
+    expect(staleAfterEviction).toBeTruthy();
   });
 });
 

--- a/src/mcp/mcp-server-manager.ts
+++ b/src/mcp/mcp-server-manager.ts
@@ -8,24 +8,90 @@ import { MCPServer } from './mcp-server.js';
 import type { HttpProfileContext } from '../types/http-transport.js';
 import type { HttpTransport } from '../transport/http-transport.js';
 import { ProfileRegistry } from '../profile/profile-registry.js';
+import type { ResolvedProfile } from '../profile/profile-resolver.js';
+
+const DEFAULT_PROFILE_SERVER_CACHE_MAX_ENTRIES = 32;
+const DEFAULT_PROFILE_SERVER_CACHE_TTL_MS = 15 * 60 * 1000;
+
+interface ServerCacheEntry {
+  serverPromise: Promise<MCPServer>;
+  lastAccessedAt: number;
+  activeSessionIds: Set<string>;
+}
+
+export interface MCPServerManagerOptions {
+  cacheMaxEntries?: number;
+  cacheTtlMs?: number;
+  now?: () => number;
+  serverFactory?: (profileId: string, resolved: ResolvedProfile) => Promise<MCPServer>;
+}
+
+export interface MCPServerManagerConfig {
+  cacheMaxEntries: number;
+  cacheTtlMs: number;
+}
+
+export function buildMCPServerManagerConfigFromEnv(): MCPServerManagerConfig {
+  return {
+    cacheMaxEntries: parsePositiveIntegerEnv('MCP4_PROFILE_SERVER_CACHE_MAX', DEFAULT_PROFILE_SERVER_CACHE_MAX_ENTRIES),
+    cacheTtlMs: parseNonNegativeIntegerEnv('MCP4_PROFILE_SERVER_CACHE_TTL_MS', DEFAULT_PROFILE_SERVER_CACHE_TTL_MS),
+  };
+}
+
+function parsePositiveIntegerEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) {
+    return defaultValue;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${name}: expected positive integer`);
+  }
+
+  return parsed;
+}
+
+function parseNonNegativeIntegerEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) {
+    return defaultValue;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid ${name}: expected non-negative integer`);
+  }
+
+  return parsed;
+}
 
 export class MCPServerManager {
   private registry: ProfileRegistry;
   private logger: Logger;
   private httpTransport?: HttpTransport;
   private globalFiltering?: FilteringRules;
-  private servers = new Map<string, Promise<MCPServer>>();
+  private readonly cacheMaxEntries: number;
+  private readonly cacheTtlMs: number;
+  private readonly now: () => number;
+  private readonly serverFactory?: (profileId: string, resolved: ResolvedProfile) => Promise<MCPServer>;
+  private servers = new Map<string, ServerCacheEntry>();
 
   constructor(
     registry: ProfileRegistry,
     logger: Logger,
     httpTransport?: HttpTransport,
-    globalFiltering?: FilteringRules
+    globalFiltering?: FilteringRules,
+    options: MCPServerManagerOptions = {}
   ) {
     this.registry = registry;
     this.logger = logger;
     this.httpTransport = httpTransport;
     this.globalFiltering = globalFiltering;
+    this.cacheMaxEntries = options.cacheMaxEntries ?? DEFAULT_PROFILE_SERVER_CACHE_MAX_ENTRIES;
+    this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_PROFILE_SERVER_CACHE_TTL_MS;
+    this.now = options.now ?? (() => Date.now());
+    this.serverFactory = options.serverFactory;
   }
 
   getDefaultProfileId(): string | undefined {
@@ -38,18 +104,121 @@ export class MCPServerManager {
   }
 
   async getServer(profileId: string): Promise<MCPServer> {
+    this.pruneExpiredInactiveEntries();
+
     const existing = this.servers.get(profileId);
     if (existing) {
-      return existing;
+      this.touchEntry(existing);
+      return existing.serverPromise;
     }
 
-    const createPromise = this.createServer(profileId);
-    this.servers.set(profileId, createPromise);
-    return createPromise;
+    const entry = this.createCacheEntry(profileId);
+    this.servers.set(profileId, entry);
+    this.enforceCacheLimit();
+    return entry.serverPromise;
+  }
+
+  async handleHttpMessage(message: unknown, sessionId: string | undefined, profileId: string): Promise<unknown> {
+    const server = await this.getServer(profileId);
+    const response = await server.handleHttpMessage(message, sessionId, profileId);
+
+    if (sessionId) {
+      const entry = this.servers.get(profileId);
+      if (entry) {
+        entry.activeSessionIds.add(sessionId);
+        this.touchEntry(entry);
+      }
+    }
+
+    return response;
+  }
+
+  async handleSessionDestroyed(profileId: string, sessionId: string): Promise<void> {
+    const entry = this.servers.get(profileId);
+    if (!entry) {
+      return;
+    }
+
+    entry.activeSessionIds.delete(sessionId);
+    const server = await entry.serverPromise;
+    server.handleSessionDestroyed(profileId, sessionId);
+    this.pruneExpiredInactiveEntries();
+    this.enforceCacheLimit();
+  }
+
+  private createCacheEntry(profileId: string): ServerCacheEntry {
+    const entry: ServerCacheEntry = {
+      serverPromise: Promise.resolve(null as never),
+      lastAccessedAt: this.now(),
+      activeSessionIds: new Set<string>(),
+    };
+
+    entry.serverPromise = this.createServer(profileId).catch((error) => {
+      const current = this.servers.get(profileId);
+      if (current === entry) {
+        this.servers.delete(profileId);
+      }
+      throw error;
+    });
+
+    return entry;
+  }
+
+  private touchEntry(entry: ServerCacheEntry): void {
+    entry.lastAccessedAt = this.now();
+  }
+
+  private pruneExpiredInactiveEntries(): void {
+    if (this.cacheTtlMs === 0) {
+      return;
+    }
+
+    const now = this.now();
+    for (const [profileId, entry] of this.servers.entries()) {
+      if (entry.activeSessionIds.size > 0) {
+        continue;
+      }
+      if (now - entry.lastAccessedAt < this.cacheTtlMs) {
+        continue;
+      }
+      this.servers.delete(profileId);
+    }
+  }
+
+  private enforceCacheLimit(): void {
+    while (this.servers.size > this.cacheMaxEntries) {
+      const candidate = this.findOldestInactiveProfileId();
+      if (!candidate) {
+        break;
+      }
+      this.servers.delete(candidate);
+    }
+  }
+
+  private findOldestInactiveProfileId(): string | null {
+    let oldestProfileId: string | null = null;
+    let oldestAccessTime = Number.POSITIVE_INFINITY;
+
+    for (const [profileId, entry] of this.servers.entries()) {
+      if (entry.activeSessionIds.size > 0) {
+        continue;
+      }
+      if (entry.lastAccessedAt >= oldestAccessTime) {
+        continue;
+      }
+      oldestProfileId = profileId;
+      oldestAccessTime = entry.lastAccessedAt;
+    }
+
+    return oldestProfileId;
   }
 
   private async createServer(profileId: string): Promise<MCPServer> {
     const resolved = await this.registry.resolveProfile(profileId);
+    if (this.serverFactory) {
+      return this.serverFactory(profileId, resolved);
+    }
+
     const server = new MCPServer(this.logger);
     server.setGlobalFiltering(this.globalFiltering);
     await server.initialize(resolved.specPath, resolved.profilePath);


### PR DESCRIPTION
## Summary
- bound profile-routed `MCPServerManager` cache growth with inactive-entry TTL pruning and deterministic max-size eviction
- keep active-session profile servers resident while routing requests through manager-owned session tracking
- document the new cache env vars and remove the completed TODO item

## Root cause
HTTP profile routing cached each lazily initialized `MCPServer` forever in an unbounded map. The session-destroyed path also called `getServer(profileId)`, so cleanup could recreate an evicted or inactive profile server just to handle session teardown.

## Changes made
- replaced the bare `Map<string, Promise<MCPServer>>` cache with explicit cache metadata (`lastAccessedAt`, active session ids)
- added manager-owned `handleHttpMessage(...)` and `handleSessionDestroyed(...)` so session activity is tracked in one place and cleanup no longer recreates missing servers
- added safe cache configuration from env via `MCP4_PROFILE_SERVER_CACHE_MAX` and `MCP4_PROFILE_SERVER_CACHE_TTL_MS`
- evict only inactive profile servers using oldest-access-first eviction plus idle TTL pruning
- documented the new env vars in `README.md` and removed the completed TODO entry

## Test coverage added/updated
- added focused manager tests for max-size eviction, active-session preservation, TTL pruning, and cleanup without server recreation
- added config parsing tests for the new cache env vars and validation rules
- ran `npx vitest run src/mcp/mcp-server-manager.test.ts src/mcp/mcp-server-manager-config.test.ts`
- ran `npm run typecheck`

## Risk assessment
Low. The change is narrowly scoped to the in-memory profile-routed server cache, preserves lazy initialization behavior, avoids evicting active-session servers, and adds focused regression coverage around the new eviction and cleanup paths.

Closes #148
