### PR TITLE
fix(auth): require explicit oauth redirect schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `express-rate-limit` to `^8.3.1` to remediate the open GitHub Security / Dependabot alert for IPv4-mapped IPv6 rate-limit keying.
 
 ### Fixed
+- Hardened OAuth redirect URI validation with an explicit `allowed_redirect_schemes` allowlist that defaults to `http`/`https` and requires explicit custom-scheme opt-in while preserving host allowlists.
 - Blocked dangerous URI schemes during URI validation to prevent XSS through attacker-controlled links and redirects.
 - Removed raw environment variable values from selected configuration error messages and added regression checks to prevent secret leakage in errors.
 - Hardened MCP Apps resource loading so `file_path` stays inside the profile directory after normalization and symlink resolution, while keeping `resources/read` output shape consistent across inline, file-backed, and fetch-backed resources.

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ export MCP4_OAUTH_CLIENT_SECRET=your_dcr_client_secret
 export MCP4_OAUTH_REDIRECT_URI=http://127.0.0.1:3003/oauth/callback
 # OAuth endpoints are automatically discovered from API base URL
 ```
-**Note**: DCR and OAuth callback must be registered with the OAuth provider.
+**Note**: DCR and OAuth callback must be registered with the OAuth provider. Custom desktop/mobile redirect URIs now require explicit profile opt-in via `oauth_config.allowed_redirect_schemes` (default: `http`, `https`) plus a matching `allowed_redirect_hosts` entry.
 
 **Configuration priority:**
 1. **Explicit URLs**: `MCP4_OAUTH_AUTHORIZATION_URL`, `MCP4_OAUTH_TOKEN_URL` (highest priority)

--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,6 @@
   - [11. Reduce usage of any casts in HTTP transport](#11-reduce-usage-of-any-casts-in-http-transport)
   - [12. Avoid HTTP profile hint collisions across shared IPs](#12-avoid-http-profile-hint-collisions-across-shared-ips)
   - [13. Prevent unbounded growth of HTTP profile hint cache](#13-prevent-unbounded-growth-of-http-profile-hint-cache)
-  - [14. Consider strict OAuth redirect scheme allowlist](#14-consider-strict-oauth-redirect-scheme-allowlist)
   - [15. Replace JSON fingerprint auth comparison for tenant collisions](#15-replace-json-fingerprint-auth-comparison-for-tenant-collisions)
   - [16. Extract tenant session lifecycle from HttpTransport](#16-extract-tenant-session-lifecycle-from-httptransport)
 
@@ -281,24 +280,6 @@ export DEFAULT_PROFILE_EXCLUDE_TAGS="admin,system"
 - `README.md` - document any new env vars or limits
 
 **Estimated effort**: 1-2 hours
-
-### 14. Consider strict OAuth redirect scheme allowlist
-**Current**: `ExternalOAuthProvider` uses a denylist for dangerous redirect URI schemes (`javascript:`, `data:`, `vbscript:`, `file:`, `blob:`, `about:`) while keeping compatibility with custom client schemes.
-
-**Goal**: Evaluate migrating to a strict allowlist-based scheme policy for stronger security guarantees.
-
-**Implementation options**:
-- Add `allowed_redirect_schemes` to OAuth profile config with secure defaults (`http`, `https`) and explicit custom scheme opt-in.
-- Keep denylist as fallback behavior during migration to avoid breaking existing clients.
-- Add compatibility tests for common deep-link clients and document migration guidance.
-
-**Files to modify**:
-- `src/types/profile.ts` - OAuth config type extension
-- `src/auth/oauth-provider.ts` - scheme validation logic
-- `src/auth/oauth-provider.test.ts` - allowlist and migration tests
-- `docs/OAUTH.md` and `README.md` - configuration guidance
-
-**Estimated effort**: 2-4 hours
 
 ### 15. Replace JSON fingerprint auth comparison for tenant collisions
 **Current**: `authFingerprint` in `src/transport/http-tenant-config.ts` compares tenant auth compatibility via `JSON.stringify` over mapped auth config objects.

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -366,7 +366,20 @@ If you need a different callback URL:
 }
 ```
 
