### PR TITLE
fix(http): isolate profile hint routing by cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened MCP Apps resource loading so `file_path` stays inside the profile directory after normalization and symlink resolution, while keeping `resources/read` output shape consistent across inline, file-backed, and fetch-backed resources.
 - Fixed HTTP single-profile startup to carry `enterprise_authorization` into transport runtime so enterprise JWT bearer exchange and authenticated initialization work outside profile-routing mode, with dedicated E2E coverage.
 - Clarified and locked runtime enterprise authorization behavior so `required` mode enforces trusted enterprise-issued bearer tokens, `optional` mode stays backward-compatible, tool-category policy covers both listing and execution, and invalid env-backed values fail during profile loading.
+- Isolated profile-routed OAuth metadata hints with a short-lived `HttpOnly` cookie so shared IP/user-agent clients no longer overwrite each other's root metadata selection.
 
 ## [0.5.7] - 2026-03-03
 

--- a/TODO.md
+++ b/TODO.md
@@ -15,11 +15,10 @@
   - [9. Break MCPServer-HttpTransport circular dependency](#9-break-mcpserver-httptransport-circular-dependency)
   - [10. Split HttpTransport into smaller modules](#10-split-httptransport-into-smaller-modules)
   - [11. Reduce usage of any casts in HTTP transport](#11-reduce-usage-of-any-casts-in-http-transport)
-  - [12. Avoid HTTP profile hint collisions across shared IPs](#12-avoid-http-profile-hint-collisions-across-shared-ips)
-  - [13. Prevent unbounded growth of HTTP profile hint cache](#13-prevent-unbounded-growth-of-http-profile-hint-cache)
-  - [14. Consider strict OAuth redirect scheme allowlist](#14-consider-strict-oauth-redirect-scheme-allowlist)
-  - [15. Replace JSON fingerprint auth comparison for tenant collisions](#15-replace-json-fingerprint-auth-comparison-for-tenant-collisions)
-  - [16. Extract tenant session lifecycle from HttpTransport](#16-extract-tenant-session-lifecycle-from-httptransport)
+- [12. Prevent unbounded growth of HTTP profile hint cache](#12-prevent-unbounded-growth-of-http-profile-hint-cache)
+- [13. Consider strict OAuth redirect scheme allowlist](#13-consider-strict-oauth-redirect-scheme-allowlist)
+- [14. Replace JSON fingerprint auth comparison for tenant collisions](#14-replace-json-fingerprint-auth-comparison-for-tenant-collisions)
+- [15. Extract tenant session lifecycle from HttpTransport](#15-extract-tenant-session-lifecycle-from-httptransport)
 
 ## P2: Nice-to-Have
 
@@ -250,23 +249,7 @@ export DEFAULT_PROFILE_EXCLUDE_TAGS="admin,system"
 
 **Estimated effort**: 2-4 hours
 
-### 12. Avoid HTTP profile hint collisions across shared IPs
-**Problem**: Profile hint keys are derived from IP and user-agent only, so different clients behind the same NAT with identical user agents can overwrite each other's hints. This can misroute profile resolution for OAuth endpoints or origin checks when profile routing has no default profile.
-
-**Goal**: Make profile hint association more robust to shared IPs and identical user-agent strings.
-
-**Implementation options**:
-- Include additional request entropy in the key (e.g., TLS session ID, `X-Forwarded-For` chain hash, or a server-generated hint cookie).
-- Set a hint cookie on first profile-routed request and use that as the primary key.
-- Add a short-lived per-profile routing token embedded in OAuth metadata links.
-
-**Files to modify**:
-- `src/http-transport.ts` - profile hint keying and lookup logic
-- `docs/HTTP-TRANSPORT.md` - document new hint mechanism (if user-facing)
-
-**Estimated effort**: 2-4 hours
-
-### 13. Prevent unbounded growth of HTTP profile hint cache
+### 12. Prevent unbounded growth of HTTP profile hint cache
 **Problem**: Profile hints are stored per client but only cleaned up on subsequent lookups, so many one-off clients can cause the cache to grow without bound in long-running servers.
 
 **Goal**: Bound memory usage for profile hint cache.
@@ -282,7 +265,7 @@ export DEFAULT_PROFILE_EXCLUDE_TAGS="admin,system"
 
 **Estimated effort**: 1-2 hours
 
-### 14. Consider strict OAuth redirect scheme allowlist
+### 13. Consider strict OAuth redirect scheme allowlist
 **Current**: `ExternalOAuthProvider` uses a denylist for dangerous redirect URI schemes (`javascript:`, `data:`, `vbscript:`, `file:`, `blob:`, `about:`) while keeping compatibility with custom client schemes.
 
 **Goal**: Evaluate migrating to a strict allowlist-based scheme policy for stronger security guarantees.
@@ -300,7 +283,7 @@ export DEFAULT_PROFILE_EXCLUDE_TAGS="admin,system"
 
 **Estimated effort**: 2-4 hours
 
-### 15. Replace JSON fingerprint auth comparison for tenant collisions
+### 14. Replace JSON fingerprint auth comparison for tenant collisions
 **Current**: `authFingerprint` in `src/transport/http-tenant-config.ts` compares tenant auth compatibility via `JSON.stringify` over mapped auth config objects.
 
 **Analysis**:
@@ -323,7 +306,7 @@ export DEFAULT_PROFILE_EXCLUDE_TAGS="admin,system"
 
 **Estimated effort**: 1-2 hours
 
-### 16. Extract tenant session lifecycle from HttpTransport
+### 15. Extract tenant session lifecycle from HttpTransport
 **Problem**: `HttpTransport` currently combines routing, auth, filtering, SSE/session control, and tenant-specific session state/lifecycle (`tenantOAuthProvidersBySessionId`, tenant selector consistency checks, tenant context hydration). This concentration increases coupling and regression risk.
 
 **Goal**: Move tenant session responsibilities into a dedicated service while keeping transport behavior unchanged.

--- a/docs/HTTP-TRANSPORT.md
+++ b/docs/HTTP-TRANSPORT.md
@@ -156,7 +156,9 @@ OAuth and metadata endpoints are scoped per profile when routing is enabled:
 Root protected resource metadata also supports a `resource` query parameter for profile selection:
 - `/.well-known/oauth-protected-resource/mcp?resource=http://host/profile/:profileId/mcp`
 
-If no default profile is configured, use the `resource` query parameter to resolve metadata.
+When profile routing is enabled without a default profile, the transport stores a short-lived `HttpOnly` profile-hint cookie after profile-scoped or `resource`-scoped discovery requests so follow-up root OAuth metadata requests stay pinned to the same profile even behind shared IP/user-agent pairs.
+
+If no default profile is configured, use a profile-scoped route or the `resource` query parameter before requesting root OAuth metadata.
 
 
 

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -253,6 +253,8 @@ When profile routing is enabled, you can select a profile with a `resource` quer
 /.well-known/oauth-protected-resource/mcp?resource=http://localhost:3003/profile/gitlab/mcp
 ```
 
+Without a default profile, the transport also issues a short-lived `HttpOnly` profile-hint cookie after profile-scoped or `resource`-scoped discovery so follow-up root OAuth metadata requests stay pinned to the same profile.
+
 ### OAuth Flow Endpoints
 
 - **`/oauth/authorize`** - Authorization endpoint (redirects to external OAuth provider)

--- a/src/transport/http-transport.test.ts
+++ b/src/transport/http-transport.test.ts
@@ -3757,7 +3757,7 @@ describeIfListen('HttpTransport', () => {
       await routingTransport.stop();
     });
 
-    it('serves root auth server metadata using profile hint', async () => {
+    it('serves root auth server metadata using profile hint cookie', async () => {
       const routingTransport = new HttpTransport(
         {
           host: '127.0.0.1',
@@ -3784,14 +3784,15 @@ describeIfListen('HttpTransport', () => {
       }));
 
       const routingApp = (routingTransport as any).app;
+      const agent = request.agent(routingApp);
 
       // Prime hint via profile route
-      await request(routingApp)
+      await agent
         .post('/profile/gitlab/mcp')
         .send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
         .ok(() => true);
 
-      const response = await request(routingApp).get('/.well-known/oauth-authorization-server');
+      const response = await agent.get('/.well-known/oauth-authorization-server');
 
       expect(response.status).toBe(200);
       expect(response.body.issuer).toContain('/profile/gitlab');
@@ -3799,6 +3800,110 @@ describeIfListen('HttpTransport', () => {
       expect(response.body.token_endpoint).toContain('/profile/gitlab/oauth/token');
 
       await routingTransport.stop();
+    });
+
+    it('isolates profile hints for clients sharing ip and user agent', async () => {
+      const routingTransport = new HttpTransport(
+        {
+          host: '127.0.0.1',
+          port: 0,
+          sessionTimeoutMs: 1800000,
+          heartbeatEnabled: false,
+          heartbeatIntervalMs: 30000,
+          metricsEnabled: false,
+          metricsPath: '/metrics',
+          profileRoutingEnabled: true,
+        },
+        logger
+      );
+      routingTransport.setProfileContextProvider(async (id) => ({
+        profileId: id,
+        oauthConfig: {
+          authorization_endpoint: `https://auth.example.com/${id}/oauth/authorize`,
+          token_endpoint: `https://auth.example.com/${id}/oauth/token`,
+          client_id: `${id}-client`,
+          client_secret: 'secret',
+          redirect_uri: 'http://localhost:3003/oauth/callback',
+          scopes: ['api'],
+        },
+      }));
+
+      const routingApp = (routingTransport as any).app;
+      const firstClient = request.agent(routingApp);
+      const secondClient = request.agent(routingApp);
+      const userAgent = 'shared-agent/1.0';
+
+      await firstClient
+        .post('/profile/gitlab/mcp')
+        .set('User-Agent', userAgent)
+        .send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+        .ok(() => true);
+
+      await secondClient
+        .post('/profile/github/mcp')
+        .set('User-Agent', userAgent)
+        .send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+        .ok(() => true);
+
+      const firstResponse = await firstClient
+        .get('/.well-known/oauth-authorization-server')
+        .set('User-Agent', userAgent);
+      const secondResponse = await secondClient
+        .get('/.well-known/oauth-authorization-server')
+        .set('User-Agent', userAgent);
+
+      expect(firstResponse.status).toBe(200);
+      expect(firstResponse.body.issuer).toContain('/profile/gitlab');
+      expect(secondResponse.status).toBe(200);
+      expect(secondResponse.body.issuer).toContain('/profile/github');
+
+      await routingTransport.stop();
+    });
+
+    it('expires profile hint cookies with the existing ttl', async () => {
+      vi.useFakeTimers();
+      const routingTransport = new HttpTransport(
+        {
+          host: '127.0.0.1',
+          port: 0,
+          sessionTimeoutMs: 1800000,
+          heartbeatEnabled: false,
+          heartbeatIntervalMs: 30000,
+          metricsEnabled: false,
+          metricsPath: '/metrics',
+          profileRoutingEnabled: true,
+        },
+        logger
+      );
+      routingTransport.setProfileContextProvider(async (id) => ({
+        profileId: id,
+        oauthConfig: {
+          authorization_endpoint: 'https://auth.example.com/oauth/authorize',
+          token_endpoint: 'https://auth.example.com/oauth/token',
+          client_id: 'client',
+          client_secret: 'secret',
+          redirect_uri: 'http://localhost:3003/oauth/callback',
+          scopes: ['api'],
+        },
+      }));
+
+      const routingApp = (routingTransport as any).app;
+      const agent = request.agent(routingApp);
+
+      await agent
+        .post('/profile/gitlab/mcp')
+        .send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+        .ok(() => true);
+
+      vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+
+      const response = await agent.get('/.well-known/oauth-authorization-server');
+
+      expect(response.status).toBe(404);
+      expect(response.body.message).toBe('OAuth metadata unavailable for requested resource');
+
+      await routingTransport.stop();
+      vi.useRealTimers();
     });
 
     it('forces profile prefix when resource query targets default profile path', async () => {

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -101,6 +101,11 @@ interface OAuthRequiredErrorResponse {
   };
 }
 
+interface ProfileHintEntry {
+  profileId: string;
+  lastSeen: number;
+}
+
 export class HttpTransport {
   private app: express.Application;
   private server: Server | https.Server | null = null;
@@ -113,8 +118,10 @@ export class HttpTransport {
   private profileStates: Map<string, ProfileRuntimeState> = new Map();
   private oauthRedirectHostCache: Map<string, string[]> = new Map();
   private warnedMissingOAuthRedirectEnvVars: Set<string> = new Set();
-  private profileHintsByClient: Map<string, { profileId: string; lastSeen: number }> = new Map();
+  private profileHintsByClient: Map<string, ProfileHintEntry> = new Map();
+  private profileHintsByToken: Map<string, ProfileHintEntry> = new Map();
   private static readonly PROFILE_HINT_TTL_MS = 10 * 60 * 1000;
+  private static readonly PROFILE_HINT_COOKIE_NAME = 'mcp4_profile_hint';
   private profileIndexProvider: (() => Promise<ListedProfileDetails[]>) | null = null;
   private ssrfValidator: SSRFValidator;
   private rawTenantConfig: HttpTenantsConfig | null;
@@ -330,11 +337,11 @@ export class HttpTransport {
     });
 
     // Capture profile hints for clients using profile routing
-    this.app.use((req: Request, _res: Response, next: NextFunction) => {
+    this.app.use((req: Request, res: Response, next: NextFunction) => {
       if (this.config.profileRoutingEnabled) {
         const profileId = this.resolveProfileIdFromPath(req.path);
         if (profileId) {
-          this.storeProfileHint(req, profileId);
+          this.storeProfileHint(req, res, profileId);
         }
       }
       next();
@@ -686,22 +693,90 @@ export class HttpTransport {
     return `${req.ip}|${userAgent}`;
   }
 
-  private storeProfileHint(req: Request, profileId: string): void {
-    const key = this.getClientHintKey(req);
-    this.profileHintsByClient.set(key, { profileId, lastSeen: Date.now() });
+  private parseCookieHeader(cookieHeader: string | undefined): Map<string, string> {
+    const cookies = new Map<string, string>();
+    if (!cookieHeader) {
+      return cookies;
+    }
+
+    for (const segment of cookieHeader.split(';')) {
+      const trimmed = segment.trim();
+      if (!trimmed) {
+        continue;
+      }
+      const separatorIndex = trimmed.indexOf('=');
+      if (separatorIndex <= 0) {
+        continue;
+      }
+      const name = trimmed.slice(0, separatorIndex).trim();
+      const value = trimmed.slice(separatorIndex + 1).trim();
+      if (!name) {
+        continue;
+      }
+      cookies.set(name, value);
+    }
+
+    return cookies;
   }
 
-  private resolveProfileIdFromHint(req: Request): string | null {
-    const key = this.getClientHintKey(req);
-    const hint = this.profileHintsByClient.get(key);
+  private getProfileHintToken(req: Request): string | null {
+    const cookies = this.parseCookieHeader(req.get('cookie'));
+    const token = cookies.get(HttpTransport.PROFILE_HINT_COOKIE_NAME);
+    return token && token.length > 0 ? token : null;
+  }
+
+  private getOrCreateProfileHintToken(req: Request): string {
+    return this.getProfileHintToken(req) ?? crypto.randomBytes(16).toString('hex');
+  }
+
+  private setProfileHintCookie(req: Request, res: Response, token: string): void {
+    const attributes = [
+      `${HttpTransport.PROFILE_HINT_COOKIE_NAME}=${token}`,
+      'Path=/',
+      'HttpOnly',
+      'SameSite=Lax',
+      `Max-Age=${Math.floor(HttpTransport.PROFILE_HINT_TTL_MS / 1000)}`,
+    ];
+
+    if (req.secure || req.get('x-forwarded-proto') === 'https') {
+      attributes.push('Secure');
+    }
+
+    res.append('Set-Cookie', attributes.join('; '));
+  }
+
+  private consumeProfileHint(map: Map<string, ProfileHintEntry>, key: string, now: number): string | null {
+    const hint = map.get(key);
     if (!hint) {
       return null;
     }
-    if (Date.now() - hint.lastSeen > HttpTransport.PROFILE_HINT_TTL_MS) {
-      this.profileHintsByClient.delete(key);
+    if (now - hint.lastSeen > HttpTransport.PROFILE_HINT_TTL_MS) {
+      map.delete(key);
       return null;
     }
     return hint.profileId;
+  }
+
+  private storeProfileHint(req: Request, res: Response, profileId: string): void {
+    const now = Date.now();
+    const clientKey = this.getClientHintKey(req);
+    const token = this.getOrCreateProfileHintToken(req);
+    const entry: ProfileHintEntry = { profileId, lastSeen: now };
+
+    this.profileHintsByClient.set(clientKey, entry);
+    this.profileHintsByToken.set(token, entry);
+    this.setProfileHintCookie(req, res, token);
+  }
+
+  private resolveProfileIdFromHint(req: Request): string | null {
+    const now = Date.now();
+    const token = this.getProfileHintToken(req);
+    if (token) {
+      return this.consumeProfileHint(this.profileHintsByToken, token, now);
+    }
+
+    const key = this.getClientHintKey(req);
+    return this.consumeProfileHint(this.profileHintsByClient, key, now);
   }
 
   private resolveProfileIdForOriginCheck(req: Request): string | null {
@@ -1320,7 +1395,7 @@ export class HttpTransport {
 
       (req as McpRequest).profileId = info.profileId;
       (req as McpRequest).forceProfilePrefix = info.forceProfilePrefix;
-      this.storeProfileHint(req, info.profileId);
+      this.storeProfileHint(req, res, info.profileId);
       next();
     };
 


### PR DESCRIPTION
## Summary
- isolate profile-routed OAuth metadata hints with a short-lived `HttpOnly` cookie
- keep the existing client-key fallback only for requests that do not present a hint cookie
- document the hint flow, add regression coverage, and remove the completed TODO item

## Root cause
`HttpTransport` keyed profile hints only by `req.ip` and `user-agent`. Distinct clients behind the same NAT/proxy with the same user agent could overwrite each other's hint and cause root OAuth metadata to resolve to the wrong profile.

## Changes made
- added a dedicated profile-hint cookie token path in `HttpTransport` and store/look up hint entries by that token first
- kept the legacy `ip|user-agent` key only as a compatibility fallback when no hint cookie is present
- set a short-lived `HttpOnly`/`SameSite=Lax` hint cookie from profile-scoped and `resource`-scoped discovery requests
- added regression tests for shared-IP/shared-user-agent isolation and TTL expiry of the hint cookie
- updated HTTP/OAuth docs, changelog, and removed the completed TODO entry

## Test coverage added/updated
- `npx vitest run src/transport/http-transport.test.ts --testNamePattern "profile hint"`
- `npx vitest run src/transport/http-transport.test.ts`
- `npm run typecheck`

## Risk assessment
Low. The change is narrowly scoped to profile hint association for profile-routed OAuth metadata, preserves current single-client behavior, keeps a compatibility fallback for clients without cookies, and adds focused regression coverage for the shared-client collision path.

Closes #159
