### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing Correlation IDs in 500 API responses

### DIFF
--- a/src/auth/oauth-provider.test.ts
+++ b/src/auth/oauth-provider.test.ts
@@ -1695,7 +1695,7 @@ describe('ExternalOAuthProvider', () => {
       await provider.handleCallback(mockReq, mockRes);
 
       expect(mockRes.status).toHaveBeenCalledWith(500);
-      expect(mockRes.send).toHaveBeenCalledWith('Internal Server Error during token exchange');
+      expect(mockRes.send).toHaveBeenCalledWith(expect.stringMatching(/^Internal error \(correlation ID: .+\)$/));
     });
   });
 

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -32,6 +32,7 @@ import { OAUTH_CLEANUP, OAUTH_PATHS, PROXY_CREDENTIALS } from '../core/constants
 import { escapeHtmlSafe } from '../validation/validation-utils.js';
 import { SSRFValidator } from '../security/ssrf-validator.js';
 import { parseOAuthMetadataEndpoints } from './oauth-metadata.js';
+import { generateCorrelationId } from '../core/errors.js';
 import { InMemoryClientsStore } from './client-store/in-memory-clients-store.js';
 export { InMemoryClientsStore };
 export type { InMemoryClientsStoreOptions } from './client-store/types.js';
@@ -723,8 +724,9 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
         res.redirect(clientUrl.toString());
 
     } catch (err) {
-        this.logger.error('Callback handling failed', err as Error);
-        res.status(500).send('Internal Server Error during token exchange');
+        const correlationId = generateCorrelationId();
+        this.logger.error('Callback handling failed', err as Error, { correlationId });
+        res.status(500).send(`Internal error (correlation ID: ${correlationId})`);
     }
   }
 

--- a/src/transport/http-transport-security.test.ts
+++ b/src/transport/http-transport-security.test.ts
@@ -692,7 +692,7 @@ describe('HttpTransport security behavior (no listen)', () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(500);
-    expect(String(res.body)).toContain('OAuth authorization failed');
+    expect(String(res.body)).toContain('Internal error (correlation ID:');
 
     await transport.stop();
   });
@@ -1378,7 +1378,7 @@ describe('HttpTransport security behavior (no listen)', () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(500);
-    expect(String(res.body)).toContain('OAuth callback failed');
+    expect(String(res.body)).toContain('Internal error (correlation ID:');
 
     await transport.stop();
   });
@@ -1592,7 +1592,8 @@ describe('HttpTransport security behavior (no listen)', () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(500);
-    expect(res.body).toMatchObject({ error: 'server_error', error_description: 'Registration failed' });
+    expect(res.body).toMatchObject({ error: 'server_error' });
+    expect(String((res.body as any).error_description)).toContain('Internal error (correlation ID:');
 
     await transport.stop();
   });
@@ -1724,7 +1725,8 @@ describe('HttpTransport security behavior (no listen)', () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(500);
-    expect(res.body).toMatchObject({ error: 'server_error', error_description: 'Registration failed' });
+    expect(res.body).toMatchObject({ error: 'server_error' });
+    expect(String((res.body as any).error_description)).toContain('Internal error (correlation ID:');
 
     await transport.stop();
   });