-**Important**: Update redirect URI in GitLab application settings to match. Native-app schemes (`cursor://…`, `vscode://…`) are supported - just add their host to `allowed_redirect_hosts` (or `MCP4_ALLOWED_ORIGINS`) so validation passes.
+**Important**: Update redirect URI in GitLab application settings to match. OAuth redirect URIs now default to the `http` and `https` schemes only. Native-app schemes (`cursor://…`, `vscode://…`) require both the host allowlist and an explicit `allowed_redirect_schemes` opt-in.
+
+```json
+{
+  "auth": {
+    "type": "oauth",
+    "oauth_config": {
+      "redirect_uri": "cursor://anysphere.cursor-mcp/oauth/callback",
+      "allowed_redirect_hosts": ["anysphere.cursor-mcp"],
+      "allowed_redirect_schemes": ["http", "https", "cursor"]
+    }
+  }
+}
+```
 
 Allowed redirect hosts accept exact hostnames, wildcard subdomains (`*.example.com`), IPv4 addresses, IPv4 CIDR ranges (e.g., `10.0.0.0/8`), and IPv6 addresses/CIDR ranges (e.g., `2001:db8::/32`) so you can allow whole internal networks without listing individual machines.
 

--- a/profile-schema.json
+++ b/profile-schema.json
@@ -1221,6 +1221,13 @@
             "type": "string"
           },
           "description": "Optional: Allowed redirect hosts for OAuth callbacks\nUsed to prevent open redirect vulnerabilities\n\nSupports wildcards: \"*.example.com\" matches any subdomain\nDefaults to [\"localhost\", \"127.0.0.1\"] for security\n\nCan reference MCP4_ALLOWED_ORIGINS environment variable"
+        },
+        "allowed_redirect_schemes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional: Allowed redirect URI schemes for OAuth callbacks Defaults to [\"http\", \"https\"] and requires explicit opt-in for custom app schemes"
         }
       },
       "description": "OAuth 2.0 configuration. Must provide EITHER 'issuer' (endpoints auto-derived) OR both 'authorization_endpoint' and 'token_endpoint' (explicit)."
@@ -1399,14 +1406,14 @@
           ]
         },
         "overrides": {
-          "$ref": "#/definitions/Record%3Cstring%2Cstructure-1535101595-18530-18566-1535101595-18515-18567-1535101595-18501-18568-1535101595-18430-18570-1535101595-0-18710%3E"
+          "$ref": "#/definitions/Record%3Cstring%2Cstructure-1535101595-18733-18769-1535101595-18718-18770-1535101595-18704-18771-1535101595-18633-18773-1535101595-0-18913%3E"
         }
       },
       "required": [
         "max_requests_per_minute"
       ]
     },
-    "Record<string,structure-1535101595-18530-18566-1535101595-18515-18567-1535101595-18501-18568-1535101595-18430-18570-1535101595-0-18710>": {
+    "Record<string,structure-1535101595-18733-18769-1535101595-18718-18770-1535101595-18704-18771-1535101595-18633-18773-1535101595-0-18913>": {
       "type": "object",
       "additionalProperties": {
         "type": "object",
@@ -1728,6 +1735,20 @@
               "type": "string"
             }
           }
+        ]
+      }
+    },
+    "Record<string,structure-1535101595-18530-18566-1535101595-18515-18567-1535101595-18501-18568-1535101595-18430-18570-1535101595-0-18710>": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "max_requests_per_minute": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "max_requests_per_minute"
         ]
       }
     },

--- a/src/auth/oauth-provider.test.ts
+++ b/src/auth/oauth-provider.test.ts
@@ -761,6 +761,34 @@ describe('ExternalOAuthProvider', () => {
       ).rejects.toThrow('Redirect URI not allowed');
     });
 
