### PR TITLE
refactor(test): add typed http transport harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added env-backed `enterprise_authorization` field resolution for issuer, audience, mode, selected access-policy settings, and claim mappings so deployments can override enterprise auth without editing profiles.
 
 ### Changed
+- Added a typed `HttpTransport` test harness for app/session/profile-state helpers and migrated transport suites away from repeated private reach-ins, making incremental refactors safer without changing runtime behavior.
 - Bumped transitive security-sensitive dependencies via overrides (`@hono/node-server` to `1.19.10`, `hono` to `4.12.4`) and aligned Semgrep SBOM negative test inputs/expectations with current `deploymentSlug`/`deployment_id` validation behavior.
 - Updated `express-rate-limit` to `^8.3.1` to remediate the open GitHub Security / Dependabot alert for IPv4-mapped IPv6 rate-limit keying.
 

--- a/src/transport/http-transport.test-harness.test.ts
+++ b/src/transport/http-transport.test-harness.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { HttpTransport } from './http-transport.js';
+import { ConsoleLogger } from '../core/logger.js';
+import { createHttpTransportTestHarness } from './http-transport.test-harness.js';
+
+describe('createHttpTransportTestHarness', () => {
+  const logger = new ConsoleLogger();
+  const transports: HttpTransport[] = [];
+
+  afterEach(async () => {
+    await Promise.all(transports.map(async (transport) => transport.stop()));
+    transports.length = 0;
+  });
+
+  const createTransport = (): HttpTransport => {
+    const transport = new HttpTransport(
+      {
+        host: '127.0.0.1',
+        port: 0,
+        sessionTimeoutMs: 1800000,
+        heartbeatEnabled: false,
+        heartbeatIntervalMs: 30000,
+        metricsEnabled: false,
+        metricsPath: '/metrics',
+      },
+      logger,
+    );
+    transports.push(transport);
+    return transport;
+  };
+
+  it('creates seeded profile state and manages sessions through typed helpers', () => {
+    const harness = createHttpTransportTestHarness(createTransport());
+    const profileState = harness.createProfileState();
+
+    const sessionId = harness.createSession(profileState, {
+      authToken: 'access-token',
+      filtering: { project_id: ['1'] },
+      filteringHeader: 'project_id=1',
+    });
+
+    expect(harness.app).toBeDefined();
+    expect(harness.getProfileState('default')).toBe(profileState);
+    expect(profileState.sessions.get(sessionId)?.authToken).toBe('access-token');
+
+    harness.destroySession(profileState, sessionId);
+    expect(profileState.sessions.has(sessionId)).toBe(false);
+  });
+
+  it('reads header helpers through a typed request shim', () => {
+    const harness = createHttpTransportTestHarness(createTransport());
+
+    expect(harness.getFilteringHeaderValue({ headers: { 'x-mcp4-params': 'project_id=1' } })).toBe('project_id=1');
+    expect(harness.getTenantIdHeaderValue({ headers: { 'x-mcp4-tenant-id': ' team-a ' } })).toBe('team-a');
+    expect(harness.getToolFilterHeaderValue({ headers: { 'x-mcp4-tools': 'get_user' } })).toBe('get_user');
+  });
+});

