### PR TITLE
refactor(tool-filter): share service factory wiring

### DIFF
--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -58,13 +58,8 @@ import { NamingStrategy, type OperationForNaming } from '../core/naming.js';
 import { isSafePropertyName } from '../validation/validation-utils.js';
 import {
   ToolFilterService,
-  EnvConfigParser,
-  HeaderConfigParser,
-  RegexCompiler,
-  RegexValidator,
   OperationClassifier,
-  OpenAPIOperationResolver,
-  OperationDetector,
+  createToolFilterService,
   applySessionToolFilter,
   type SessionToolFilterCompat as SessionToolFilter,
   type SessionToolFilterRequest,
@@ -2276,22 +2271,10 @@ export class MCPServer {
 
     // Initialize ToolFilterService if not already done
     if (!this.toolFilterService) {
-      const validator = new RegexValidator();
-      const compiler = new RegexCompiler(validator);
-      const envParser = new EnvConfigParser(compiler);
-      const headerParser = new HeaderConfigParser(compiler);
-      
-      // Create OperationDetector for category filtering
-      const classifier = new OperationClassifier();
-      const resolver = new OpenAPIOperationResolver(this.parser);
-      const detector = new OperationDetector(classifier, resolver);
-      
-      this.toolFilterService = new ToolFilterService(
-        envParser,
-        headerParser,
-        this.logger,
-        detector
-      );
+      this.toolFilterService = createToolFilterService({
+        logger: this.logger,
+        parser: this.parser,
+      });
     }
 
     const originalTools = this.profile.tools;

--- a/src/tool-filter/index.ts
+++ b/src/tool-filter/index.ts
@@ -30,6 +30,10 @@ export { HeaderConfigParser } from './config/header-config-parser.js';
 
 // Integration service
 export { ToolFilterService } from './integration/tool-filter-service.js';
+export {
+  createToolFilterService,
+  type CreateToolFilterServiceOptions,
+} from './integration/tool-filter-service-factory.js';
 
 // Utilities
 export { normalizeToolName } from './utils.js';

--- a/src/tool-filter/integration/tool-filter-service-factory.test.ts
+++ b/src/tool-filter/integration/tool-filter-service-factory.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ToolDefinition } from '../../types/profile.js';
+import { createToolFilterService } from './tool-filter-service-factory.js';
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+describe('createToolFilterService', () => {
+  const tools: ToolDefinition[] = [
+    {
+      name: 'list_users',
+      description: 'List users',
+      parameters: {},
+      operations: { list: 'listUsers' },
+    },
+    {
+      name: 'delete_user',
+      description: 'Delete user',
+      parameters: {},
+      operations: { delete: 'deleteUser' },
+    },
+  ];
+
+  it('supports exact-name filtering without an OpenAPI parser', () => {
+    const service = createToolFilterService({ logger: mockLogger as any });
+
+    const result = service.applySessionFilter(tools, 'delete_user');
+
+    expect(result.allowedToolNames).toEqual(new Set(['delete_user']));
+  });
+
+  it('enables category filtering when an OpenAPI parser is provided', () => {
+    const parser = {
+      getOperation: vi.fn((operationId: string) => {
+        if (operationId === 'listUsers') {
+          return { method: 'get', parameters: [] };
+        }
+        if (operationId === 'deleteUser') {
+          return { method: 'delete', parameters: [] };
+        }
+        return undefined;
+      }),
+      getPath: vi.fn(),
+    };
+
+    const service = createToolFilterService({
+      logger: mockLogger as any,
+      parser: parser as any,
+    });
+
+    const result = service.applySessionFilter(tools, '_allow_list');
+
+    expect(result.allowedToolNames).toEqual(new Set(['list_users']));
+  });
+});

--- a/src/tool-filter/integration/tool-filter-service-factory.ts
+++ b/src/tool-filter/integration/tool-filter-service-factory.ts
@@ -1,0 +1,34 @@
+import type { Logger } from '../../core/logger.js';
+import type { OpenAPIParser } from '../../openapi/openapi-parser.js';
+import { EnvConfigParser } from '../config/env-config-parser.js';
+import { HeaderConfigParser } from '../config/header-config-parser.js';
+import { ToolFilterService } from './tool-filter-service.js';
+import { OperationClassifier } from '../operation/operation-classifier.js';
+import { OperationDetector } from '../operation/operation-detector.js';
+import { OpenAPIOperationResolver } from '../operation/operation-resolver.js';
+import { RegexCompiler } from '../regex/regex-compiler.js';
+import { RegexValidator } from '../regex/regex-validator.js';
+
+export interface CreateToolFilterServiceOptions {
+  logger: Logger;
+  parser?: OpenAPIParser;
+}
+
+export function createToolFilterService({
+  logger,
+  parser,
+}: CreateToolFilterServiceOptions): ToolFilterService {
+  const validator = new RegexValidator();
+  const compiler = new RegexCompiler(validator);
+  const envParser = new EnvConfigParser(compiler);
+  const headerParser = new HeaderConfigParser(compiler);
+  const detector = parser ? createOperationDetector(parser) : undefined;
+
+  return new ToolFilterService(envParser, headerParser, logger, detector);
+}
+
+function createOperationDetector(parser: OpenAPIParser): OperationDetector {
+  const classifier = new OperationClassifier();
+  const resolver = new OpenAPIOperationResolver(parser);
+  return new OperationDetector(classifier, resolver);
+}

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -54,13 +54,7 @@ import {
 import { mergeFilteringRules, parseFilteringHeader, normalizeFilteringHeaderValue } from '../core/filtering.js';
 import {
   ToolFilterService,
-  EnvConfigParser,
-  HeaderConfigParser,
-  RegexCompiler,
-  RegexValidator,
-  OperationClassifier,
-  OpenAPIOperationResolver,
-  OperationDetector,
+  createToolFilterService,
   normalizeToolFilterHeaderValue,
   parseSessionToolFilterHeader,
 } from '../tool-filter/index.js';
@@ -2507,25 +2501,10 @@ export class HttpTransport {
    */
   private getToolFilterService(profileState: ProfileRuntimeState): ToolFilterService {
     if (!profileState.toolFilterService) {
-      const validator = new RegexValidator();
-      const compiler = new RegexCompiler(validator);
-      const envParser = new EnvConfigParser(compiler);
-      const headerParser = new HeaderConfigParser(compiler);
-      
-      // Create OperationDetector for category filtering (if parser available)
-      let detector: OperationDetector | undefined;
-      if (profileState.context.parser) {
-        const classifier = new OperationClassifier();
-        const resolver = new OpenAPIOperationResolver(profileState.context.parser);
-        detector = new OperationDetector(classifier, resolver);
-      }
-      
-      profileState.toolFilterService = new ToolFilterService(
-        envParser,
-        headerParser,
-        this.logger,
-        detector
-      );
+      profileState.toolFilterService = createToolFilterService({
+        logger: this.logger,
+        parser: profileState.context.parser,
+      });
     }
     return profileState.toolFilterService;
   }


### PR DESCRIPTION
## Summary
- extract shared `ToolFilterService` construction into one typed factory under `src/tool-filter/integration`
- reuse that factory from both `MCPServer` and `HttpTransport` while preserving lazy initialization behavior
- add focused regression coverage for parser-backed and parser-free factory variants

## Root cause
`MCPServer` and `HttpTransport` each assembled the same `ToolFilterService` dependency graph inline. That duplicated wiring across two runtime entry points and increased drift risk whenever regex parsing, detector wiring, or tool-filter defaults changed in only one path.

## Changes made
- added `createToolFilterService(...)` and a small internal detector helper in `src/tool-filter/integration/tool-filter-service-factory.ts`
- exported the shared factory from `src/tool-filter/index.ts`
- updated `MCPServer.applyGlobalToolFiltering()` to initialize its service through the shared factory
- updated `HttpTransport.getToolFilterService()` to initialize per-profile services through the same shared factory while preserving optional parser behavior
- kept all existing filtering semantics and caching/lazy-init behavior unchanged

## Test coverage added/updated
- added `src/tool-filter/integration/tool-filter-service-factory.test.ts`
- verified the new factory test failed first because the module did not exist yet
- ran `npx vitest run src/tool-filter/integration/tool-filter-service-factory.test.ts`
- ran `npx vitest run src/tool-filter/integration/tool-filter-service-factory.test.ts src/tool-filter/integration/tool-filter-service.test.ts src/transport/http-transport.unit.test.ts src/mcp/mcp-server.test.ts`
- ran `npm run typecheck`

## Risk assessment
Low. This is a narrow deduplication refactor that preserves existing call-site behavior, keeps the parser optional for HTTP profile states, and adds focused regression coverage around both supported construction paths.

Closes #169
