### PR TITLE
refactor(automation): remove runtime maxItems alias

### DIFF
--- a/scripts/github-agent-runtime.test.ts
+++ b/scripts/github-agent-runtime.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import {
+  listOpenPullRequests,
+  listRecentIssues,
   mapIssueSummaryToProposalCandidate,
   mapPullRequestSummaryToProposalCandidate,
   readIssueRuntimeConfig,
 } from './github-agent-runtime.js';
 
 describe('github-agent-runtime config', () => {
-  it('prefers MAX_CANDIDATES and falls back to legacy proposal-intake bounds', () => {
+  it('prefers MAX_CANDIDATES and falls back to legacy proposal-intake bounds without exposing maxItems', () => {
     const defaults = {
       lookbackHours: 72,
       maxCandidates: 10,
@@ -19,25 +21,123 @@ describe('github-agent-runtime config', () => {
       PROPOSAL_INTAKE_MAX_CANDIDATES: '7',
       PROPOSAL_INTAKE_MAX_ISSUES: '8',
       PROPOSAL_INTAKE_MAX_ITEMS: '9',
-    }, 'PROPOSAL_INTAKE', defaults).maxCandidates).toBe(7);
+    }, 'PROPOSAL_INTAKE', defaults)).toMatchObject({ maxCandidates: 7 });
 
     expect(readIssueRuntimeConfig({
       GITHUB_REPOSITORY: 'davidruzicka/mcp4openapi',
       GITHUB_TOKEN: 'token',
       PROPOSAL_INTAKE_MAX_ISSUES: '8',
       PROPOSAL_INTAKE_MAX_ITEMS: '9',
-    }, 'PROPOSAL_INTAKE', defaults).maxCandidates).toBe(8);
+    }, 'PROPOSAL_INTAKE', defaults)).toMatchObject({ maxCandidates: 8 });
 
     expect(readIssueRuntimeConfig({
       GITHUB_REPOSITORY: 'davidruzicka/mcp4openapi',
       GITHUB_TOKEN: 'token',
       PROPOSAL_INTAKE_MAX_ITEMS: '9',
-    }, 'PROPOSAL_INTAKE', defaults).maxCandidates).toBe(9);
+    }, 'PROPOSAL_INTAKE', defaults)).toMatchObject({ maxCandidates: 9 });
 
-    expect(readIssueRuntimeConfig({
+    const runtimeConfig = readIssueRuntimeConfig({
       GITHUB_REPOSITORY: 'davidruzicka/mcp4openapi',
       GITHUB_TOKEN: 'token',
-    }, 'PROPOSAL_INTAKE', defaults).maxCandidates).toBe(10);
+    }, 'PROPOSAL_INTAKE', defaults);
+
+    expect(runtimeConfig).toMatchObject({ maxCandidates: 10 });
+    expect(runtimeConfig).not.toHaveProperty('maxItems');
+  });
+});
+
+describe('github-agent-runtime listing bounds', () => {
+  it('uses maxCandidates to cap recent issue retrieval', async () => {
+    const fetchMock = globalThis.fetch;
+    globalThis.fetch = async () => new Response(JSON.stringify([
+      {
+        number: 11,
+        title: 'Newest issue',
+        body: null,
+        html_url: 'https://github.com/davidruzicka/mcp4openapi/issues/11',
+        updated_at: '2026-03-17T10:00:00.000Z',
+      },
+      {
+        number: 10,
+        title: 'Second issue',
+        body: null,
+        html_url: 'https://github.com/davidruzicka/mcp4openapi/issues/10',
+        updated_at: '2026-03-17T09:00:00.000Z',
+      },
+      {
+        number: 9,
+        title: 'Older issue',
+        body: null,
+        html_url: 'https://github.com/davidruzicka/mcp4openapi/issues/9',
+        updated_at: '2026-03-17T08:00:00.000Z',
+      },
+    ]), { status: 200 });
+
+    try {
+      await expect(listRecentIssues({
+        repository: 'davidruzicka/mcp4openapi',
+        token: 'token',
+        apiBaseUrl: 'https://api.github.com',
+        lookbackHours: 48,
+        maxCandidates: 2,
+        agentId: 'proposal-intake',
+        runId: 'manual-test',
+        now: '2026-03-17T12:00:00.000Z',
+      })).resolves.toMatchObject([{ number: 11 }, { number: 10 }]);
+    } finally {
+      globalThis.fetch = fetchMock;
+    }
+  });
+
+  it('uses maxCandidates to cap recent pull request retrieval', async () => {
+    const fetchMock = globalThis.fetch;
+    globalThis.fetch = async () => new Response(JSON.stringify([
+      {
+        number: 21,
+        title: 'Newest PR',
+        body: null,
+        html_url: 'https://github.com/davidruzicka/mcp4openapi/pull/21',
+        draft: false,
+        updated_at: '2026-03-17T10:00:00.000Z',
+        state: 'open',
+        head: { sha: 'sha-21', ref: 'feat/newest' },
+      },
+      {
+        number: 20,
+        title: 'Second PR',
+        body: null,
+        html_url: 'https://github.com/davidruzicka/mcp4openapi/pull/20',
+        draft: false,
+        updated_at: '2026-03-17T09:00:00.000Z',
+        state: 'open',
+        head: { sha: 'sha-20', ref: 'feat/second' },
+      },
+      {
+        number: 19,
+        title: 'Older PR',
+        body: null,
+        html_url: 'https://github.com/davidruzicka/mcp4openapi/pull/19',
+        draft: false,
+        updated_at: '2026-03-17T08:00:00.000Z',
+        state: 'open',
+        head: { sha: 'sha-19', ref: 'feat/older' },
+      },
+    ]), { status: 200 });
+
+    try {
+      await expect(listOpenPullRequests({
+        repository: 'davidruzicka/mcp4openapi',
+        token: 'token',
+        apiBaseUrl: 'https://api.github.com',
+        lookbackHours: 48,
+        maxCandidates: 2,
+        agentId: 'proposal-intake',
+        runId: 'manual-test',
+        now: '2026-03-17T12:00:00.000Z',
+      })).resolves.toMatchObject([{ number: 21 }, { number: 20 }]);
+    } finally {
+      globalThis.fetch = fetchMock;
+    }
   });
 });
 

