### PR TITLE
fix(http): bound profile-routed runtime cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened MCP Apps resource loading so `file_path` stays inside the profile directory after normalization and symlink resolution, while keeping `resources/read` output shape consistent across inline, file-backed, and fetch-backed resources.
 - Fixed HTTP single-profile startup to carry `enterprise_authorization` into transport runtime so enterprise JWT bearer exchange and authenticated initialization work outside profile-routing mode, with dedicated E2E coverage.
 - Clarified and locked runtime enterprise authorization behavior so `required` mode enforces trusted enterprise-issued bearer tokens, `optional` mode stays backward-compatible, tool-category policy covers both listing and execution, and invalid env-backed values fail during profile loading.
+- Bounded profile-routed `HttpTransport` runtime caches with inactive-entry TTL pruning and deterministic eviction while preserving active-session profiles and OAuth metadata behavior.
 
 ## [0.5.7] - 2026-03-03
 

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -89,6 +89,11 @@ interface ProfileRuntimeState {
   tenantOAuthProvidersBySessionId: Map<string, ExternalOAuthProvider>;
 }
 
+interface OAuthRedirectHostCacheEntry {
+  patterns: string[];
+  lastAccessedAt: number;
+}
+
 interface RequestWithStartTime extends Request {
   startTime?: number;
 }
