### PR TITLE
fix: canonicalize query redaction across parser paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened MCP Apps resource loading so `file_path` stays inside the profile directory after normalization and symlink resolution, while keeping `resources/read` output shape consistent across inline, file-backed, and fetch-backed resources.
 - Fixed HTTP single-profile startup to carry `enterprise_authorization` into transport runtime so enterprise JWT bearer exchange and authenticated initialization work outside profile-routing mode, with dedicated E2E coverage.
 - Clarified and locked runtime enterprise authorization behavior so `required` mode enforces trusted enterprise-issued bearer tokens, `optional` mode stays backward-compatible, tool-category policy covers both listing and execution, and invalid env-backed values fail during profile loading.
+- Canonicalized query-parameter redaction across URL parser paths so percent-encoded sensitive keys are redacted consistently in absolute and fallback-relative URLs.
 
 ## [0.5.7] - 2026-03-03
 

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,6 @@
 - [P2: Nice-to-Have](#p2-nice-to-have)
   - [2. Export Profile Command](#2-export-profile-command)
   - [3. OpenAPI Operation Filter for Default Profile](#3-openapi-operation-filter-for-default-profile)
-  - [4. Harden query parameter redaction canonicalization](#4-harden-query-parameter-redaction-canonicalization)
   - [7. Strengthen ReDoS Protection in Regex Compiler](#7-strengthen-redos-protection-in-regex-compiler)
   - [8. Limit HTTP profile server cache growth](#8-limit-http-profile-server-cache-growth)
   - [9. Break MCPServer-HttpTransport circular dependency](#9-break-mcpserver-httptransport-circular-dependency)
@@ -98,24 +97,6 @@ export DEFAULT_PROFILE_EXCLUDE_TAGS="admin,deprecated"
 ```
 
 **Pros**: Include most, exclude specific dangerous operations
-
-### 4. Harden query parameter redaction canonicalization
-**Current**: `redactQueryParam()` supports exact key matching and now covers dot-separated parameter names, but standard URL parsing and fallback/manual parsing do not explicitly share one canonicalization strategy for encoded query keys or equivalent key spellings.
-
-**Goal**: Keep query-parameter redaction deterministic across parser paths and reduce the risk of log leakage when sensitive keys appear in percent-encoded or otherwise equivalent forms.
-
-**Implementation**:
-- Define one canonicalization strategy for query parameter keys before comparison.
-- Align `new URL()` handling and manual fallback handling so both paths redact the same keys.
-- Add explicit tests for percent-encoded query keys and parser-path consistency.
-- Keep the implementation bounded and regex-safe; do not introduce heuristic fuzzy matching.
-
-**Files to modify**:
-- `src/validation/validation-utils.ts`
-- `src/validation/validation-utils.test.ts`
-
-**Estimated effort**: 1-2 hours
-**Cons**: May miss new dangerous operations
 
 **Option C: Tag-based Filter (Leverages OpenAPI Tags)**
 ```bash

--- a/src/validation/validation-utils.test.ts
+++ b/src/validation/validation-utils.test.ts
@@ -113,6 +113,26 @@ describe('Validation Utils', () => {
       expect(redacted).toBe('/api?token=%5BREDACTED%5D&other=value');
     });
 
+    it('should redact percent-encoded query keys on absolute URLs', () => {
+      const url = 'https://example.com/api?api%2Ekey=secret&other=value';
+      const redacted = redactQueryParam(url, 'api.key');
+      expect(redacted).toContain('api.key=%5BREDACTED%5D');
+      expect(redacted).toContain('other=value');
+    });
+
+    it('should redact percent-encoded query keys on relative URLs', () => {
+      const url = '/api?api%2Ekey=secret&other=value';
+      expect(redactQueryParam(url, 'api.key')).toBe('/api?api%2Ekey=%5BREDACTED%5D&other=value');
+    });
+
+    it('should redact the same logical query key across absolute and relative URLs', () => {
+      const absoluteUrl = 'https://example.com/api?api%2Ekey=secret';
+      const relativeUrl = '/api?api%2Ekey=secret';
+
+      expect(redactQueryParam(absoluteUrl, 'api.key')).toBe('https://example.com/api?api.key=%5BREDACTED%5D');
+      expect(redactQueryParam(relativeUrl, 'api.key')).toBe('/api?api%2Ekey=%5BREDACTED%5D');
+    });
+
     it('should leave URL unchanged when no query string present', () => {
       const url = 'https://example.com/path';
       expect(redactQueryParam(url, 'token')).toBe(url);

--- a/src/validation/validation-utils.ts
+++ b/src/validation/validation-utils.ts
@@ -71,6 +71,17 @@ export function redactHeader(
 }
 
 /**
+ * Normalize a query parameter key for deterministic comparison across parser paths.
+ */
+function normalizeQueryParamKey(key: string): string {
+  try {
+    return decodeURIComponent(key);
+  } catch {
+    return key;
+  }
+}
+
+/**
  * Redact query parameter from URL string
  */
 export function redactQueryParam(
@@ -82,11 +93,16 @@ export function redactQueryParam(
   if (!/^[A-Za-z0-9_.-]{1,64}$/.test(paramName)) {
     return url; // Unsafe param name; return original unmodified
   }
+
+  const normalizedParamName = normalizeQueryParamKey(paramName);
   
   try {
     const urlObj = new URL(url);
-    if (urlObj.searchParams.has(paramName)) {
-      urlObj.searchParams.set(paramName, '[REDACTED]');
+    const matchingKey = Array.from(urlObj.searchParams.keys()).find(
+      key => normalizeQueryParamKey(key) === normalizedParamName
+    );
+    if (matchingKey) {
+      urlObj.searchParams.set(matchingKey, '[REDACTED]');
     }
     return urlObj.toString();
   } catch {
@@ -101,7 +117,7 @@ export function redactQueryParam(
       const eqIndex = part.indexOf('=');
       if (eqIndex === -1) return part; // skip malformed segment
       const key = part.substring(0, eqIndex);
-      if (key === paramName) {
+      if (normalizeQueryParamKey(key) === normalizedParamName) {
         // Encode [REDACTED] for consistency with URLSearchParams behavior
         return key + '=%5BREDACTED%5D';
       }


### PR DESCRIPTION
## Summary
- harden `redactQueryParam()` so encoded query keys are compared consistently across URL parser paths
- add regression coverage for percent-encoded keys on absolute and relative URLs
- remove the completed TODO item and document the fix in the changelog

## Root cause
`redactQueryParam()` relied on two different key-comparison behaviors. The `URLSearchParams` path effectively compared decoded keys, but the manual fallback compared raw key bytes, so relative URLs with percent-encoded sensitive keys could bypass redaction.

## Changes made
- added a small `normalizeQueryParamKey()` helper that safely decodes query keys for deterministic comparison
- reused the same normalization rule in both the `URLSearchParams` branch and the manual fallback branch
- added regression tests for encoded dotted keys and parser-path parity
- updated `TODO.md` and `CHANGELOG.md`

## Test coverage added/updated
- added absolute-URL regression coverage for `api%2Ekey`
- added fallback-relative regression coverage for `api%2Ekey`
- added a parity test proving both parser paths redact the same logical key
- ran `npm test -- src/validation/validation-utils.test.ts`
- ran `npm run typecheck`

## Risk assessment
Low risk. The change is narrowly scoped to query-key normalization inside `redactQueryParam()` and preserves existing safe-name validation and redaction behavior for already-supported inputs.

Closes #150