--- a/scripts/github-agent-runtime.ts
+++ b/scripts/github-agent-runtime.ts
@@ -47,7 +47,6 @@ export interface IssueRuntimeConfig {
   readonly apiBaseUrl: string;
   readonly lookbackHours: number;
   readonly maxCandidates: number;
-  readonly maxItems: number;
   readonly agentId: string;
   readonly runId: string;
   readonly now: string;
@@ -56,7 +55,7 @@ export interface IssueRuntimeConfig {
 export function readIssueRuntimeConfig(
   env: NodeJS.ProcessEnv,
   prefix: string,
-  defaults: { readonly lookbackHours: number; readonly maxItems?: number; readonly maxCandidates?: number; readonly agentId: string; },
+  defaults: { readonly lookbackHours: number; readonly maxCandidates: number; readonly agentId: string; },
 ): IssueRuntimeConfig {
   const repository = env.GITHUB_REPOSITORY;
   const token = env.GITHUB_TOKEN;
@@ -67,14 +66,9 @@ export function readIssueRuntimeConfig(
     throw new Error('Missing required GITHUB_TOKEN environment variable.');
   }
 
-  const defaultMaxItems = defaults.maxCandidates ?? defaults.maxItems;
-  if (!defaultMaxItems) {
-    throw new Error(`Missing default max item bound for ${prefix}.`);
-  }
-
   const maxCandidates = parsePositiveInteger(
     env[`${prefix}_MAX_CANDIDATES`] ?? env[`${prefix}_MAX_ISSUES`] ?? env[`${prefix}_MAX_ITEMS`],
-    defaultMaxItems,
+    defaults.maxCandidates,
   );
 
   return {
@@ -83,7 +77,6 @@ export function readIssueRuntimeConfig(
     apiBaseUrl: env.GITHUB_API_URL ?? 'https://api.github.com',
     lookbackHours: parsePositiveInteger(env[`${prefix}_LOOKBACK_HOURS`], defaults.lookbackHours),
     maxCandidates,
-    maxItems: maxCandidates,
     agentId: env[`${prefix}_AGENT_ID`] ?? defaults.agentId,
     runId: env.GITHUB_RUN_ID ? `github-actions-${env.GITHUB_RUN_ID}` : `manual-${Date.now()}`,
     now: env[`${prefix}_NOW`] ?? new Date().toISOString(),
@@ -241,7 +234,7 @@ async function listRecentIssueSummaries(config: IssueRuntimeConfig, state: 'open
   return issues
     .filter((issue) => !issue.pull_request)
     .filter((issue) => issue.updated_at >= updatedSince)
-    .slice(0, config.maxItems);
+    .slice(0, config.maxCandidates);
 }
 
 async function listRecentPullRequests(config: IssueRuntimeConfig, state: 'open' | 'closed'): Promise<GitHubPullRequestSummary[]> {
@@ -249,7 +242,7 @@ async function listRecentPullRequests(config: IssueRuntimeConfig, state: 'open' 
   const pullRequests = await githubRequest<GitHubPullRequestSummary[]>(config, `/repos/${config.repository}/pulls?state=${state}&sort=updated&direction=desc&per_page=100`);
   return pullRequests
     .filter((pullRequest) => pullRequest.updated_at >= updatedSince)
-    .slice(0, config.maxItems);
+    .slice(0, config.maxCandidates);
 }
 
 async function githubRequest<T = unknown>(config: IssueRuntimeConfig, path: string, init: RequestInit = {}): Promise<T> {

--- a/scripts/run-implementor.ts
+++ b/scripts/run-implementor.ts
@@ -26,7 +26,7 @@ import {
 const execFileAsync = promisify(execFile);
 const runtimeConfig = readIssueRuntimeConfig(process.env, 'IMPLEMENTOR', {
   lookbackHours: 72,
-  maxItems: 5,
+  maxCandidates: 5,
   agentId: 'implementor',
 });
 const implementorCommand = process.env.IMPLEMENTOR_COMMAND?.trim();
@@ -64,7 +64,7 @@ const assignments = collectImplementorAssignments({
   leaseTtlMinutes,
 });
 
-for (const assignment of assignments.slice(0, runtimeConfig.maxItems)) {
+for (const assignment of assignments.slice(0, runtimeConfig.maxCandidates)) {
   await addIssueLabels(runtimeConfig, assignment.issueNumber, assignment.labelsToAdd);
   await removeIssueLabels(runtimeConfig, assignment.issueNumber, assignment.labelsToRemove);
   await createIssueComment(runtimeConfig, assignment.issueNumber, assignment.leaseCommentBody);
@@ -107,7 +107,7 @@ for (const assignment of assignments.slice(0, runtimeConfig.maxItems)) {
   process.stdout.write(`Implementor processed issue #${assignment.issueNumber} (${result.outcome}).\n`);
 }
 
-process.stdout.write(`Implementor runner completed. Processed ${Math.min(assignments.length, runtimeConfig.maxItems)} issue(s).\n`);
+process.stdout.write(`Implementor runner completed. Processed ${Math.min(assignments.length, runtimeConfig.maxCandidates)} issue(s).\n`);
 
 async function runImplementorCommand(command: string, payload: unknown) {
   const { stdout } = await execFileAsync('bash', ['-lc', command], {

--- a/scripts/run-issuer.ts
+++ b/scripts/run-issuer.ts
@@ -12,7 +12,7 @@ import {
 
 const runtimeConfig = readIssueRuntimeConfig(process.env, 'ISSUER', {
   lookbackHours: 72,
-  maxItems: 20,
+  maxCandidates: 20,
   agentId: 'issuer',
 });
 
@@ -31,11 +31,11 @@ const assignments = collectIssuerAssignments({
   now: runtimeConfig.now,
 });
 
-for (const assignment of assignments.slice(0, runtimeConfig.maxItems)) {
+for (const assignment of assignments.slice(0, runtimeConfig.maxCandidates)) {
   await addIssueLabels(runtimeConfig, assignment.issueNumber, assignment.labelsToAdd);
   await removeIssueLabels(runtimeConfig, assignment.issueNumber, assignment.labelsToRemove);
   await createIssueComment(runtimeConfig, assignment.issueNumber, assignment.commentBody);
   process.stdout.write(`Issuer processed issue #${assignment.issueNumber} (${assignment.suitable ? 'safe' : 'unsafe'}).\n`);
 }
 
-process.stdout.write(`Issuer runner completed. Processed ${Math.min(assignments.length, runtimeConfig.maxItems)} issue(s).\n`);
+process.stdout.write(`Issuer runner completed. Processed ${Math.min(assignments.length, runtimeConfig.maxCandidates)} issue(s).\n`);

--- a/scripts/run-planner.ts
+++ b/scripts/run-planner.ts
@@ -12,7 +12,7 @@ import {
 
 const runtimeConfig = readIssueRuntimeConfig(process.env, 'PLANNER', {
   lookbackHours: 72,
-  maxItems: 10,
+  maxCandidates: 10,
   agentId: 'planner',
 });
 
@@ -41,11 +41,11 @@ const assignments = collectPlannerAssignments({
   now: runtimeConfig.now,
 });
 
-for (const assignment of assignments.slice(0, runtimeConfig.maxItems)) {
+for (const assignment of assignments.slice(0, runtimeConfig.maxCandidates)) {
   await addIssueLabels(runtimeConfig, assignment.issueNumber, assignment.labelsToAdd);
   await removeIssueLabels(runtimeConfig, assignment.issueNumber, assignment.labelsToRemove);
   await createIssueComment(runtimeConfig, assignment.issueNumber, assignment.commentBody);
   process.stdout.write(`Planner processed issue #${assignment.issueNumber} (${assignment.remainsSuitable ? 'planned' : assignment.blocked ? 'blocked' : 'de-scoped'}).\n`);
 }
 
-process.stdout.write(`Planner runner completed. Processed ${Math.min(assignments.length, runtimeConfig.maxItems)} issue(s).\n`);
+process.stdout.write(`Planner runner completed. Processed ${Math.min(assignments.length, runtimeConfig.maxCandidates)} issue(s).\n`);


### PR DESCRIPTION
## Summary
- remove the duplicate `maxItems` runtime config field and keep automation runners on `maxCandidates` only
- update recent issue and pull request helpers to use the canonical candidate bound
- add regression tests covering legacy env fallback precedence plus helper slicing behavior

## Test Plan
- npm test -- scripts/github-agent-runtime.test.ts
