### PR TITLE
fix(security): allowlist HTTP schemes in SSRF validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Blocked dangerous URI schemes during URI validation to prevent XSS through attacker-controlled links and redirects.
+- Restricted shared SSRF validation to `http:` and `https:` URLs so outbound bootstrap/OAuth/proxy guards reject unsupported schemes before hostname or DNS checks.
 - Removed raw environment variable values from selected configuration error messages and added regression checks to prevent secret leakage in errors.
 - Hardened MCP Apps resource loading so `file_path` stays inside the profile directory after normalization and symlink resolution, while keeping `resources/read` output shape consistent across inline, file-backed, and fetch-backed resources.
 - Fixed HTTP single-profile startup to carry `enterprise_authorization` into transport runtime so enterprise JWT bearer exchange and authenticated initialization work outside profile-routing mode, with dedicated E2E coverage.

--- a/src/security/ssrf-validator.test.ts
+++ b/src/security/ssrf-validator.test.ts
@@ -31,9 +31,23 @@ describe('SSRFValidator', () => {
   });
 
   describe('validate', () => {
-    it('should allow valid public domains', async () => {
+    it('should allow valid public HTTP(S) domains', async () => {
       (lookup as any).mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
       await expect(validator.validate('http://example.com')).resolves.not.toThrow();
+      await expect(validator.validate('https://example.com')).resolves.not.toThrow();
+    });
+
+    it('should reject non-HTTP(S) URL schemes before hostname validation', async () => {
+      await expect(validator.validate('ftp://example.com')).rejects.toThrow(
+        "URL scheme not allowed: 'ftp:'"
+      );
+      await expect(validator.validate('file:///etc/passwd')).rejects.toThrow(
+        "URL scheme not allowed: 'file:'"
+      );
+      await expect(validator.validate('gopher://example.com')).rejects.toThrow(
+        "URL scheme not allowed: 'gopher:'"
+      );
+      expect(lookup).not.toHaveBeenCalled();
     });
 
     it('should block localhost by hostname', async () => {

--- a/src/security/ssrf-validator.ts
+++ b/src/security/ssrf-validator.ts
@@ -31,6 +31,13 @@ export class SSRFValidator {
    */
   async validate(url: string, options: SSRFOptions = {}): Promise<void> {
     const parsedUrl = new URL(url);
+    const protocol = parsedUrl.protocol.toLowerCase();
+
+    if (!ALLOWED_HTTP_PROTOCOLS.has(protocol)) {
+      this.logger.warn('SSRF blocked: URL scheme not allowed', { protocol, url });
+      throw new ValidationError(`URL scheme not allowed: '${protocol}'`);
+    }
+
     const hostnameRaw = parsedUrl.hostname.toLowerCase();
 
     // Remove brackets from IPv6 literals for checking
@@ -172,6 +179,8 @@ export class SSRFValidator {
     return IPV6_CIDR_BLOCKS.some(block => addr.match(block));
   }
 }
+
+const ALLOWED_HTTP_PROTOCOLS = new Set(['http:', 'https:']);
 
 const IPV4_CIDR_BLOCKS: Array<[ipaddr.IPv4, number]> = [
   '127.0.0.0/8', // loopback


### PR DESCRIPTION
## Summary
- reject non-HTTP(S) URLs at the start of shared SSRF validation
- preserve existing hostname/IP/DNS checks for supported HTTP(S) targets
- add regression coverage for unsupported schemes and HTTP(S) compatibility

## Root cause
`SSRFValidator.validate()` accepted any URL scheme that `new URL()` could parse, then moved directly into hostname and DNS validation. That left the shared outbound SSRF guard permissive for unsupported protocols instead of enforcing the repository's intended HTTP-oriented transport boundary up front.

## Changes made
- added a centralized `http:`/`https:` allowlist in `SSRFValidator`
- fail fast with a typed `ValidationError` and warning log when the scheme is unsupported
- added focused regression tests for `ftp:`, `file:`, and `gopher:` inputs plus explicit HTTP(S) success coverage
- updated the changelog with the SSRF hardening note

## Test coverage added/updated
- added non-HTTP(S) rejection coverage in `src/security/ssrf-validator.test.ts`
- expanded success coverage to assert both `http://example.com` and `https://example.com`
- ran `npx vitest run src/security/ssrf-validator.test.ts` before the fix to confirm the new regression test failed
- ran `npx vitest run src/security/ssrf-validator.test.ts src/tooling/proxy-executor-security.test.ts`
- ran `npm run typecheck`

## Risk assessment
Low. The change is narrowly scoped to the shared SSRF validator, keeps existing hostname/IP/DNS validation unchanged for supported HTTP(S) URLs, and only blocks unsupported schemes that fall outside the repository's outbound transport contract.

Closes #163