--- a/src/transport/http-transport.test.ts
+++ b/src/transport/http-transport.test.ts
@@ -2340,7 +2340,7 @@ describeIfListen('HttpTransport', () => {
         .query({ code: 'test-code' });
 
       expect(response.status).toBe(500);
-      expect(response.text).toBe('OAuth callback failed');
+      expect(response.text).toMatch(/^Internal error \(correlation ID: .+\)$/);
     });
   });
 

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -1617,10 +1617,11 @@ export class HttpTransport {
     try {
       profiles = await this.profileIndexProvider();
     } catch (error) {
-      this.logger.error('Failed to load profile index', error instanceof Error ? error : new Error(String(error)));
+      const correlationId = generateCorrelationId();
+      this.logger.error('Failed to load profile index', error instanceof Error ? error : new Error(String(error)), { correlationId });
       res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({
         error: 'Internal Server Error',
-        message: 'Failed to load profile index',
+        message: `Internal error (correlation ID: ${correlationId})`,
       });
       return;
     }
@@ -1806,8 +1807,9 @@ export class HttpTransport {
 
       await profileState.oauthProvider.authorize(client, params, res);
     } catch (error) {
-      this.logger.error('OAuth authorize error', error instanceof Error ? error : new Error(String(error)));
-      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send('OAuth authorization failed');
+      const correlationId = generateCorrelationId();
+      this.logger.error('OAuth authorize error', error instanceof Error ? error : new Error(String(error)), { correlationId });
+      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send(`Internal error (correlation ID: ${correlationId})`);
     }
   }
 
@@ -2052,9 +2054,10 @@ export class HttpTransport {
 
       await profileState.oauthProvider.handleCallback(req, res);
     } catch (error) {
-      this.logger.error('OAuth callback error', error instanceof Error ? error : new Error(String(error)));
+      const correlationId = generateCorrelationId();
+      this.logger.error('OAuth callback error', error instanceof Error ? error : new Error(String(error)), { correlationId });
       if (!res.headersSent) {
-        res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send('OAuth callback failed');
+        res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send(`Internal error (correlation ID: ${correlationId})`);
       }
     }
   }
@@ -2088,8 +2091,9 @@ export class HttpTransport {
       };
       res.json(buildAuthorizationServerMetadata(metadata, profileState.context.enterpriseAuthorization));
     } catch (error) {
-      this.logger.error('OAuth authorization server metadata error', error instanceof Error ? error : new Error(String(error)));
-      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send('OAuth metadata failed');
+      const correlationId = generateCorrelationId();
+      this.logger.error('OAuth authorization server metadata error', error instanceof Error ? error : new Error(String(error)), { correlationId });
+      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send(`Internal error (correlation ID: ${correlationId})`);
     }
   }
 
@@ -2155,8 +2159,9 @@ export class HttpTransport {
         return;
       }
 
-      this.logger.error('Client registration failed', error instanceof Error ? error : new Error(String(error)));
-      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({ error: 'server_error', error_description: 'Registration failed' });
+      const correlationId = generateCorrelationId();
+      this.logger.error('Client registration failed', error instanceof Error ? error : new Error(String(error)), { correlationId });
+      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({ error: 'server_error', error_description: `Internal error (correlation ID: ${correlationId})` });
     }
   }
 
@@ -2665,7 +2670,9 @@ export class HttpTransport {
       // If contains requests, process and return response
       if (messageType === 'request') {
         if (!this.messageHandler) {
-          res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({ error: 'Internal Server Error', message: 'Message handler not configured' });
+          const correlationId = generateCorrelationId();
+          this.logger.error('Message handler not configured', new Error('Message handler not configured'), { correlationId });
+          res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({ error: 'Internal Server Error', message: `Internal error (correlation ID: ${correlationId})` });
           return;
         }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Several catch blocks mapping to 500 Internal Server Error in the `HttpTransport` and `ExternalOAuthProvider` did not generate or log a correlation ID when responding to clients, violating the security guideline from `.jules/sentinel.md` to map internal errors to a unique ID for traceablity.
🎯 Impact: Inability to trace ambiguous client errors to specific internal errors/stacktraces, making debugging or auditing security incidents difficult. Some implementations could be prone to leaking details in the future without this explicit masking.
🔧 Fix: Used the imported `generateCorrelationId()` function across all `res.status(500)` calls. Logged the correlation ID into the logger contexts and responded to clients with a generic "Internal error (correlation ID: <id>)" message.
✅ Verification: Ran `npm run typecheck` and updated relevant unit tests verifying string matching of `Internal error`.

---
*PR created automatically by Jules for task [16968302615795037413](https://jules.google.com/task/16968302615795037413) started by @davidruzicka*