@@ -102,6 +107,10 @@ interface OAuthRequiredErrorResponse {
 }
 
 export class HttpTransport {
+  private static readonly PROFILE_HINT_TTL_MS = 10 * 60 * 1000;
+  private static readonly PROFILE_RUNTIME_CACHE_TTL_MS = 10 * 60 * 1000;
+  private static readonly PROFILE_RUNTIME_CACHE_MAX_ENTRIES = 64;
+
   private app: express.Application;
   private server: Server | https.Server | null = null;
   private config: HttpTransportConfig;
@@ -111,10 +120,10 @@ export class HttpTransport {
   private messageHandler: ((message: unknown, sessionId?: string, profileId?: string) => Promise<unknown>) | null = null;
   private profileContextProvider: ((profileId: string) => Promise<HttpProfileContext | null>) | null = null;
   private profileStates: Map<string, ProfileRuntimeState> = new Map();
-  private oauthRedirectHostCache: Map<string, string[]> = new Map();
+  private profileStateLastAccess: Map<string, number> = new Map();
+  private oauthRedirectHostCache: Map<string, OAuthRedirectHostCacheEntry> = new Map();
   private warnedMissingOAuthRedirectEnvVars: Set<string> = new Set();
   private profileHintsByClient: Map<string, { profileId: string; lastSeen: number }> = new Map();
-  private static readonly PROFILE_HINT_TTL_MS = 10 * 60 * 1000;
   private profileIndexProvider: (() => Promise<ListedProfileDetails[]>) | null = null;
   private ssrfValidator: SSRFValidator;
   private rawTenantConfig: HttpTenantsConfig | null;
@@ -210,6 +219,129 @@ export class HttpTransport {
 
   setProfileIndexProvider(provider: (() => Promise<ListedProfileDetails[]>) | null): void {
     this.profileIndexProvider = provider;
+  }
+
+  private touchProfileState(profileId: string, now: number = Date.now()): void {
+    this.profileStateLastAccess.set(profileId, now);
+  }
+
+  private hasActiveProfileSessions(profileId: string): boolean {
+    return (this.profileStates.get(profileId)?.sessions.size ?? 0) > 0;
+  }
+
+  private deleteProfileState(profileId: string): void {
+    this.profileStates.delete(profileId);
+    this.profileStateLastAccess.delete(profileId);
+  }
+
+  private pruneInactiveProfileStates(now: number = Date.now()): void {
+    for (const [profileId, lastAccessedAt] of this.profileStateLastAccess.entries()) {
+      if (!this.profileStates.has(profileId)) {
+        this.profileStateLastAccess.delete(profileId);
+        continue;
+      }
+      if (this.hasActiveProfileSessions(profileId)) {
+        continue;
+      }
+      if (now - lastAccessedAt > HttpTransport.PROFILE_RUNTIME_CACHE_TTL_MS) {
+        this.deleteProfileState(profileId);
+      }
+    }
+  }
+
+  private evictInactiveProfileStatesIfNeeded(): void {
+    while (this.profileStates.size > HttpTransport.PROFILE_RUNTIME_CACHE_MAX_ENTRIES) {
+      let oldestInactiveProfileId: string | null = null;
+      let oldestInactiveAccess = Number.POSITIVE_INFINITY;
+
+      for (const [profileId, lastAccessedAt] of this.profileStateLastAccess.entries()) {
+        if (this.hasActiveProfileSessions(profileId)) {
+          continue;
+        }
+        if (lastAccessedAt < oldestInactiveAccess) {
+          oldestInactiveAccess = lastAccessedAt;
+          oldestInactiveProfileId = profileId;
+        }
+      }
+
+      if (!oldestInactiveProfileId) {
+        return;
+      }
+
+      this.deleteProfileState(oldestInactiveProfileId);
+    }
+  }
+
+  private cacheProfileState(state: ProfileRuntimeState): ProfileRuntimeState {
+    const now = Date.now();
+    this.pruneInactiveProfileStates(now);
+    this.profileStates.set(state.profileId, state);
+    this.touchProfileState(state.profileId, now);
+    this.evictInactiveProfileStatesIfNeeded();
+    return state;
+  }
+
+  private getCachedProfileState(profileId: string): ProfileRuntimeState | undefined {
+    this.pruneInactiveProfileStates();
+    const state = this.profileStates.get(profileId);
+    if (!state) {
+      this.profileStateLastAccess.delete(profileId);
+      return undefined;
+    }
+    this.touchProfileState(profileId);
+    return state;
+  }
+
+  private hasCachedOAuthRedirectHosts(profileId: string): boolean {
+    this.pruneInactiveOAuthRedirectHostCache();
+    const cached = this.oauthRedirectHostCache.get(profileId);
+    if (!cached) {
+      return false;
+    }
+    cached.lastAccessedAt = Date.now();
+    return true;
+  }
+
+  private cacheOAuthRedirectHosts(profileId: string, patterns: string[]): void {
+    const now = Date.now();
+    this.pruneInactiveOAuthRedirectHostCache(now);
+    this.oauthRedirectHostCache.set(profileId, { patterns, lastAccessedAt: now });
+    this.evictInactiveOAuthRedirectHostsIfNeeded();
+  }
+
+  private pruneInactiveOAuthRedirectHostCache(now: number = Date.now()): void {
+    for (const [profileId, entry] of this.oauthRedirectHostCache.entries()) {
+      if (this.hasActiveProfileSessions(profileId)) {
+        entry.lastAccessedAt = now;
+        continue;
+      }
+      if (now - entry.lastAccessedAt > HttpTransport.PROFILE_RUNTIME_CACHE_TTL_MS) {
+        this.oauthRedirectHostCache.delete(profileId);
+      }
+    }
+  }
+
+  private evictInactiveOAuthRedirectHostsIfNeeded(): void {
+    while (this.oauthRedirectHostCache.size > HttpTransport.PROFILE_RUNTIME_CACHE_MAX_ENTRIES) {
+      let oldestInactiveProfileId: string | null = null;
+      let oldestInactiveAccess = Number.POSITIVE_INFINITY;
+
+      for (const [profileId, entry] of this.oauthRedirectHostCache.entries()) {
+        if (this.hasActiveProfileSessions(profileId)) {
+          continue;
+        }
+        if (entry.lastAccessedAt < oldestInactiveAccess) {
+          oldestInactiveAccess = entry.lastAccessedAt;
+          oldestInactiveProfileId = profileId;
+        }
+      }
+
+      if (!oldestInactiveProfileId) {
+        return;
+      }
+
+      this.oauthRedirectHostCache.delete(oldestInactiveProfileId);
+    }
   }
 
   /**
@@ -431,7 +563,7 @@ export class HttpTransport {
   }
 
   private async getProfileState(profileId: string): Promise<ProfileRuntimeState | null> {
-    const existing = this.profileStates.get(profileId);
+    const existing = this.getCachedProfileState(profileId);
     if (existing) {
       return existing;
     }
@@ -501,8 +633,7 @@ export class HttpTransport {
       this.logger.info('HTTP tenant configuration enabled', { profileId, tenantCount: tenantIndex.byTenantId.size });
     }
 
-    this.profileStates.set(profileId, state);
-    return state;
+    return this.cacheProfileState(state);
   }
 
   private hasTrustedEnterpriseToken(
@@ -595,6 +726,7 @@ export class HttpTransport {
     const hosts = new Set<string>();
     const defaultProfileId = this.getDefaultProfileId() ?? 'default';
 
+    this.pruneInactiveProfileStates();
     for (const state of this.profileStates.values()) {
       const redirectUri = state.oauthProvider?.redirectUri;
       if (!redirectUri) {
@@ -614,8 +746,9 @@ export class HttpTransport {
       }
     }
 
-    for (const patterns of this.oauthRedirectHostCache.values()) {
-      for (const pattern of patterns) {
+    this.pruneInactiveOAuthRedirectHostCache();
+    for (const entry of this.oauthRedirectHostCache.values()) {
+      for (const pattern of entry.patterns) {
         hosts.add(pattern);
       }
     }
@@ -726,18 +859,18 @@ export class HttpTransport {
       return;
     }
 
-    if (this.oauthRedirectHostCache.has(profileId)) {
+    if (this.hasCachedOAuthRedirectHosts(profileId)) {
       return;
     }
 
     try {
       const context = await this.profileContextProvider(profileId);
       if (!context?.oauthConfig) {
-        this.oauthRedirectHostCache.set(profileId, []);
+        this.cacheOAuthRedirectHosts(profileId, []);
         return;
       }
       const patterns = this.extractRedirectHostPatterns(context.oauthConfig, profileId);
-      this.oauthRedirectHostCache.set(profileId, patterns);
+      this.cacheOAuthRedirectHosts(profileId, patterns);
     } catch (error) {
       if (error instanceof ConfigurationError && error.message === 'Profile not found') {
         return;
@@ -3414,6 +3547,9 @@ export class HttpTransport {
       }
       
       profileState.sessions.delete(sessionId);
+      this.touchProfileState(profileState.profileId);
+      this.pruneInactiveProfileStates();
+      this.pruneInactiveOAuthRedirectHostCache();
       this.logger.info('Session destroyed', { profileId: profileState.profileId, sessionId });
       
       // Notify session destruction listeners (for cleanup in MCPServer)
@@ -3563,6 +3699,9 @@ export class HttpTransport {
         this.destroySession(state, entry.sessionId);
       }
     }
+
+    this.pruneInactiveProfileStates(now);
+    this.pruneInactiveOAuthRedirectHostCache(now);
 
     if (expiredSessions.length > 0) {
       this.logger.info('Cleaned up expired sessions', { count: expiredSessions.length });

--- a/src/transport/http-transport.unit.test.ts
+++ b/src/transport/http-transport.unit.test.ts
@@ -705,7 +705,10 @@ describe('HttpTransport unit', () => {
         oauthTokensByAccessToken: new Map(),
         sessions: new Map(),
       });
-      (localTransport as any).oauthRedirectHostCache.set('cached', ['cached.example.com']);
+      (localTransport as any).oauthRedirectHostCache.set('cached', {
+        patterns: ['cached.example.com'],
+        lastAccessedAt: Date.now(),
+      });
 
       const hosts = (localTransport as any).getOAuthRedirectHostPatterns();
       expect(hosts).toContain('state.example.com');
@@ -822,7 +825,7 @@ describe('HttpTransport unit', () => {
 
       const primer = (localTransport as any).primeOAuthRedirectHosts.bind(localTransport);
       await primer('empty');
-      expect((localTransport as any).oauthRedirectHostCache.get('empty')).toEqual([]);
+      expect((localTransport as any).oauthRedirectHostCache.get('empty')?.patterns).toEqual([]);
 
       await primer('missing');
       await primer('boom');
@@ -833,6 +836,109 @@ describe('HttpTransport unit', () => {
 
       warnSpy.mockRestore();
       await localTransport.stop();
+    });
+
+    it('evicts the oldest inactive profile runtime state when the cache reaches capacity', async () => {
+      const localTransport = new HttpTransport(
+        {
+          host: '127.0.0.1',
+          port: 0,
+          sessionTimeoutMs: 1800000,
+          heartbeatEnabled: false,
+          heartbeatIntervalMs: 30000,
+          metricsEnabled: false,
+          metricsPath: '/metrics',
+          profileRoutingEnabled: true,
+        } as any,
+        logger
+      );
+
+      localTransport.setProfileContextProvider(async (profileId) => ({ profileId }));
+      const getProfileState = (localTransport as any).getProfileState.bind(localTransport);
+      const maxEntries = (HttpTransport as any).PROFILE_RUNTIME_CACHE_MAX_ENTRIES;
+
+      for (let index = 0; index <= maxEntries; index += 1) {
+        await getProfileState(`profile-${index}`);
+      }
+
+      expect((localTransport as any).profileStates.size).toBe(maxEntries);
+      expect((localTransport as any).profileStates.has('profile-0')).toBe(false);
+      expect((localTransport as any).profileStates.has(`profile-${maxEntries}`)).toBe(true);
+
+      await localTransport.stop();
+    });
+
+    it('keeps active-session profile runtime state resident during cache eviction', async () => {
+      const localTransport = new HttpTransport(
+        {
+          host: '127.0.0.1',
+          port: 0,
+          sessionTimeoutMs: 1800000,
+          heartbeatEnabled: false,
+          heartbeatIntervalMs: 30000,
+          metricsEnabled: false,
+          metricsPath: '/metrics',
+          profileRoutingEnabled: true,
+        } as any,
+        logger
+      );
+
+      localTransport.setProfileContextProvider(async (profileId) => ({ profileId }));
+      const getProfileState = (localTransport as any).getProfileState.bind(localTransport);
+      const createSession = (localTransport as any).createSession.bind(localTransport);
+      const maxEntries = (HttpTransport as any).PROFILE_RUNTIME_CACHE_MAX_ENTRIES;
+
+      const activeState = await getProfileState('active');
+      createSession(activeState);
+
+      for (let index = 0; index < maxEntries; index += 1) {
+        await getProfileState(`profile-${index}`);
+      }
+
+      expect((localTransport as any).profileStates.size).toBe(maxEntries);
+      expect((localTransport as any).profileStates.has('active')).toBe(true);
+      expect((localTransport as any).profileStates.has('profile-0')).toBe(false);
+
+      await localTransport.stop();
+    });
+
+    it('prunes stale redirect-host cache entries before caching a new profile', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-15T00:00:00.000Z'));
+
+      const localTransport = new HttpTransport(
+        {
+          host: '127.0.0.1',
+          port: 0,
+          sessionTimeoutMs: 1800000,
+          heartbeatEnabled: false,
+          heartbeatIntervalMs: 30000,
+          metricsEnabled: false,
+          metricsPath: '/metrics',
+          profileRoutingEnabled: true,
+        } as any,
+        logger
+      );
+
+      localTransport.setProfileContextProvider(async (profileId) => ({
+        profileId,
+        oauthConfig: {
+          redirect_uri: `https://${profileId}.example.com/callback`,
+        },
+      }));
+
+      const primeOAuthRedirectHosts = (localTransport as any).primeOAuthRedirectHosts.bind(localTransport);
+      const cacheTtlMs = (HttpTransport as any).PROFILE_RUNTIME_CACHE_TTL_MS;
+
+      await primeOAuthRedirectHosts('alpha');
+      vi.advanceTimersByTime(cacheTtlMs + 1);
+      await primeOAuthRedirectHosts('beta');
+
+      expect((localTransport as any).oauthRedirectHostCache.has('alpha')).toBe(false);
+      expect((localTransport as any).oauthRedirectHostCache.has('beta')).toBe(true);
+
+      await localTransport.stop();
+      vi.useRealTimers();
     });
 
     it('isAllowedOriginForRequest returns false when routing disabled or no profile id', async () => {


### PR DESCRIPTION
## Summary
- bound profile-routed `HttpTransport` runtime caches with inactive-entry TTL pruning and deterministic max-size eviction
- keep active-session profile runtime state resident while allowing cold profile state and redirect-host caches to be recreated on demand
- add focused transport regression coverage and update the changelog

## Root cause
`HttpTransport` memoized profile-routed runtime state and OAuth redirect-host patterns in process-wide maps with no pruning or capacity limit. In long-running profile-routing deployments, distinct one-off profiles could accumulate indefinitely even after their sessions went idle.

## Changes made
- added shared cache-lifecycle helpers for profile runtime state and OAuth redirect-host caches
- tracked last-access timestamps for cached profile runtime state and redirect-host entries
- pruned inactive entries after a conservative TTL and applied deterministic oldest-inactive eviction when caches exceed their cap
- preserved active-session profile runtime state during eviction and kept OAuth metadata behavior intact for hot profiles
- updated the changelog with the runtime-cache hardening note

## Test coverage added/updated
- added regression coverage for oldest-inactive profile-state eviction when the runtime cache reaches capacity
- added regression coverage proving active-session profile runtime state is not evicted
- added regression coverage for stale redirect-host cache pruning before caching a new profile
- ran `npx vitest run src/transport/http-transport.unit.test.ts --testNamePattern "evicts the oldest inactive profile runtime state when the cache reaches capacity|keeps active-session profile runtime state resident during cache eviction|prunes stale redirect-host cache entries before caching a new profile|collects OAuth redirect host patterns from states, config, and cache|primeOAuthRedirectHosts caches empty configs and handles errors"`
- ran `npx vitest run src/transport/http-transport.unit.test.ts src/transport/http-transport.test.ts`
- ran `npm run typecheck`

## Risk assessment
Low. The change is narrowly scoped to in-memory profile-routed cache bookkeeping, only evicts inactive entries, preserves active-session profile state, and adds focused regression coverage around the new pruning and eviction paths.

Closes #165