--- a/src/transport/http-transport.test-harness.ts
+++ b/src/transport/http-transport.test-harness.ts
@@ -1,0 +1,388 @@
+import type { Express, Request, Response } from 'express';
+import type { HttpTransport } from './http-transport.js';
+import type { HttpProfileContext, SessionData, SessionToolFilterRequest } from '../types/http-transport.js';
+import type { HttpTenantIndex, ResolvedTenantContext } from '../types/http-tenants.js';
+import type { ToolFilterService } from '../tool-filter/index.js';
+import type { OAuthConfig } from '../types/profile.js';
+import type { OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js';
+
+interface StoredOAuthTokenState {
+  refreshToken?: string;
+  expiresAt?: number;
+  clientId: string;
+  scopes: string[];
+}
+
+export interface HttpTransportTestProfileState {
+  profileId: string;
+  context: HttpProfileContext;
+  oauthProvider: unknown | null;
+  enterpriseAuthProvider: unknown | null;
+  toolFilterService?: ToolFilterService;
+  oauthTokensByAccessToken: Map<string, StoredOAuthTokenState>;
+  sessions: Map<string, SessionData>;
+  tenantIndex: HttpTenantIndex;
+  tenantOAuthProvidersBySessionId: Map<string, unknown>;
+}
+
+export interface HttpTransportSessionOptions {
+  authToken?: string;
+  refreshToken?: string;
+  accessTokenExpiresAt?: number;
+  scopes?: string[];
+  oauthClientId?: string;
+  filtering?: Record<string, string[]>;
+  filteringHeader?: string;
+  toolFilterRequest?: SessionToolFilterRequest;
+  toolFilterHeader?: string;
+  tenantContext?: ResolvedTenantContext | null;
+  tenantHeaderValue?: string;
+}
+
+export interface HeaderRequestLike {
+  headers: Request['headers'];
+  get?(name: string): string | undefined;
+  path?: string;
+  originalUrl?: string;
+  profileId?: string;
+}
+
+interface HttpTransportInternals {
+  app: Express;
+  profileStates: Map<string, HttpTransportTestProfileState>;
+  oauthRedirectHostCache: Map<string, string[]>;
+  getProfileState(profileId: string): Promise<HttpTransportTestProfileState | null>;
+  getMessageType(body: unknown): 'request' | 'notification-only' | 'response-only' | 'mixed' | 'unknown';
+  getFilteringHeaderValue(req: Request): string | undefined;
+  getToolFilterHeaderValue(req: Request): string | undefined;
+  getTenantIdHeaderValue(req: Request): string | undefined;
+  getTenantBaseUrlHeaderValue(req: Request): string | undefined;
+  getToolFilterService(profileState: HttpTransportTestProfileState): ToolFilterService;
+  createSession(
+    profileState: HttpTransportTestProfileState,
+    authToken?: string,
+    refreshToken?: string,
+    accessTokenExpiresAt?: number,
+    scopes?: string[],
+    oauthClientId?: string,
+    filtering?: Record<string, string[]>,
+    filteringHeader?: string,
+    toolFilterRequest?: SessionToolFilterRequest,
+    toolFilterHeader?: string,
+    tenantContext?: ResolvedTenantContext | null,
+    tenantHeaderValue?: string,
+  ): string;
+  destroySession(profileState: HttpTransportTestProfileState, sessionId: string): void;
+  cleanupExpiredSessions(): void;
+  refreshAccessToken(profileId: string, sessionId: string): Promise<boolean>;
+  getOAuthProviderForSession(profileState: HttpTransportTestProfileState, session: SessionData): unknown | null;
+  storeOAuthTokens(
+    profileState: HttpTransportTestProfileState,
+    tokens: OAuthTokens,
+    clientId: string,
+    scopes: string[],
+  ): void;
+  startSSEStream(
+    response: Response,
+    sessionId: string,
+    lastEventId: string | undefined,
+    profileState: HttpTransportTestProfileState,
+  ): void;
+  isAllowedOrigin(origin: string): boolean;
+  getOAuthRedirectHostPatterns(): string[];
+  extractRedirectHostPatterns(oauthConfig: OAuthConfig | undefined, profileId: string): string[];
+  resolveRedirectUriFromEnv(value: string, profileId: string): string | undefined;
+  resolveProfileIdFromPath(pathname: string): string | null;
+  resolveProfileIdForOriginCheck(req: Request): string | null;
+  primeOAuthRedirectHosts(profileId: string): Promise<void>;
+  isAllowedOriginForRequest(origin: string, req: Request): Promise<boolean>;
+  matchOrigin(hostname: string, pattern: string): boolean;
+  ipv4ToInt(ip: string): number | null;
+  ipv6ToBigInt(ip: string): bigint | null;
+  ipv6Mask(maskBits: number): bigint;
+}
+
+const toInternals = (transport: HttpTransport): HttpTransportInternals => transport as unknown as HttpTransportInternals;
+
+const createEmptyTenantIndex = (): HttpTenantIndex => ({
+  enabled: false,
+  byTenantId: new Map(),
+  byBaseUrl: new Map(),
+  maskSelectors: [],
+  selectorTypeByTenantId: new Map(),
+});
+
+const toRequest = (request: HeaderRequestLike): Request => request as Request;
+
+const normalizeCreateSessionArguments = (
+  optionsOrAuthToken?: HttpTransportSessionOptions | string,
+  refreshToken?: string,
+  accessTokenExpiresAt?: number,
+  scopes?: string[],
+  oauthClientId?: string,
+  filtering?: Record<string, string[]>,
+  filteringHeader?: string,
+  toolFilterRequest?: SessionToolFilterRequest,
+  toolFilterHeader?: string,
+  tenantContext?: ResolvedTenantContext | null,
+  tenantHeaderValue?: string,
+): HttpTransportSessionOptions => {
+  if (typeof optionsOrAuthToken === 'object' && optionsOrAuthToken !== null && !Array.isArray(optionsOrAuthToken)) {
+    return optionsOrAuthToken;
+  }
+
+  return {
+    authToken: typeof optionsOrAuthToken === 'string' ? optionsOrAuthToken : undefined,
+    refreshToken,
+    accessTokenExpiresAt,
+    scopes,
+    oauthClientId,
+    filtering,
+    filteringHeader,
+    toolFilterRequest,
+    toolFilterHeader,
+    tenantContext,
+    tenantHeaderValue,
+  };
+};
+
+export interface HttpTransportTestHarness {
+  readonly app: Express;
+  createProfileState(profileId?: string, overrides?: Partial<HttpTransportTestProfileState>): HttpTransportTestProfileState;
+  setProfileState(profileState: HttpTransportTestProfileState): void;
+  getProfileState(profileId: string): HttpTransportTestProfileState | undefined;
+  loadProfileState(profileId: string): Promise<HttpTransportTestProfileState | null>;
+  setOAuthRedirectHosts(profileId: string, hosts: string[]): void;
+  getOAuthRedirectHosts(profileId: string): string[] | undefined;
+  getMessageType(body: unknown): 'request' | 'notification-only' | 'response-only' | 'mixed' | 'unknown';
+  getFilteringHeaderValue(request: HeaderRequestLike): string | undefined;
+  getToolFilterHeaderValue(request: HeaderRequestLike): string | undefined;
+  getTenantIdHeaderValue(request: HeaderRequestLike): string | undefined;
+  getTenantBaseUrlHeaderValue(request: HeaderRequestLike): string | undefined;
+  getToolFilterService(profileState: HttpTransportTestProfileState): ToolFilterService;
+  createSession(profileState: HttpTransportTestProfileState, options?: HttpTransportSessionOptions): string;
+  createSession(
+    profileState: HttpTransportTestProfileState,
+    authToken?: string,
+    refreshToken?: string,
+    accessTokenExpiresAt?: number,
+    scopes?: string[],
+    oauthClientId?: string,
+    filtering?: Record<string, string[]>,
+    filteringHeader?: string,
+    toolFilterRequest?: SessionToolFilterRequest,
+    toolFilterHeader?: string,
+    tenantContext?: ResolvedTenantContext | null,
+    tenantHeaderValue?: string,
+  ): string;
+  destroySession(profileState: HttpTransportTestProfileState, sessionId: string): void;
+  cleanupExpiredSessions(): void;
+  refreshAccessToken(profileId: string, sessionId: string): Promise<boolean>;
+  getOAuthProviderForSession(profileState: HttpTransportTestProfileState, session: SessionData): unknown | null;
+  storeOAuthTokens(profileState: HttpTransportTestProfileState, tokens: OAuthTokens, clientId: string, scopes: string[]): void;
+  setStartSseStream(
+    implementation: (response: Response, sessionId: string, lastEventId: string | undefined, profileState: HttpTransportTestProfileState) => void,
+  ): void;
+  isAllowedOrigin(origin: string): boolean;
+  getOAuthRedirectHostPatterns(): string[];
+  extractRedirectHostPatterns(oauthConfig: OAuthConfig | undefined, profileId: string): string[];
+  resolveRedirectUriFromEnv(value: string, profileId: string): string | undefined;
+  resolveProfileIdFromPath(pathname: string): string | null;
+  resolveProfileIdForOriginCheck(request: HeaderRequestLike): string | null;
+  primeOAuthRedirectHosts(profileId: string): Promise<void>;
+  isAllowedOriginForRequest(origin: string, request: HeaderRequestLike): Promise<boolean>;
+  setIsAllowedOriginForRequest(implementation: (origin: string, request: Request) => Promise<boolean>): void;
+  matchOrigin(hostname: string, pattern: string): boolean;
+  ipv4ToInt(ip: string): number | null;
+  ipv6ToBigInt(ip: string): bigint | null;
+  ipv6Mask(maskBits: number): bigint;
+}
+
+export const createHttpTransportTestHarness = (transport: HttpTransport): HttpTransportTestHarness => {
+  const internals = toInternals(transport);
+
+  return {
+    get app() {
+      return internals.app;
+    },
+
+    createProfileState(profileId = 'default', overrides = {}) {
+      const profileState: HttpTransportTestProfileState = {
+        profileId,
+        context: { profileId },
+        oauthProvider: null,
+        enterpriseAuthProvider: null,
+        oauthTokensByAccessToken: new Map(),
+        sessions: new Map(),
+        tenantIndex: createEmptyTenantIndex(),
+        tenantOAuthProvidersBySessionId: new Map(),
+        ...overrides,
+      };
+      internals.profileStates.set(profileId, profileState);
+      return profileState;
+    },
+
+    setProfileState(profileState) {
+      internals.profileStates.set(profileState.profileId, profileState);
+    },
+
+    getProfileState(profileId) {
+      return internals.profileStates.get(profileId);
+    },
+
+    loadProfileState(profileId) {
+      return internals.getProfileState(profileId);
+    },
+
+    setOAuthRedirectHosts(profileId, hosts) {
+      internals.oauthRedirectHostCache.set(profileId, hosts);
+    },
+
+    getOAuthRedirectHosts(profileId) {
+      return internals.oauthRedirectHostCache.get(profileId);
+    },
+
+    getMessageType(body) {
+      return internals.getMessageType(body);
+    },
+
+    getFilteringHeaderValue(request) {
+      return internals.getFilteringHeaderValue(toRequest(request));
+    },
+
+    getToolFilterHeaderValue(request) {
+      return internals.getToolFilterHeaderValue(toRequest(request));
+    },
+
+    getTenantIdHeaderValue(request) {
+      return internals.getTenantIdHeaderValue(toRequest(request));
+    },
+
+    getTenantBaseUrlHeaderValue(request) {
+      return internals.getTenantBaseUrlHeaderValue(toRequest(request));
+    },
+
+    getToolFilterService(profileState) {
+      return internals.getToolFilterService(profileState);
+    },
+
+    createSession(
+      profileState: HttpTransportTestProfileState,
+      optionsOrAuthToken?: HttpTransportSessionOptions | string,
+      refreshToken?: string,
+      accessTokenExpiresAt?: number,
+      scopes?: string[],
+      oauthClientId?: string,
+      filtering?: Record<string, string[]>,
+      filteringHeader?: string,
+      toolFilterRequest?: SessionToolFilterRequest,
+      toolFilterHeader?: string,
+      tenantContext?: ResolvedTenantContext | null,
+      tenantHeaderValue?: string,
+    ) {
+      const options = normalizeCreateSessionArguments(
+        optionsOrAuthToken,
+        refreshToken,
+        accessTokenExpiresAt,
+        scopes,
+        oauthClientId,
+        filtering,
+        filteringHeader,
+        toolFilterRequest,
+        toolFilterHeader,
+        tenantContext,
+        tenantHeaderValue,
+      );
+      return internals.createSession(
+        profileState,
+        options.authToken,
+        options.refreshToken,
+        options.accessTokenExpiresAt,
+        options.scopes,
+        options.oauthClientId,
+        options.filtering,
+        options.filteringHeader,
+        options.toolFilterRequest,
+        options.toolFilterHeader,
+        options.tenantContext,
+        options.tenantHeaderValue,
+      );
+    },
+
+    destroySession(profileState, sessionId) {
+      internals.destroySession(profileState, sessionId);
+    },
+
+    cleanupExpiredSessions() {
+      internals.cleanupExpiredSessions();
+    },
+
+    refreshAccessToken(profileId, sessionId) {
+      return internals.refreshAccessToken(profileId, sessionId);
+    },
+
+    getOAuthProviderForSession(profileState, session) {
+      return internals.getOAuthProviderForSession(profileState, session);
+    },
+
+    storeOAuthTokens(profileState, tokens, clientId, scopes) {
+      internals.storeOAuthTokens(profileState, tokens, clientId, scopes);
+    },
+
+    setStartSseStream(implementation) {
+      internals.startSSEStream = implementation;
+    },
+
+    isAllowedOrigin(origin) {
+      return internals.isAllowedOrigin(origin);
+    },
+
+    getOAuthRedirectHostPatterns() {
+      return internals.getOAuthRedirectHostPatterns();
+    },
+
+    extractRedirectHostPatterns(oauthConfig, profileId) {
+      return internals.extractRedirectHostPatterns(oauthConfig, profileId);
+    },
+
+    resolveRedirectUriFromEnv(value, profileId) {
+      return internals.resolveRedirectUriFromEnv(value, profileId);
+    },
+
+    resolveProfileIdFromPath(pathname) {
+      return internals.resolveProfileIdFromPath(pathname);
+    },
+
+    resolveProfileIdForOriginCheck(request) {
+      return internals.resolveProfileIdForOriginCheck(toRequest(request));
+    },
+
+    primeOAuthRedirectHosts(profileId) {
+      return internals.primeOAuthRedirectHosts(profileId);
+    },
+
+    isAllowedOriginForRequest(origin, request) {
+      return internals.isAllowedOriginForRequest(origin, toRequest(request));
+    },
+
+    setIsAllowedOriginForRequest(implementation) {
+      internals.isAllowedOriginForRequest = implementation;
+    },
+
+    matchOrigin(hostname, pattern) {
+      return internals.matchOrigin(hostname, pattern);
+    },
+
+    ipv4ToInt(ip) {
+      return internals.ipv4ToInt(ip);
+    },
+
+    ipv6ToBigInt(ip) {
+      return internals.ipv6ToBigInt(ip);
+    },
+
+    ipv6Mask(maskBits) {
+      return internals.ipv6Mask(maskBits);
+    },
+  };
+};

--- a/src/transport/http-transport.test.ts
+++ b/src/transport/http-transport.test.ts
@@ -10,25 +10,19 @@ import type { Express } from 'express';
 import fs from 'fs';
 import https from 'https';
 import { HttpTransport } from './http-transport.js';
+import { createHttpTransportTestHarness, type HttpTransportTestHarness } from './http-transport.test-harness.js';
 import { ConsoleLogger, type Logger } from '../core/logger.js';
 import { describeIfListen } from '../testing/listen-support.js';
 import { parseSessionToolFilterHeader } from '../tool-filter/index.js';
 
 describeIfListen('HttpTransport', () => {
   let transport: HttpTransport;
+  let harness: HttpTransportTestHarness;
   let app: Express;
   const logger = new ConsoleLogger();
-  const createProfileState = (target: any, profileId: string = 'default') => {
-    const state = {
-      profileId,
-      context: { profileId },
-      oauthProvider: null,
-      oauthTokensByAccessToken: new Map(),
-      sessions: new Map(),
-    };
-    target.profileStates.set(profileId, state);
-    return state;
-  };
+  const getHarness = (target: HttpTransport): HttpTransportTestHarness => createHttpTransportTestHarness(target);
+  const createProfileState = (target: HttpTransport, profileId: string = 'default') =>
+    getHarness(target).createProfileState(profileId);
 
   beforeEach(async () => {
     const config = {
@@ -42,8 +36,8 @@ describeIfListen('HttpTransport', () => {
     };
 
     transport = new HttpTransport(config, logger);
-    // Access private app property for testing
-    app = (transport as any).app;
+    harness = getHarness(transport);
+    app = harness.app;
   });
 
   afterEach(async () => {
@@ -55,8 +49,8 @@ describeIfListen('HttpTransport', () => {
   describe('filtering header mismatch', () => {
     it('rejects mismatched filtering header on existing session', async () => {
       transport.setMessageHandler(async () => ({ result: 'ok' }));
-      const sessionId = (transport as any).createSession(
-        createProfileState(transport as any),
+      const sessionId = harness.createSession(
+        createProfileState(transport),
         undefined,
         undefined,
         undefined,
@@ -81,8 +75,8 @@ describeIfListen('HttpTransport', () => {
     it('rejects mismatched tool filter header on existing session', async () => {
       transport.setMessageHandler(async () => ({ result: 'ok' }));
       const toolFilterRequest = parseSessionToolFilterHeader('get_user');
-      const sessionId = (transport as any).createSession(
-        createProfileState(transport as any),
+      const sessionId = harness.createSession(
+        createProfileState(transport),
         undefined,
         undefined,
         undefined,
@@ -153,7 +147,7 @@ describeIfListen('HttpTransport', () => {
         logger,
       );
       tenantTransport.setMessageHandler(async () => ({ result: { ok: true } }));
-      const tenantApp = (tenantTransport as any).app;
+      const tenantApp = getHarness(tenantTransport).app;
 
       const initResponse = await request(tenantApp)
         .post('/mcp')
@@ -190,7 +184,7 @@ describeIfListen('HttpTransport', () => {
         logger,
       );
       tenantTransport.setMessageHandler(async () => ({ result: { ok: true } }));
-      const tenantApp = (tenantTransport as any).app;
+      const tenantApp = getHarness(tenantTransport).app;
 
       const response = await request(tenantApp)
         .post('/mcp')
@@ -222,7 +216,7 @@ describeIfListen('HttpTransport', () => {
         logger,
       );
       tenantTransport.setMessageHandler(async () => ({ result: { ok: true } }));
-      const tenantApp = (tenantTransport as any).app;
+      const tenantApp = getHarness(tenantTransport).app;
 
       const initResponse = await request(tenantApp)
         .post('/mcp')
@@ -261,7 +255,7 @@ describeIfListen('HttpTransport', () => {
         logger,
       );
       tenantTransport.setMessageHandler(async () => ({ result: { ok: true } }));
-      const tenantApp = (tenantTransport as any).app;
+      const tenantApp = getHarness(tenantTransport).app;
 
       const initResponse = await request(tenantApp)
         .post('/mcp')
@@ -315,7 +309,7 @@ describeIfListen('HttpTransport', () => {
         logger,
       );
       tenantTransport.setMessageHandler(async () => ({ result: { ok: true } }));
-      const tenantApp = (tenantTransport as any).app;
+      const tenantApp = getHarness(tenantTransport).app;
 
       const initResponse = await request(tenantApp)
         .post('/mcp')
@@ -364,7 +358,7 @@ describeIfListen('HttpTransport', () => {
         logger,
       );
       tenantTransport.setMessageHandler(async () => ({ result: { ok: true } }));
-      const tenantApp = (tenantTransport as any).app;
+      const tenantApp = getHarness(tenantTransport).app;
 
       const initResponse = await request(tenantApp)
         .post('/mcp')
@@ -409,7 +403,7 @@ describeIfListen('HttpTransport', () => {
         logger,
       );
       tenantTransport.setMessageHandler(async () => ({ result: { ok: true } }));
-      const tenantApp = (tenantTransport as any).app;
+      const tenantApp = getHarness(tenantTransport).app;
 
       const initResponse = await request(tenantApp)
         .post('/mcp')
@@ -498,7 +492,7 @@ describeIfListen('HttpTransport', () => {
         logger,
       );
       tenantTransport.setMessageHandler(async () => ({ result: { ok: true } }));
-      const tenantApp = (tenantTransport as any).app;
+      const tenantApp = getHarness(tenantTransport).app;
 
       const initResponse = await request(tenantApp)
         .post('/mcp')
@@ -570,7 +564,7 @@ describeIfListen('HttpTransport', () => {
         logger,
       );
       tenantTransport.setMessageHandler(async () => ({ result: { ok: true } }));
-      const tenantApp = (tenantTransport as any).app;
+      const tenantApp = getHarness(tenantTransport).app;
 
       const response = await request(tenantApp)
         .post('/mcp')
@@ -615,7 +609,7 @@ describeIfListen('HttpTransport', () => {
         logger,
       );
       tenantTransport.setMessageHandler(async () => ({ result: { ok: true } }));
-      const tenantApp = (tenantTransport as any).app;
+      const tenantApp = getHarness(tenantTransport).app;
 
       const response = await request(tenantApp)
         .post('/mcp')
@@ -662,7 +656,7 @@ describeIfListen('HttpTransport', () => {
         logger,
       );
       tenantTransport.setMessageHandler(async () => ({ result: { ok: true } }));
-      const tenantApp = (tenantTransport as any).app;
+      const tenantApp = getHarness(tenantTransport).app;
 
       const response = await request(tenantApp)
         .post('/mcp')
@@ -711,7 +705,7 @@ describeIfListen('HttpTransport', () => {
         recordHttpRequest: vi.fn(),
       };
 
-      localApp = (localTransport as any).app;
+      localApp = getHarness(localTransport).app;
       localTransport.setMessageHandler(async () => ({ result: 'ok' }));
     });
 
@@ -851,7 +845,7 @@ describeIfListen('HttpTransport', () => {
 
     beforeEach(async () => {
       indexTransport = createIndexTransport();
-      indexApp = (indexTransport as any).app;
+      indexApp = getHarness(indexTransport).app;
     });
 
     afterEach(async () => {
@@ -974,7 +968,7 @@ describeIfListen('HttpTransport', () => {
       });
       await indexTransport.stop();
       indexTransport = createIndexTransport();
-      indexApp = (indexTransport as any).app;
+      indexApp = getHarness(indexTransport).app;
 
       indexTransport.setProfileContextProvider(async (profileId: string) => ({
         profileId,
@@ -1037,7 +1031,7 @@ describeIfListen('HttpTransport', () => {
       });
       await indexTransport.stop();
       indexTransport = createIndexTransport();
-      indexApp = (indexTransport as any).app;
+      indexApp = getHarness(indexTransport).app;
 
       indexTransport.setProfileContextProvider(async (profileId: string) => ({
         profileId,
@@ -1153,7 +1147,7 @@ describeIfListen('HttpTransport', () => {
       };
 
       customTransport = new HttpTransport(config, logger);
-      customApp = (customTransport as any).app;
+      customApp = getHarness(customTransport).app;
       customTransport.setMessageHandler(async (_msg) => ({ result: 'ok' }));
     });
 
@@ -1646,9 +1640,9 @@ describeIfListen('HttpTransport', () => {
 
       const sessionId = initResponse.headers['mcp-session-id'];
 
-      (transport as any).startSSEStream = () => {
+      harness.setStartSseStream(() => {
         throw new Error('SSE failure');
-      };
+      });
 
       const response = await request(app)
         .get('/mcp')
@@ -1936,7 +1930,7 @@ describeIfListen('HttpTransport', () => {
       });
 
       const sessionId = initResponse.headers['mcp-session-id'];
-      const profileState = (transport as any).profileStates.get('default');
+      const profileState = harness.getProfileState('default');
       const session = profileState.sessions.get(sessionId);
 
       expect(session).toBeDefined();
@@ -1963,7 +1957,7 @@ describeIfListen('HttpTransport', () => {
       });
 
       const sessionId = initResponse.headers['mcp-session-id'];
-      const profileState = (transport as any).profileStates.get('default');
+      const profileState = harness.getProfileState('default');
       const initialActivity = profileState.sessions.get(sessionId).lastActivityAt;
 
       // Wait a bit
@@ -2001,7 +1995,7 @@ describeIfListen('HttpTransport', () => {
       };
 
       metricsTransport = new HttpTransport(config, logger);
-      metricsApp = (metricsTransport as any).app;
+      metricsApp = getHarness(metricsTransport).app;
       metricsTransport.setMessageHandler(async (_msg) => ({ result: 'ok' }));
     });
 
@@ -2042,7 +2036,7 @@ describeIfListen('HttpTransport', () => {
         },
         logger
       );
-      const noMetricsApp = (noMetricsTransport as any).app;
+      const noMetricsApp = getHarness(noMetricsTransport).app;
 
       // Metrics endpoint should not be registered when disabled
       const response = await request(noMetricsApp)
@@ -2095,7 +2089,7 @@ describeIfListen('HttpTransport', () => {
       };
 
       const disabledTransport = new HttpTransport(disabledConfig, logger);
-      const disabledApp = (disabledTransport as any).app;
+      const disabledApp = getHarness(disabledTransport).app;
 
       const response = await request(disabledApp)
         .get('/metrics')
@@ -2151,7 +2145,7 @@ describeIfListen('HttpTransport', () => {
       };
 
       const customTransport = new HttpTransport(customConfig, logger);
-      const customApp = (customTransport as any).app;
+      const customApp = getHarness(customTransport).app;
 
       // Custom path should work
       const response1 = await request(customApp).get('/custom-metrics');
@@ -2187,7 +2181,7 @@ describeIfListen('HttpTransport', () => {
       };
 
       oauthTransport = new HttpTransport(oauthConfig, logger);
-      oauthApp = (oauthTransport as any).app;
+      oauthApp = getHarness(oauthTransport).app;
     });
 
     afterEach(async () => {
@@ -2263,8 +2257,8 @@ describeIfListen('HttpTransport', () => {
         logger
       );
       // Force oauthProvider to null after setup to test the else branch
-      createProfileState(oauthTransport as any).oauthProvider = null;
-      const oauthApp = (oauthTransport as any).app;
+      createProfileState(oauthTransport).oauthProvider = null;
+      const oauthApp = getHarness(oauthTransport).app;
 
       const response = await request(oauthApp)
         .post('/oauth/token')
@@ -2304,7 +2298,7 @@ describeIfListen('HttpTransport', () => {
       };
 
       oauthTransport = new HttpTransport(oauthConfig, logger);
-      oauthApp = (oauthTransport as any).app;
+      oauthApp = getHarness(oauthTransport).app;
     });
 
     afterEach(async () => {
@@ -2329,7 +2323,7 @@ describeIfListen('HttpTransport', () => {
 
     it('should handle exception during OAuth callback', async () => {
       // Mock the oauthProvider to throw an error during handleCallback
-      createProfileState(oauthTransport as any).oauthProvider = {
+      createProfileState(oauthTransport).oauthProvider = {
         handleCallback: async () => {
           throw new Error('Token exchange failed');
         }
@@ -2366,7 +2360,7 @@ describeIfListen('HttpTransport', () => {
       };
 
       oauthTransport = new HttpTransport(oauthConfig, logger);
-      oauthApp = (oauthTransport as any).app;
+      oauthApp = getHarness(oauthTransport).app;
     });
 
     afterEach(async () => {
@@ -2423,7 +2417,7 @@ describeIfListen('HttpTransport', () => {
       };
 
       oauthTransport = new HttpTransport(oauthConfig, logger);
-      oauthApp = (oauthTransport as any).app;
+      oauthApp = getHarness(oauthTransport).app;
     });
 
     afterEach(async () => {
@@ -2482,7 +2476,7 @@ describeIfListen('HttpTransport', () => {
       };
 
       oauthTransport = new HttpTransport(minimalOauthConfig as any, logger);
-      oauthApp = (oauthTransport as any).app;
+      oauthApp = getHarness(oauthTransport).app;
 
       const response = await request(oauthApp)
         .get('/.well-known/oauth-protected-resource/mcp');
@@ -2511,7 +2505,7 @@ describeIfListen('HttpTransport', () => {
       };
 
       const noOAuthTransport = new HttpTransport(noOAuthConfig, logger);
-      const noOAuthApp = (noOAuthTransport as any).app;
+      const noOAuthApp = getHarness(noOAuthTransport).app;
 
       // OAuth endpoints should not exist
       const authorizeResponse = await request(noOAuthApp).get('/oauth/authorize');
@@ -2538,7 +2532,7 @@ describeIfListen('HttpTransport', () => {
       };
 
       const tokenTransport = new HttpTransport(configWithMaxLength, logger);
-      const tokenApp = (tokenTransport as any).app;
+      const tokenApp = getHarness(tokenTransport).app;
       tokenTransport.setMessageHandler(async (_msg) => ({ result: 'ok' }));
 
       // Token within limit
@@ -2578,7 +2572,7 @@ describeIfListen('HttpTransport', () => {
         } as any,
         logger
       );
-      const tokenApp = (tokenTransport as any).app;
+      const tokenApp = getHarness(tokenTransport).app;
       tokenTransport.setMessageHandler(async () => ({ result: 'ok' }));
 
       const originalFetch = global.fetch;
@@ -2624,7 +2618,7 @@ describeIfListen('HttpTransport', () => {
         } as any,
         logger
       );
-      const tokenApp = (tokenTransport as any).app;
+      const tokenApp = getHarness(tokenTransport).app;
       tokenTransport.setMessageHandler(async () => ({ result: 'ok' }));
 
       const originalFetch = global.fetch;
@@ -2776,7 +2770,7 @@ describeIfListen('HttpTransport', () => {
       );
 
       // Mock invalid redirect URI
-      createProfileState(oauthTransport as any).oauthProvider = {
+      createProfileState(oauthTransport).oauthProvider = {
         redirectUri: 'not-a-valid-url'
       };
 
@@ -2918,7 +2912,7 @@ describeIfListen('HttpTransport', () => {
       };
 
       const oauthTransport = new HttpTransport(oauthConfig, logger);
-      await (oauthTransport as any).getProfileState('default');
+      await getHarness(oauthTransport).loadProfileState('default');
       expect(oauthTransport.hasOAuthProvider()).toBe(true);
       oauthTransport.stop();
     });
@@ -2947,7 +2941,7 @@ describeIfListen('HttpTransport', () => {
       };
 
       const oauthTransport = new HttpTransport(oauthConfig, logger);
-      await (oauthTransport as any).getProfileState('default');
+      await getHarness(oauthTransport).loadProfileState('default');
       expect(oauthTransport.getOAuthAuthorizationUrl()).toBe('https://example.com/oauth/authorize');
       oauthTransport.stop();
     });
@@ -2977,7 +2971,7 @@ describeIfListen('HttpTransport', () => {
       };
 
       const oauthTransport = new HttpTransport(oauthConfig, logger);
-      await (oauthTransport as any).getProfileState('default');
+      await getHarness(oauthTransport).loadProfileState('default');
       expect(oauthTransport.getOAuthScopes()).toEqual(['api', 'read_user']);
       oauthTransport.stop();
     });
@@ -2991,9 +2985,9 @@ describeIfListen('HttpTransport', () => {
 
   describe('destroySession', () => {
     it('should handle destroying non-existent session gracefully', () => {
-      const profileState = createProfileState(transport as any);
+      const profileState = createProfileState(transport);
       // Should not throw
-      expect(() => (transport as any).destroySession(profileState, 'non-existent-session')).not.toThrow();
+      expect(() => harness.destroySession(profileState, 'non-existent-session')).not.toThrow();
     });
   });
 
@@ -3028,41 +3022,41 @@ describeIfListen('HttpTransport', () => {
 
   describe('cleanupExpiredSessions', () => {
     it('should not throw when no sessions to clean', () => {
-      expect(() => (transport as any).cleanupExpiredSessions()).not.toThrow();
+      expect(() => harness.cleanupExpiredSessions()).not.toThrow();
     });
   });
 
   describe('refreshAccessToken', () => {
     it('should return false when session does not exist', async () => {
-      const result = await (transport as any).refreshAccessToken('default', 'non-existent');
+      const result = await harness.refreshAccessToken('default', 'non-existent');
       expect(result).toBe(false);
     });
 
     it('should return false when session has no refresh token', async () => {
       // Create session without refresh token
-      const profileState = createProfileState(transport as any);
-      const sessionId = (transport as any).createSession(profileState, 'access-token');
-      const result = await (transport as any).refreshAccessToken('default', sessionId);
+      const profileState = createProfileState(transport);
+      const sessionId = harness.createSession(profileState, 'access-token');
+      const result = await harness.refreshAccessToken('default', sessionId);
       expect(result).toBe(false);
     });
 
     it('should return false when OAuth provider is not configured', async () => {
       // Create session with refresh token but no OAuth provider
-      const profileState = createProfileState(transport as any);
-      const sessionId = (transport as any).createSession(profileState, 'access-token', 'refresh-token');
-      const result = await (transport as any).refreshAccessToken('default', sessionId);
+      const profileState = createProfileState(transport);
+      const sessionId = harness.createSession(profileState, 'access-token', 'refresh-token');
+      const result = await harness.refreshAccessToken('default', sessionId);
       expect(result).toBe(false);
     });
 
     it('reuses tenant OAuth provider instance per session and clears it on session destroy', () => {
-      const profileState = createProfileState(transport as any);
+      const profileState = createProfileState(transport);
       const tenantOAuthConfig = {
         authorization_endpoint: 'https://auth.example.com/oauth/authorize',
         token_endpoint: 'https://auth.example.com/oauth/token',
         client_id: 'tenant-client',
         client_secret: 'tenant-secret',
       };
-      const sessionId = (transport as any).createSession(
+      const sessionId = harness.createSession(
         profileState,
         'access-token',
         'refresh-token',
@@ -3084,12 +3078,12 @@ describeIfListen('HttpTransport', () => {
       const session = profileState.sessions.get(sessionId);
       expect(session).toBeDefined();
 
-      const firstProvider = (transport as any).getOAuthProviderForSession(profileState, session);
-      const secondProvider = (transport as any).getOAuthProviderForSession(profileState, session);
+      const firstProvider = harness.getOAuthProviderForSession(profileState, session);
+      const secondProvider = harness.getOAuthProviderForSession(profileState, session);
       expect(firstProvider).toBe(secondProvider);
       expect((profileState as any).tenantOAuthProvidersBySessionId.get(sessionId)).toBe(firstProvider);
 
-      (transport as any).destroySession(profileState, sessionId);
+      harness.destroySession(profileState, sessionId);
       expect((profileState as any).tenantOAuthProvidersBySessionId.has(sessionId)).toBe(false);
     });
 
@@ -3113,8 +3107,8 @@ describeIfListen('HttpTransport', () => {
         logger
       );
 
-      const profileState = createProfileState(oauthTransport as any);
-      const sessionId = (oauthTransport as any).createSession(profileState, 'old-access', 'refresh-token');
+      const profileState = createProfileState(oauthTransport);
+      const sessionId = getHarness(oauthTransport).createSession(profileState, 'old-access', 'refresh-token');
       const session = profileState.sessions.get(sessionId);
       session.oauthClientId = 'test-client';
 
@@ -3131,7 +3125,7 @@ describeIfListen('HttpTransport', () => {
         })
       };
 
-      const result = await (oauthTransport as any).refreshAccessToken('default', sessionId);
+      const result = await getHarness(oauthTransport).refreshAccessToken('default', sessionId);
       expect(result).toBe(true);
       expect(session.accessTokenExpiresAt).toBeUndefined();
       expect(session.authToken).toBe('new-access');
@@ -3159,8 +3153,8 @@ describeIfListen('HttpTransport', () => {
         logger
       );
 
-      const profileState = createProfileState(oauthTransport as any);
-      const sessionId = (oauthTransport as any).createSession(profileState, 'old-access', 'refresh-token');
+      const profileState = createProfileState(oauthTransport);
+      const sessionId = getHarness(oauthTransport).createSession(profileState, 'old-access', 'refresh-token');
       const session = profileState.sessions.get(sessionId);
       session.oauthClientId = 'test-client';
 
@@ -3174,7 +3168,7 @@ describeIfListen('HttpTransport', () => {
         }
       };
 
-      const result = await (oauthTransport as any).refreshAccessToken('default', sessionId);
+      const result = await getHarness(oauthTransport).refreshAccessToken('default', sessionId);
       expect(result).toBe(false);
 
       await oauthTransport.stop();
@@ -3190,14 +3184,14 @@ describeIfListen('HttpTransport', () => {
         oauthTokensByAccessToken: new Map(),
         sessions: new Map(),
       };
-      (transport as any).profileStates.set('default', profileState);
+      harness.setProfileState(profileState);
       const tokens = {
         access_token: 'test-access-token',
         refresh_token: 'test-refresh-token',
         expires_in: 3600
       };
       
-      (transport as any).storeOAuthTokens(profileState, tokens, 'client-id', ['read', 'write']);
+      harness.storeOAuthTokens(profileState, tokens, 'client-id', ['read', 'write']);
       
       const stored = profileState.oauthTokensByAccessToken.get('test-access-token');
       expect(stored).toBeDefined();
@@ -3215,12 +3209,12 @@ describeIfListen('HttpTransport', () => {
         oauthTokensByAccessToken: new Map(),
         sessions: new Map(),
       };
-      (transport as any).profileStates.set('default', profileState);
+      harness.setProfileState(profileState);
       const tokens = {
         access_token: 'test-access-token-2'
       };
       
-      (transport as any).storeOAuthTokens(profileState, tokens, 'client-id', []);
+      harness.storeOAuthTokens(profileState, tokens, 'client-id', []);
       
       const stored = profileState.oauthTokensByAccessToken.get('test-access-token-2');
       expect(stored).toBeDefined();
@@ -3231,8 +3225,8 @@ describeIfListen('HttpTransport', () => {
 
   describe('getSessionToken', () => {
     it('should return token for existing session', () => {
-      const profileState = createProfileState(transport as any);
-      const sessionId = (transport as any).createSession(profileState, 'my-auth-token');
+      const profileState = createProfileState(transport);
+      const sessionId = harness.createSession(profileState, 'my-auth-token');
       const token = transport.getSessionToken('default', sessionId);
       expect(token).toBe('my-auth-token');
     });
@@ -3260,7 +3254,7 @@ describeIfListen('HttpTransport', () => {
       }));
       routingTransport.setMessageHandler(handler);
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
 
       const response = await request(routingApp)
         .post('/profile/gitlab/mcp')
@@ -3302,7 +3296,7 @@ describeIfListen('HttpTransport', () => {
         serverInfo: { name: 'test' },
       }));
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const response = await request(routingApp)
         .post('/profile/gitlab/sse')
         .set('Accept', 'text/event-stream')
@@ -3343,7 +3337,7 @@ describeIfListen('HttpTransport', () => {
         result: { ok: true },
       }));
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const response = await request(routingApp)
         .post('/mcp')
         .set('Accept', 'application/json')
@@ -3386,7 +3380,7 @@ describeIfListen('HttpTransport', () => {
       }));
       routingTransport.setMessageHandler(handler);
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const response = await request(routingApp)
         .post('/mcp')
         .set('Accept', 'application/json')
@@ -3430,7 +3424,7 @@ describeIfListen('HttpTransport', () => {
       }));
       routingTransport.setMessageHandler(handler);
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const response = await request(routingApp)
         .post('/profile/alias-default/mcp')
         .set('Accept', 'application/json')
@@ -3475,7 +3469,7 @@ describeIfListen('HttpTransport', () => {
       }));
       routingTransport.setMessageHandler(handler);
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const response = await request(routingApp)
         .post('/profile/alias/mcp')
         .set('Accept', 'application/json')
@@ -3522,7 +3516,7 @@ describeIfListen('HttpTransport', () => {
         },
       }));
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const response = await request(routingApp).get('/profile/gitlab/.well-known/oauth-authorization-server');
 
       expect(response.status).toBe(200);
@@ -3559,7 +3553,7 @@ describeIfListen('HttpTransport', () => {
         },
       }));
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const response = await request(routingApp).get('/.well-known/oauth-authorization-server/profile/gitlab');
 
       expect(response.status).toBe(200);
@@ -3596,7 +3590,7 @@ describeIfListen('HttpTransport', () => {
         },
       }));
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const responseProfilePath = await request(routingApp).get('/profile/gitlab/.well-known/openid-configuration');
       const responseSuffixPath = await request(routingApp).get('/.well-known/openid-configuration/profile/gitlab');
 
@@ -3635,7 +3629,7 @@ describeIfListen('HttpTransport', () => {
         },
       }));
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const response = await request(routingApp).get('/profile/default/.well-known/oauth-authorization-server');
 
       expect(response.status).toBe(200);
@@ -3672,7 +3666,7 @@ describeIfListen('HttpTransport', () => {
         },
       }));
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const response = await request(routingApp).get('/profile/gitlab/.well-known/oauth-protected-resource/mcp');
 
       expect(response.status).toBe(200);
@@ -3708,7 +3702,7 @@ describeIfListen('HttpTransport', () => {
         },
       }));
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const response = await request(routingApp)
         .get('/.well-known/oauth-protected-resource/mcp')
         .query({ resource: 'https://example.com/profile/gitlab/mcp/' });
@@ -3746,7 +3740,7 @@ describeIfListen('HttpTransport', () => {
         },
       }));
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const response = await request(routingApp)
         .get('/.well-known/oauth-protected-resource/profile/gitlab/mcp');
 
@@ -3783,7 +3777,7 @@ describeIfListen('HttpTransport', () => {
         },
       }));
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
 
       // Prime hint via profile route
       await request(routingApp)
@@ -3828,7 +3822,7 @@ describeIfListen('HttpTransport', () => {
         },
       }));
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const response = await request(routingApp)
         .get('/.well-known/oauth-protected-resource/mcp')
         .query({ resource: 'https://example.com/profile/gitlab/mcp' });
@@ -3855,7 +3849,7 @@ describeIfListen('HttpTransport', () => {
         logger
       );
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const response = await request(routingApp)
         .get('/.well-known/oauth-protected-resource/mcp')
         .query({ resource: ['one', 'two'] });
@@ -3881,7 +3875,7 @@ describeIfListen('HttpTransport', () => {
         logger
       );
 
-      const routingApp = (routingTransport as any).app;
+      const routingApp = getHarness(routingTransport).app;
       const response = await request(routingApp)
         .get('/.well-known/oauth-protected-resource/mcp')
         .query({ resource: 'not-a-url' });
@@ -3916,7 +3910,7 @@ describeIfListen('HttpTransport', () => {
 
     it('should allow origin matching OAuth redirect URI host', async () => {
       // Mock OAuth provider with redirect URI
-      (oauthTransport as any).profileStates.set('default', {
+      getHarness(oauthTransport).setProfileState({
         profileId: 'default',
         context: { profileId: 'default' },
         oauthProvider: { redirectUri: 'http://myapp.example.com:3000/callback' },
@@ -3924,13 +3918,13 @@ describeIfListen('HttpTransport', () => {
         sessions: new Map(),
       });
 
-      const isAllowed = (oauthTransport as any).isAllowedOrigin('http://myapp.example.com:3000');
+      const isAllowed = getHarness(oauthTransport).isAllowedOrigin('http://myapp.example.com:3000');
       expect(isAllowed).toBe(true);
     });
 
     it('should handle invalid OAuth redirect URI gracefully', async () => {
       // Mock OAuth provider with invalid redirect URI
-      (oauthTransport as any).profileStates.set('default', {
+      getHarness(oauthTransport).setProfileState({
         profileId: 'default',
         context: { profileId: 'default' },
         oauthProvider: { redirectUri: 'not-a-valid-url' },
@@ -3939,7 +3933,7 @@ describeIfListen('HttpTransport', () => {
       });
 
       // Should not throw and should fall back to other checks
-      const isAllowed = (oauthTransport as any).isAllowedOrigin('http://localhost:3000');
+      const isAllowed = getHarness(oauthTransport).isAllowedOrigin('http://localhost:3000');
       expect(isAllowed).toBe(true); // localhost always allowed
     });
   });

--- a/src/transport/http-transport.unit.test.ts
+++ b/src/transport/http-transport.unit.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { HttpTransport } from './http-transport.js';
+import { createHttpTransportTestHarness, type HttpTransportTestHarness } from './http-transport.test-harness.js';
 import { ConsoleLogger } from '../core/logger.js';
 import { parseSessionToolFilterHeader } from '../tool-filter/index.js';
 import type { SessionToolFilter } from '../types/http-transport.js';
@@ -11,19 +12,12 @@ import { ConfigurationError, ValidationError } from '../core/errors.js';
 
 describe('HttpTransport unit', () => {
   let transport: HttpTransport;
+  let harness: HttpTransportTestHarness;
   const logger = new ConsoleLogger();
 
-  const createProfileState = (target: any, profileId: string = 'default') => {
-    const state = {
-      profileId,
-      context: { profileId },
-      oauthProvider: null,
-      oauthTokensByAccessToken: new Map(),
-      sessions: new Map(),
-    };
-    target.profileStates.set(profileId, state);
-    return state;
-  };
+  const getHarness = (target: HttpTransport): HttpTransportTestHarness => createHttpTransportTestHarness(target);
+  const createProfileState = (target: HttpTransport, profileId: string = 'default') =>
+    getHarness(target).createProfileState(profileId);
 
   const withGet = (req: any) => {
     if (typeof req.get === 'function') {
@@ -52,6 +46,7 @@ describe('HttpTransport unit', () => {
     };
 
     transport = new HttpTransport(config, logger);
+    harness = getHarness(transport);
   });
 
   afterEach(async () => {
@@ -60,17 +55,17 @@ describe('HttpTransport unit', () => {
 
   describe('filtering header helpers', () => {
     it('detects unknown message types', () => {
-      const messageType = (transport as any).getMessageType(123);
+      const messageType = harness.getMessageType(123);
       expect(messageType).toBe('unknown');
     });
 
     it('detects response-only messages', () => {
-      const messageType = (transport as any).getMessageType({ result: { ok: true } });
+      const messageType = harness.getMessageType({ result: { ok: true } });
       expect(messageType).toBe('response-only');
     });
 
     it('handles filtering header arrays', () => {
-      const getFilteringHeaderValue = (transport as any).getFilteringHeaderValue.bind(transport);
+      const getFilteringHeaderValue = harness.getFilteringHeaderValue;
       expect(getFilteringHeaderValue({ headers: { 'x-mcp4-params': [] } })).toBeUndefined();
       expect(() =>
         getFilteringHeaderValue({ headers: { 'x-mcp4-params': ['a=b', 'c=d'] } })
@@ -78,7 +73,7 @@ describe('HttpTransport unit', () => {
     });
 
     it('returns first filtering header value when single entry is provided', () => {
-      const getFilteringHeaderValue = (transport as any).getFilteringHeaderValue.bind(transport);
+      const getFilteringHeaderValue = harness.getFilteringHeaderValue;
       expect(getFilteringHeaderValue({ headers: { 'x-mcp4-params': ['project_id=1'] } })).toBe(
         'project_id=1'
       );
@@ -88,8 +83,8 @@ describe('HttpTransport unit', () => {
     });
 
     it('exposes session filtering values', () => {
-      const sessionId = (transport as any).createSession(
-        createProfileState(transport as any),
+      const sessionId = harness.createSession(
+        createProfileState(transport),
         undefined,
         undefined,
         undefined,
@@ -119,7 +114,7 @@ describe('HttpTransport unit', () => {
       );
 
       try {
-        const sessionId = (scopedTransport as any).createSession(createProfileState(scopedTransport as any));
+        const sessionId = getHarness(scopedTransport).createSession(createProfileState(scopedTransport));
         expect(scopedTransport.getSessionFiltering('default', sessionId)).toEqual({
           project_id: ['1'],
           _allow_read: [],
@@ -146,8 +141,8 @@ describe('HttpTransport unit', () => {
       );
 
       try {
-        const sessionId = (scopedTransport as any).createSession(
-          createProfileState(scopedTransport as any),
+        const sessionId = getHarness(scopedTransport).createSession(
+          createProfileState(scopedTransport),
           undefined,
           undefined,
           undefined,
@@ -186,8 +181,8 @@ describe('HttpTransport unit', () => {
 
       try {
         expect(() =>
-          (scopedTransport as any).createSession(
-            createProfileState(scopedTransport as any),
+          getHarness(scopedTransport).createSession(
+            createProfileState(scopedTransport),
             undefined,
             undefined,
             undefined,
@@ -203,8 +198,8 @@ describe('HttpTransport unit', () => {
     });
 
     it('handles tenant header arrays and invalid values', () => {
-      const getTenantIdHeaderValue = (transport as any).getTenantIdHeaderValue.bind(transport);
-      const getTenantBaseUrlHeaderValue = (transport as any).getTenantBaseUrlHeaderValue.bind(transport);
+      const getTenantIdHeaderValue = harness.getTenantIdHeaderValue;
+      const getTenantBaseUrlHeaderValue = harness.getTenantBaseUrlHeaderValue;
 
       expect(getTenantIdHeaderValue({ headers: { 'x-mcp4-tenant-id': [] } })).toBeUndefined();
       expect(() => getTenantIdHeaderValue({ headers: { 'x-mcp4-tenant-id': ['a', 'b'] } })).toThrow();
@@ -218,7 +213,7 @@ describe('HttpTransport unit', () => {
     });
 
     it('handles tool filter header arrays', () => {
-      const getToolFilterHeaderValue = (transport as any).getToolFilterHeaderValue.bind(transport);
+      const getToolFilterHeaderValue = harness.getToolFilterHeaderValue;
       expect(getToolFilterHeaderValue({ headers: { 'x-mcp4-tools': [] } })).toBeUndefined();
       expect(() =>
         getToolFilterHeaderValue({ headers: { 'x-mcp4-tools': ['a', 'b'] } })
@@ -227,8 +222,8 @@ describe('HttpTransport unit', () => {
 
     it('exposes session tool filter values', () => {
       const toolFilterRequest = parseSessionToolFilterHeader('get_user');
-      const sessionId = (transport as any).createSession(
-        createProfileState(transport as any),
+      const sessionId = harness.createSession(
+        createProfileState(transport),
         undefined,
         undefined,
         undefined,
@@ -248,8 +243,8 @@ describe('HttpTransport unit', () => {
       expect(toolFilterRequest.allowCategories.has('list')).toBe(true);
       expect(toolFilterRequest.hasRules).toBe(true);
 
-      const sessionId = (transport as any).createSession(
-        createProfileState(transport as any),
+      const sessionId = harness.createSession(
+        createProfileState(transport),
         undefined,
         undefined,
         undefined,
@@ -268,8 +263,8 @@ describe('HttpTransport unit', () => {
       const toolFilterRequest = parseSessionToolFilterHeader('_allow_read');
       expect(toolFilterRequest.allowCategories.has('read')).toBe(true);
 
-      const sessionId = (transport as any).createSession(
-        createProfileState(transport as any),
+      const sessionId = harness.createSession(
+        createProfileState(transport),
         undefined,
         undefined,
         undefined,
@@ -290,8 +285,8 @@ describe('HttpTransport unit', () => {
       expect(toolFilterRequest.allowCategories.has('list')).toBe(true);
       expect(toolFilterRequest.regexPatterns.length).toBe(1);
 
-      const sessionId = (transport as any).createSession(
-        createProfileState(transport as any),
+      const sessionId = harness.createSession(
+        createProfileState(transport),
         undefined,
         undefined,
         undefined,
@@ -330,8 +325,8 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      const profileState = createProfileState(transportWithParser as any);
-      const service = (transportWithParser as any).getToolFilterService(profileState);
+      const profileState = createProfileState(transportWithParser);
+      const service = getHarness(transportWithParser).getToolFilterService(profileState);
       expect(service).toBeDefined();
 
       const toolFilterRequest = parseSessionToolFilterHeader('_allow_list');
@@ -354,8 +349,8 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      const profileState = createProfileState(transportWithoutParser as any);
-      const service = (transportWithoutParser as any).getToolFilterService(profileState);
+      const profileState = createProfileState(transportWithoutParser);
+      const service = getHarness(transportWithoutParser).getToolFilterService(profileState);
       expect(service).toBeDefined();
 
       const toolFilterRequest = parseSessionToolFilterHeader('get_user');
@@ -387,7 +382,7 @@ describe('HttpTransport unit', () => {
         patternCounts: { allow_list: 1 },
       });
 
-      const metricsOutput = await (metricsTransport as any).metrics.getMetrics();
+      const metricsOutput = await metricsTransport.getMetricsCollector()!.getMetrics();
       expect(metricsOutput).toContain('mcp_tools_total{source="profile"} 4');
       expect(metricsOutput).toContain('mcp_tools_filtered{source="global_env",action="allowed"} 3');
       expect(metricsOutput).toContain('mcp_tools_filtered{source="global_env",action="denied"} 1');
@@ -414,7 +409,7 @@ describe('HttpTransport unit', () => {
 
       metricsTransport.recordSessionToolFilterMetrics(sessionId, 2, request);
 
-      const metricsOutput = await (metricsTransport as any).metrics.getMetrics();
+      const metricsOutput = await metricsTransport.getMetricsCollector()!.getMetrics();
       expect(metricsOutput).toContain(`mcp_tools_session{session_id="${sessionId}"} 2`);
       expect(metricsOutput).toContain('mcp_tool_filter_patterns{type="session_allow_list"} 2');
       expect(metricsOutput).toContain('mcp_tool_filter_patterns{type="session_allow_regex"} 1');
@@ -439,7 +434,7 @@ describe('HttpTransport unit', () => {
       metricsTransport.recordToolFilterRejection('delete_user', 'env');
       metricsTransport.recordToolFilterRejection('drop_table', 'session');
 
-      const metricsOutput = await (metricsTransport as any).metrics.getMetrics();
+      const metricsOutput = await metricsTransport.getMetricsCollector()!.getMetrics();
       expect(metricsOutput).toContain('mcp_tool_filter_rejections_total{tool="delete_user",source="env"} 1');
       expect(metricsOutput).toContain('mcp_tool_filter_rejections_total{tool="drop_table",source="session"} 1');
 
@@ -488,8 +483,8 @@ describe('HttpTransport unit', () => {
         },
         logger
       );
-      const profileState = createProfileState(localTransport as any);
-      const sessionId = (localTransport as any).createSession(profileState);
+      const profileState = createProfileState(localTransport);
+      const sessionId = getHarness(localTransport).createSession(profileState);
 
       const toolFilter: SessionToolFilter = {
         allowedToolNames: new Set(['get_user', 'list_users']),
@@ -505,7 +500,7 @@ describe('HttpTransport unit', () => {
       expect(retrieved?.allowedToolNames.has('get_user')).toBe(true);
       expect(retrieved?.allowedToolNames.has('list_users')).toBe(true);
 
-      (localTransport as any).destroySession(profileState, sessionId);
+      getHarness(localTransport).destroySession(profileState, sessionId);
       await localTransport.stop();
     });
 
@@ -572,7 +567,7 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      const isAllowedOrigin = (localTransport as any).isAllowedOrigin.bind(localTransport);
+      const isAllowedOrigin = getHarness(localTransport).isAllowedOrigin;
       expect(isAllowedOrigin('http://localhost:1234')).toBe(true);
       expect(isAllowedOrigin('http://127.0.0.1:1234')).toBe(true);
       expect(isAllowedOrigin('https://example.com')).toBe(true);
@@ -596,7 +591,7 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      const isAllowedOrigin = (localTransport as any).isAllowedOrigin.bind(localTransport);
+      const isAllowedOrigin = getHarness(localTransport).isAllowedOrigin;
       expect(isAllowedOrigin('https://api.example.com')).toBe(true);
       expect(isAllowedOrigin('https://example.com')).toBe(true);
       expect(isAllowedOrigin('https://exact.example.org')).toBe(true);
@@ -622,7 +617,7 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      const isAllowedOrigin = (localTransport as any).isAllowedOrigin.bind(localTransport);
+      const isAllowedOrigin = getHarness(localTransport).isAllowedOrigin;
       expect(isAllowedOrigin('http://app.example.com')).toBe(true);
       expect(isAllowedOrigin('http://not-app.example.com')).toBe(false);
 
@@ -644,7 +639,7 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      const matchOrigin = (localTransport as any).matchOrigin.bind(localTransport);
+      const matchOrigin = getHarness(localTransport).matchOrigin;
       expect(matchOrigin('192.168.1.50', '192.168.1.0/24')).toBe(true);
       expect(matchOrigin('192.168.2.50', '192.168.1.0/24')).toBe(false);
       expect(matchOrigin('10.0.0.1', '10.0.0.0/not-a-number')).toBe(false);
@@ -667,7 +662,7 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      const ipv6ToBigInt = (localTransport as any).ipv6ToBigInt.bind(localTransport);
+      const ipv6ToBigInt = getHarness(localTransport).ipv6ToBigInt;
       expect(ipv6ToBigInt('2001:db8::1')).not.toBeNull();
       expect(ipv6ToBigInt('[2001:db8::1]')).not.toBeNull();
       expect(ipv6ToBigInt('::ffff:192.168.0.1')).not.toBeNull();
@@ -691,23 +686,23 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      (localTransport as any).profileStates.set('default', {
+      getHarness(localTransport).setProfileState({
         profileId: 'default',
         context: { profileId: 'default' },
         oauthProvider: { redirectUri: 'http://state.example.com/callback' },
         oauthTokensByAccessToken: new Map(),
         sessions: new Map(),
       });
-      (localTransport as any).profileStates.set('bad', {
+      getHarness(localTransport).setProfileState({
         profileId: 'bad',
         context: { profileId: 'bad' },
         oauthProvider: { redirectUri: 'not-a-url' },
         oauthTokensByAccessToken: new Map(),
         sessions: new Map(),
       });
-      (localTransport as any).oauthRedirectHostCache.set('cached', ['cached.example.com']);
+      getHarness(localTransport).setOAuthRedirectHosts('cached', ['cached.example.com']);
 
-      const hosts = (localTransport as any).getOAuthRedirectHostPatterns();
+      const hosts = getHarness(localTransport).getOAuthRedirectHostPatterns();
       expect(hosts).toContain('state.example.com');
       expect(hosts).toContain('config.example.com');
       expect(hosts).toContain('cached.example.com');
@@ -729,7 +724,7 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      const extractor = (localTransport as any).extractRedirectHostPatterns.bind(localTransport);
+      const extractor = getHarness(localTransport).extractRedirectHostPatterns;
       expect(extractor(undefined, 'default')).toEqual([]);
       expect(extractor({ redirect_uri: 'not-a-url' }, 'default')).toEqual([]);
 
@@ -750,7 +745,7 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      const resolver = (localTransport as any).resolveRedirectUriFromEnv.bind(localTransport);
+      const resolver = getHarness(localTransport).resolveRedirectUriFromEnv;
       expect(resolver('http://literal.example.com/cb', 'default')).toBe('http://literal.example.com/cb');
 
       process.env.OAUTH_REDIRECT_URI = 'http://env.example.com/cb';
@@ -776,12 +771,12 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      const fromPath = (localTransport as any).resolveProfileIdFromPath.bind(localTransport);
+      const fromPath = getHarness(localTransport).resolveProfileIdFromPath;
       expect(fromPath('/profile/gitlab/mcp')).toBe('gitlab');
       expect(fromPath('/not-profile/mcp')).toBeNull();
       expect(fromPath('/profile/%E0%A4%A/mcp')).toBeNull();
 
-      const fromReq = (localTransport as any).resolveProfileIdForOriginCheck.bind(localTransport);
+      const fromReq = getHarness(localTransport).resolveProfileIdForOriginCheck;
       const reqPath: any = { path: '/profile/alias/mcp', query: {} };
       expect(fromReq(reqPath)).toBe('alias');
 
@@ -820,9 +815,9 @@ describe('HttpTransport unit', () => {
         return { profileId: id };
       });
 
-      const primer = (localTransport as any).primeOAuthRedirectHosts.bind(localTransport);
+      const primer = getHarness(localTransport).primeOAuthRedirectHosts;
       await primer('empty');
-      expect((localTransport as any).oauthRedirectHostCache.get('empty')).toEqual([]);
+      expect(getHarness(localTransport).getOAuthRedirectHosts('empty')).toEqual([]);
 
       await primer('missing');
       await primer('boom');
@@ -849,7 +844,7 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      const checker = (localTransport as any).isAllowedOriginForRequest.bind(localTransport);
+      const checker = getHarness(localTransport).isAllowedOriginForRequest;
       const req: any = withGet({ path: '/mcp', query: {} });
       expect(await checker('http://example.com', req)).toBe(false);
 
@@ -869,7 +864,7 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      const checkerRouting = (routingTransport as any).isAllowedOriginForRequest.bind(routingTransport);
+      const checkerRouting = getHarness(routingTransport).isAllowedOriginForRequest;
       const reqNoProfile: any = withGet({ path: '/mcp', query: {} });
       expect(await checkerRouting('http://example.com', reqNoProfile)).toBe(false);
 
@@ -898,9 +893,9 @@ describe('HttpTransport unit', () => {
         localLogger as any
       );
 
-      createProfileState(localTransport as any).oauthProvider = { redirectUri: 'not-a-url' };
+      createProfileState(localTransport).oauthProvider = { redirectUri: 'not-a-url' };
 
-      const isAllowedOrigin = (localTransport as any).isAllowedOrigin.bind(localTransport);
+      const isAllowedOrigin = getHarness(localTransport).isAllowedOrigin;
       expect(isAllowedOrigin('not-a-url')).toBe(false);
       expect(isAllowedOrigin('https://not-example.com')).toBe(false);
 
@@ -929,13 +924,13 @@ describe('HttpTransport unit', () => {
         localLogger as any
       );
 
-      const matchOrigin = (localTransport as any).matchOrigin.bind(localTransport);
+      const matchOrigin = getHarness(localTransport).matchOrigin;
       expect(matchOrigin('2001:db8::1', '2001:db8::/32')).toBe(true);
       expect(matchOrigin('2001:db9::1', '2001:db8::/32')).toBe(false);
       expect(matchOrigin('2001:db8::1', '2001:db8::/129')).toBe(false);
       expect(localLogger.warn).toHaveBeenCalled();
 
-      const ipv6Mask = (localTransport as any).ipv6Mask.bind(localTransport);
+      const ipv6Mask = getHarness(localTransport).ipv6Mask;
       expect(ipv6Mask(0)).toBe(0n);
 
       await localTransport.stop();
@@ -956,7 +951,7 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      const ipv4ToInt = (localTransport as any).ipv4ToInt.bind(localTransport);
+      const ipv4ToInt = getHarness(localTransport).ipv4ToInt;
       expect(ipv4ToInt('1.2.3')).toBeNull();
       expect(ipv4ToInt('256.1.1.1')).toBeNull();
 
@@ -978,7 +973,7 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      const ipv6ToBigInt = (localTransport as any).ipv6ToBigInt.bind(localTransport);
+      const ipv6ToBigInt = getHarness(localTransport).ipv6ToBigInt;
       expect(ipv6ToBigInt('2001:db8:::1')).toBeNull();
       expect(ipv6ToBigInt('2001::db8::1')).toBeNull();
       expect(ipv6ToBigInt('2001:db8:zzzz::1')).toBeNull();
@@ -1011,7 +1006,7 @@ describe('HttpTransport unit', () => {
       }));
 
       const req: any = withGet({ path: '/profile/gitlab/oauth/authorize', query: {}, headers: {} });
-      const isAllowed = await (localTransport as any).isAllowedOriginForRequest('http://oauth.example.com', req);
+      const isAllowed = await getHarness(localTransport).isAllowedOriginForRequest('http://oauth.example.com', req);
       expect(isAllowed).toBe(true);
 
       delete process.env.OAUTH_REDIRECT_URI;
@@ -1043,7 +1038,7 @@ describe('HttpTransport unit', () => {
       }));
 
       const req: any = withGet({ path: '/profile/gitlab/oauth/authorize', query: {}, headers: {} });
-      const isAllowed = await (localTransport as any).isAllowedOriginForRequest('http://oauth.example.com', req);
+      const isAllowed = await getHarness(localTransport).isAllowedOriginForRequest('http://oauth.example.com', req);
       expect(isAllowed).toBe(false);
       expect(warnSpy).toHaveBeenCalledWith(
         'OAuth redirect_uri environment variable is empty',
@@ -1071,11 +1066,11 @@ describe('HttpTransport unit', () => {
         logger
       );
 
-      (localTransport as any).isAllowedOriginForRequest = async () => {
+      getHarness(localTransport).setIsAllowedOriginForRequest(async () => {
         throw new Error('boom');
-      };
+      });
 
-      const app = (localTransport as any).app;
+      const app = getHarness(localTransport).app;
       const router = app._router ?? app.router;
       expect(router).toBeDefined();
       const originLayer = router.stack.find((layer: any) =>


### PR DESCRIPTION
## Summary
- add a typed `HttpTransport` test harness for recurring app/session/profile-state access
- migrate the main HTTP transport test suites to use the harness instead of repeated private reach-ins
- add harness coverage and update the changelog for the refactor

## Root cause
`HttpTransport` tests were tightly coupled to internal object layout through repeated `(transport as any)` access for the private app instance, seeded profile state, session lifecycle helpers, and related transport internals. That made harmless internal refactors unnecessarily expensive and weakened the boundary between runtime behavior and test setup.

## Changes made
- added `src/transport/http-transport.test-harness.ts` with typed helpers for app access, profile-state seeding, session lifecycle setup, header helpers, and selected transport internals used by tests
- added `src/transport/http-transport.test-harness.test.ts` to verify the harness setup flows
- migrated `src/transport/http-transport.test.ts` and `src/transport/http-transport.unit.test.ts` to use the harness for high-frequency private reach-ins
- replaced several direct private property reads with existing public access where available (for example metrics collector access)
- updated `CHANGELOG.md`

## Test coverage added/updated
- added targeted harness tests for seeded profile state/session lifecycle and typed header helper access
- kept the main HTTP transport suites green after migration
- reduced `as any` usage in `http-transport.test.ts` from 123 to 31 and in `http-transport.unit.test.ts` from 96 to 37 while preserving current behavior coverage

## Risk assessment
Low risk. This is a test-focused refactor with no intended runtime behavior change. The harness centralizes test-only internal access, narrows the test surface, and keeps the production API unchanged.

Closes #153