+    it('should reject custom redirect schemes unless explicitly allowed', async () => {
+      const configWithAllowedHosts = {
+        ...config,
+        allowed_redirect_hosts: ['anysphere.cursor-mcp'],
+      };
+      provider = new ExternalOAuthProvider(configWithAllowedHosts, mockLogger);
+
+      const client: OAuthClientInformationFull = {
+        client_id: 'test-client-id',
+        redirect_uris: [],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      };
+
+      const mockRes = {
+        redirect: vi.fn(),
+      } as unknown as Response;
+
+      await expect(
+        provider.authorize(client, {
+          redirectUri: 'cursor://anysphere.cursor-mcp/oauth/callback',
+          codeChallenge: 'challenge',
+          state: 'state123',
+          scopes: ['api'],
+        }, mockRes)
+      ).rejects.toThrow('Redirect URI not allowed');
+    });
+
     it('should redirect to authorization endpoint with correct params', async () => {
       const client: OAuthClientInformationFull = {
         client_id: 'test-client-id',
@@ -1077,11 +1105,12 @@ describe('ExternalOAuthProvider', () => {
       expect(mockRes.redirect).not.toHaveBeenCalled();
     });
 
-    it('should allow registered custom scheme redirect URIs when host is allowed', async () => {
+    it('should allow registered custom scheme redirect URIs when scheme is explicitly allowed', async () => {
       const configWithAllowedHosts = {
         ...config,
         allowed_redirect_hosts: ['anysphere.cursor-mcp'],
-      };
+        allowed_redirect_schemes: ['http', 'https', 'cursor'],
+      } as OAuthConfig;
       provider = new ExternalOAuthProvider(configWithAllowedHosts, mockLogger);
 
       const client: OAuthClientInformationFull = {

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -298,33 +298,45 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
     };
   }
 
+  private getAllowedRedirectSchemes(): string[] {
+    const configuredSchemes = this.config.allowed_redirect_schemes;
+    if (!configuredSchemes || configuredSchemes.length === 0) {
+      return ['http', 'https'];
+    }
+
+    return configuredSchemes
+      .map(scheme => scheme.trim().toLowerCase())
+      .filter(Boolean);
+  }
+
+  private isAllowedRedirectScheme(protocol: string): boolean {
+    const normalizedProtocol = protocol.endsWith(':') ? protocol.slice(0, -1) : protocol;
+    return this.getAllowedRedirectSchemes().includes(normalizedProtocol.toLowerCase());
+  }
+
   /**
    * Check if redirect URI host AND scheme are allowed
-   * Prevents open redirect vulnerabilities (CWE-601) and XSS (javascript: scheme)
+   * Prevents open redirect vulnerabilities (CWE-601) and unsafe scheme redirects
    */
   private isAllowedRedirectHost(redirectUri: string): boolean {
     try {
       const url = new URL(redirectUri);
 
-      // Security: Validate protocol to prevent javascript: or data: schemes
-      // We block dangerous schemes that could lead to XSS or local file access
-      const protocol = url.protocol.toLowerCase();
-      const dangerousSchemes = ['javascript:', 'data:', 'vbscript:', 'file:', 'blob:', 'about:'];
-      if (dangerousSchemes.includes(protocol)) {
+      if (!this.isAllowedRedirectScheme(url.protocol)) {
         return false;
       }
 
       const hostname = url.hostname;
-      
+
       // Default to localhost only if not configured
       const allowedHosts = this.config.allowed_redirect_hosts || ['localhost', '127.0.0.1'];
-      
+
       for (const allowed of allowedHosts) {
         if (this.matchRedirectHost(hostname, allowed)) {
           return true;
         }
       }
-      
+
       return false;
     } catch {
       // Invalid URL

--- a/src/generated-schemas.ts
+++ b/src/generated-schemas.ts
@@ -154,7 +154,8 @@ export const oAuthConfigSchema = z.object({
     registration_endpoint: z.string().optional(),
     introspection_endpoint: z.string().optional(),
     revocation_endpoint: z.string().optional(),
-    allowed_redirect_hosts: z.array(z.string()).optional()
+    allowed_redirect_hosts: z.array(z.string()).optional(),
+    allowed_redirect_schemes: z.array(z.string()).optional()
 });
 
 export const sessionCookieConfigSchema = z.object({

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -510,6 +510,12 @@ export interface OAuthConfig {
    * Can reference MCP4_ALLOWED_ORIGINS environment variable
    */
   allowed_redirect_hosts?: string[];
+
+  /**
+   * Optional: Allowed redirect URI schemes for OAuth callbacks
+   * Defaults to ["http", "https"] and requires explicit opt-in for custom app schemes
+   */
+  allowed_redirect_schemes?: string[];
 }
 
 export interface EnterpriseAuthorizationConfig {

--- a/tests/e2e/auth-oauth.test.ts
+++ b/tests/e2e/auth-oauth.test.ts
@@ -7,6 +7,8 @@
 
 import { it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import * as path from 'path';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
 import { startStandaloneMockServer, MockServerInstance, getAvailablePort } from './utils/mock-server.js';
 import { McpProcess } from './utils/mcp-process.js';
 import { describeIfListen } from './utils/listen-support.js';
@@ -134,13 +136,35 @@ describeIfListen('E2E: OAuth 2.0 authentication', () => {
   describe('custom scheme redirect', () => {
     let mcp: McpProcess | undefined;
     let httpPort: number;
+    let customSchemeProfilePath: string;
+    let tempProfileDir: string;
 
     const cursorRedirectUri = 'cursor://anysphere.cursor-mcp/oauth/callback';
     const clientState = 'custom-state-123';
 
     beforeAll(async () => {
       httpPort = await getAvailablePort();
+
+      tempProfileDir = mkdtempSync(path.join(tmpdir(), 'mcp4openapi-oauth-'));
+      customSchemeProfilePath = path.join(tempProfileDir, 'developer-profile-oauth-custom-scheme.json');
+      const profile = JSON.parse(readFileSync(profilePath, 'utf-8')) as Record<string, any>;
+      profile.$schema = path.resolve(process.cwd(), 'profile-schema.json');
+      profile.openapi_spec_path = openapiSpecPath;
+      const oauthInterceptor = Array.isArray(profile.interceptors?.auth)
+        ? profile.interceptors.auth.find((auth: Record<string, any>) => auth.type === 'oauth')
+        : undefined;
+      if (!oauthInterceptor?.oauth_config) {
+        throw new Error('Expected OAuth interceptor in developer profile');
+      }
+      oauthInterceptor.oauth_config.allowed_redirect_schemes = ['http', 'https', 'cursor'];
+      writeFileSync(customSchemeProfilePath, JSON.stringify(profile, null, 2));
     }, 15000);
+
+    afterAll(() => {
+      if (tempProfileDir) {
+        rmSync(tempProfileDir, { recursive: true, force: true });
+      }
+    });
 
     afterEach(async () => {
       await mcp?.stop();
@@ -153,7 +177,7 @@ describeIfListen('E2E: OAuth 2.0 authentication', () => {
       mcp = new McpProcess({
         transport: 'http',
         openapiSpecPath,
-        profilePath,
+        profilePath: customSchemeProfilePath,
         apiBaseUrl: mockServer.gitlabApiUrl,
         httpPort,
         oauth: {


### PR DESCRIPTION
## Summary
- harden OAuth redirect URI validation with an explicit `allowed_redirect_schemes` allowlist
- default redirect schemes to `http` and `https` while preserving existing host allowlists
- document custom-scheme opt-in and keep custom-scheme E2E coverage green via an explicit test profile override

## Root cause
`ExternalOAuthProvider` used a denylist of dangerous redirect URI schemes and otherwise accepted any scheme whose host matched `allowed_redirect_hosts`. That left the OAuth redirect boundary permissive-by-default for custom schemes.

## Changes made
- added `allowed_redirect_schemes` to `OAuthConfig` and regenerated Zod/JSON schemas
- replaced denylist-based redirect scheme validation with an explicit allowlist that defaults to `http`/`https`
- added a regression test proving custom schemes are rejected unless explicitly allowed
- updated the existing custom-scheme callback coverage to require explicit `cursor` scheme opt-in
- updated OAuth docs/README guidance, changelog, and removed the completed TODO entry

## Test coverage added/updated
- `npx vitest run src/auth/oauth-provider.test.ts`
- `npm run typecheck`
- `npm run check-schema-sync`
- `npm run build && npx vitest run --config vitest.e2e.config.ts tests/e2e/auth-oauth.test.ts`

## Risk assessment
Low. The change is narrowly scoped to OAuth redirect URI validation, keeps host allowlist enforcement intact, defaults to conservative web schemes, and requires explicit opt-in for custom desktop/mobile schemes with focused regression coverage.

Closes #157
