### PR TITLE
refactor(mcp): narrow HTTP transport boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bumped transitive security-sensitive dependencies via overrides (`@hono/node-server` to `1.19.10`, `hono` to `4.12.4`) and aligned Semgrep SBOM negative test inputs/expectations with current `deploymentSlug`/`deployment_id` validation behavior.
 - Updated `express-rate-limit` to `^8.3.1` to remediate the open GitHub Security / Dependabot alert for IPv4-mapped IPv6 rate-limit keying.
+- Replaced concrete `HttpTransport` references in `MCPServer` and `MCPServerManager` with a narrow typed bridge so HTTP session/runtime wiring stays modular without changing transport behavior.
 
 ### Fixed
 - Blocked dangerous URI schemes during URI validation to prevent XSS through attacker-controlled links and redirects.

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,6 @@
   - [4. Harden query parameter redaction canonicalization](#4-harden-query-parameter-redaction-canonicalization)
   - [7. Strengthen ReDoS Protection in Regex Compiler](#7-strengthen-redos-protection-in-regex-compiler)
   - [8. Limit HTTP profile server cache growth](#8-limit-http-profile-server-cache-growth)
-  - [9. Break MCPServer-HttpTransport circular dependency](#9-break-mcpserver-httptransport-circular-dependency)
   - [10. Split HttpTransport into smaller modules](#10-split-httptransport-into-smaller-modules)
   - [11. Reduce usage of any casts in HTTP transport](#11-reduce-usage-of-any-casts-in-http-transport)
   - [12. Avoid HTTP profile hint collisions across shared IPs](#12-avoid-http-profile-hint-collisions-across-shared-ips)
@@ -197,24 +196,6 @@ export DEFAULT_PROFILE_EXCLUDE_TAGS="admin,system"
 - `README.md` - document new env vars
 
 **Estimated effort**: 2-4 hours
-
-### 9. Break MCPServer-HttpTransport circular dependency
-**Problem**: MCPServer holds a reference to HttpTransport (typed as any), creating a circular dependency and weaker type safety.
-
-**Goal**: Remove direct dependency between MCPServer and HttpTransport for session cleanup and related hooks.
-
-**Implementation options**:
-- Introduce a small transport interface (methods used by MCPServer only) and type against that.
-- Use event-based cleanup: MCPServer emits session cleanup events, HttpTransport subscribes.
-- Invert control: move cleanup trigger into HttpTransport and pass a callback instead of full transport instance.
-
-**Files to modify**:
-- `src/mcp-server.ts` - replace direct transport reference with interface/callback
-- `src/http-transport.ts` - adjust session cleanup hookup
-- `src/mcp-server-manager.ts` - wiring changes if needed
-- `README.md` or `IMPLEMENTATION.md` - document architecture change
-
-**Estimated effort**: 2-3 hours
 
 ### 10. Split HttpTransport into smaller modules
 **Problem**: `src/http-transport.ts` is >2700 lines. `setupRoutes` and related OAuth/MCP handlers are large and hard to maintain.

--- a/src/mcp/http-transport-bridge.ts
+++ b/src/mcp/http-transport-bridge.ts
@@ -1,0 +1,71 @@
+/**
+ * Narrow HTTP transport contracts used by MCPServer and MCPServerManager.
+ *
+ * Why: keep core MCP runtime code dependent on explicit session/runtime hooks
+ * instead of the full concrete HttpTransport implementation.
+ */
+
+import type { FilteringRules } from '../core/filtering.js';
+import type { MetricsCollector } from '../core/metrics.js';
+import type { AuthInterceptor } from '../types/profile.js';
+import type {
+  SessionToolFilterCompat as SessionToolFilter,
+  SessionToolFilterRequest,
+} from '../tool-filter/index.js';
+
+export type HttpMessageHandler = (
+  message: unknown,
+  sessionId?: string,
+  profileId?: string
+) => Promise<unknown>;
+
+export type SessionDestroyedHandler = (
+  profileId: string,
+  sessionId: string
+) => void | Promise<void>;
+
+export interface MCPServerHttpBridge {
+  stop(): Promise<void>;
+  hasOAuthProvider(profileId?: string): boolean;
+  ensureValidSessionToken(profileId: string, sessionId: string): Promise<boolean>;
+  getSessionToken(profileId: string, sessionId: string): string | undefined;
+  getSessionFiltering(profileId: string, sessionId: string): FilteringRules | undefined;
+  getMetricsCollector?(): MetricsCollector | null;
+  getOAuthProtectedResourceUrl?(profileId?: string): string;
+  getSessionTenantContext?(
+    profileId: string,
+    sessionId: string
+  ): {
+    tenantId?: string;
+    tenantBaseUrl?: string;
+    tenantAuthConfigs?: AuthInterceptor[];
+  } | undefined;
+  getSessionToolFilter?(profileId: string, sessionId: string): SessionToolFilter | undefined;
+  getSessionEnterpriseAllowedToolCategories?(
+    profileId: string,
+    sessionId: string
+  ): Set<'list' | 'read' | 'modify' | 'admin'> | undefined;
+  getSessionToolFilterRequest?(
+    profileId: string,
+    sessionId: string
+  ): SessionToolFilterRequest | undefined;
+  setSessionToolFilter?(profileId: string, sessionId: string, filter: SessionToolFilter): void;
+  recordGlobalToolFilterMetrics?(summary: {
+    originalCount: number;
+    allowedCount: number;
+    removedCount: number;
+    patternCounts: Record<string, number>;
+  }): void;
+  recordSessionToolFilterMetrics?(
+    sessionId: string,
+    allowedCount: number,
+    request: SessionToolFilterRequest
+  ): void;
+  recordToolFilterRejection?(toolName: string, source: string): void;
+}
+
+export interface MCPServerHttpRuntimeBridge extends MCPServerHttpBridge {
+  start(): Promise<void>;
+  setMessageHandler(handler: HttpMessageHandler): void;
+  onSessionDestroyed(handler: SessionDestroyedHandler): void;
+}

--- a/src/mcp/mcp-server-http-transport-coverage.test.ts
+++ b/src/mcp/mcp-server-http-transport-coverage.test.ts
@@ -95,7 +95,7 @@ describe('MCPServer HTTP transport wiring (no listen)', () => {
     (server as any).handleToolCall = handleToolCall;
     (server as any).handleOtherRequest = handleOtherRequest;
 
-    const initResponse = await (server as any).handleJsonRpcMessage(
+    const initResponse = await server.handleHttpMessage(
       {
         jsonrpc: '2.0',
         id: 1,
@@ -110,7 +110,7 @@ describe('MCPServer HTTP transport wiring (no listen)', () => {
 
     expect(initResponse).toMatchObject({ jsonrpc: '2.0', id: 1 });
 
-    const toolResponse = await (server as any).handleJsonRpcMessage(
+    const toolResponse = await server.handleHttpMessage(
       {
         jsonrpc: '2.0',
         id: 2,
@@ -121,7 +121,7 @@ describe('MCPServer HTTP transport wiring (no listen)', () => {
     );
     expect(toolResponse).toEqual({ ok: 'tool' });
 
-    const otherResponse = await (server as any).handleJsonRpcMessage(
+    const otherResponse = await server.handleHttpMessage(
       {
         jsonrpc: '2.0',
         id: 3,

--- a/src/mcp/mcp-server-manager.test.ts
+++ b/src/mcp/mcp-server-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import path from 'path';
 import fs from 'node:fs/promises';
 import os from 'node:os';
@@ -7,6 +7,8 @@ import { ProfileRegistry } from '../profile/profile-registry.js';
 import type { ResolvedProfile } from '../profile/profile-resolver.js';
 import { resolveProfileFromPath } from '../profile/profile-resolver.js';
 import { MCPServerManager } from './mcp-server-manager.js';
+import { MCPServer } from './mcp-server.js';
+import type { MCPServerHttpBridge } from './http-transport-bridge.js';
 import { HttpTransport } from '../transport/http-transport.js';
 
 describe('MCPServerManager', () => {
@@ -47,6 +49,30 @@ describe('MCPServerManager', () => {
     const manager = new MCPServerManager(registry, logger);
 
     expect(manager.getDefaultProfileId()).toBe('default');
+  });
+
+  it('attaches a narrow HTTP bridge to lazily created servers', async () => {
+    const logger = new ConsoleLogger();
+    const registry = new ProfileRegistry({
+      profilesDir: path.join(process.cwd(), 'profiles'),
+    });
+    const httpBridge: MCPServerHttpBridge = {
+      ensureValidSessionToken: async () => true,
+      getSessionToken: () => undefined,
+      getSessionFiltering: () => undefined,
+      hasOAuthProvider: () => false,
+      stop: async () => {},
+    };
+
+    const manager = new MCPServerManager(registry, logger, httpBridge);
+    const attachSpy = vi.spyOn(MCPServer.prototype, 'attachHttpTransport');
+
+    try {
+      await manager.getServer('gitlab');
+      expect(attachSpy).toHaveBeenCalledWith(httpBridge);
+    } finally {
+      attachSpy.mockRestore();
+    }
   });
 
   it('routes HTTP requests through manager for profile routing', async () => {

--- a/src/mcp/mcp-server-manager.ts
+++ b/src/mcp/mcp-server-manager.ts
@@ -6,20 +6,20 @@ import type { Logger } from '../core/logger.js';
 import type { FilteringRules } from '../core/filtering.js';
 import { MCPServer } from './mcp-server.js';
 import type { HttpProfileContext } from '../types/http-transport.js';
-import type { HttpTransport } from '../transport/http-transport.js';
+import type { MCPServerHttpBridge } from './http-transport-bridge.js';
 import { ProfileRegistry } from '../profile/profile-registry.js';
 
 export class MCPServerManager {
   private registry: ProfileRegistry;
   private logger: Logger;
-  private httpTransport?: HttpTransport;
+  private httpTransport?: MCPServerHttpBridge;
   private globalFiltering?: FilteringRules;
   private servers = new Map<string, Promise<MCPServer>>();
 
   constructor(
     registry: ProfileRegistry,
     logger: Logger,
-    httpTransport?: HttpTransport,
+    httpTransport?: MCPServerHttpBridge,
     globalFiltering?: FilteringRules
   ) {
     this.registry = registry;

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -70,7 +70,7 @@ import {
   type SessionToolFilterRequest,
 } from '../tool-filter/index.js';
 import type { HttpProfileContext } from '../types/http-transport.js';
-import type { HttpTransport } from '../transport/http-transport.js';
+import type { MCPServerHttpBridge, MCPServerHttpRuntimeBridge } from './http-transport-bridge.js';
 import { buildHttpTransportBaseConfig } from '../transport/http-transport-config.js';
 import { renderPrompt } from '../prompt/prompt-renderer.js';
 import type { MetricsCollector, MetricsContextLabels } from '../core/metrics.js';
@@ -88,7 +88,7 @@ export class MCPServer {
   private appsFetchCache = new Map<string, { expiresAt: number; value: string }>();
   private schemaValidator: SchemaValidator;
   private logger: Logger;
-  private httpTransport: HttpTransport | null = null;
+  private httpTransport: MCPServerHttpBridge | null = null;
   private stdioFiltering?: FilteringRules;
   private globalFiltering?: FilteringRules;
   private toolFilterService?: ToolFilterService;
@@ -728,7 +728,7 @@ export class MCPServer {
     // Get auth token from session (ensures token is valid/refreshed)
     const authToken = await this.getAuthTokenFromSession(sessionId, profileId);
     const effectiveProfileId = profileId || this.getProfileIdValue();
-    const tenantContext = this.httpTransport?.getSessionTenantContext(effectiveProfileId, sessionId);
+    const tenantContext = this.httpTransport?.getSessionTenantContext?.(effectiveProfileId, sessionId);
 
     // Create or get session client using factory
     return this.httpClientFactory.getOrCreateSessionClient(sessionId, {
@@ -1327,28 +1327,29 @@ export class MCPServer {
       this.logger.warn('Binding to non-localhost with empty MCP4_ALLOWED_ORIGINS. Set MCP4_ALLOWED_ORIGINS or bind to localhost.');
     }
 
-    this.httpTransport = new HttpTransport(config, this.logger);
-    const metricsCollector = this.httpTransport.getMetricsCollector?.() || null;
+    const httpTransport: MCPServerHttpRuntimeBridge = new HttpTransport(config, this.logger);
+    this.httpTransport = httpTransport;
+    const metricsCollector = httpTransport.getMetricsCollector?.() || null;
     this.httpClientFactory.setMetricsCollector(metricsCollector);
 
     this.recordGlobalToolFilterMetrics();
-    
+
     // Set message handler to process JSON-RPC messages
-    this.httpTransport.setMessageHandler(async (message: unknown, sessionId?: string, profileId?: string) => {
+    httpTransport.setMessageHandler(async (message: unknown, sessionId?: string, profileId?: string) => {
       return await this.handleJsonRpcMessage(message, sessionId, profileId);
     });
 
     // Register cleanup listener for session destruction (memory leak prevention)
-    this.httpTransport.onSessionDestroyed((profileId: string, sessionId: string) => {
+    httpTransport.onSessionDestroyed((profileId: string, sessionId: string) => {
       this.cleanupSessionClient(profileId, sessionId);
     });
 
-    await this.httpTransport.start();
+    await httpTransport.start();
     
     this.logger.info('MCP server running on HTTP', { host, port });
   }
 
-  public attachHttpTransport(transport: HttpTransport): void {
+  public attachHttpTransport(transport: MCPServerHttpBridge): void {
     this.httpTransport = transport;
     const metricsCollector = this.httpTransport.getMetricsCollector?.() || null;
     this.httpClientFactory.setMetricsCollector(metricsCollector);
@@ -1472,7 +1473,7 @@ export class MCPServer {
             message: 'Authentication required. Please authorize via OAuth.',
             data: {
               oauth_required: true,
-              resource_metadata: this.httpTransport.getOAuthProtectedResourceUrl(profileId),
+              resource_metadata: this.httpTransport.getOAuthProtectedResourceUrl?.(profileId),
               scope: 'api'
             }
           }
@@ -1790,7 +1791,7 @@ export class MCPServer {
             message: 'Authentication required. Please authorize via OAuth.',
             data: {
               oauth_required: true,
-              resource_metadata: this.httpTransport.getOAuthProtectedResourceUrl(profileId),
+              resource_metadata: this.httpTransport.getOAuthProtectedResourceUrl?.(profileId),
               scope: 'api'
             }
           }
@@ -2363,7 +2364,10 @@ export class MCPServer {
       return;
     }
 
-    if (typeof this.httpTransport.getSessionToolFilterRequest !== 'function') {
+    if (
+      typeof this.httpTransport.getSessionToolFilterRequest !== 'function' ||
+      typeof this.httpTransport.setSessionToolFilter !== 'function'
+    ) {
       return;
     }
     const effectiveProfileId = profileId || this.getProfileIdValue();


### PR DESCRIPTION
## Summary
- introduce a narrow typed HTTP transport bridge for `MCPServer` and `MCPServerManager`
- keep concrete `HttpTransport` construction in composition/runtime code while removing direct core imports
- add focused bridge coverage and trim one private message-handler reach-in to public behavior coverage

## Root cause
`MCPServer` and `MCPServerManager` depended on the concrete `HttpTransport` class even though they only need a bounded subset of session, metrics, and runtime hooks. That created avoidable circular coupling between core MCP runtime code and the HTTP transport layer.

## Changes made
- added `src/mcp/http-transport-bridge.ts` with explicit bridge contracts for session/runtime hooks used by MCP server code
- retargeted `MCPServer` and `MCPServerManager` from concrete `HttpTransport` types to the narrow bridge contracts
- kept single-profile `runHttp(...)` wiring on the concrete transport while storing only the bridge contract in MCP server state
- added a manager test that verifies lazy server creation attaches the narrow bridge
- updated HTTP transport coverage to exercise public `handleHttpMessage(...)` instead of a private JSON-RPC reach-in
- removed the completed TODO entry and updated the changelog

## Test coverage added/updated
- added `attaches a narrow HTTP bridge to lazily created servers` in `src/mcp/mcp-server-manager.test.ts`
- updated `src/mcp/mcp-server-http-transport-coverage.test.ts` to route through public `handleHttpMessage(...)`
- ran `npm run typecheck`
- ran `npx vitest run src/mcp/mcp-server-manager.test.ts src/mcp/mcp-server-http-transport-coverage.test.ts`

## Risk assessment
Low risk. The change is a type/boundary refactor that keeps runtime HTTP behavior and session cleanup wiring intact while reducing coupling between core MCP server code and the transport implementation.

Closes #155
