### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Internal Error Leakage via Prompts and Resources

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,15 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2026-03-18 - [CRITICAL] Internal Error Leakage via Prompts and Resources
+
+**Vulnerability:**
+The `handleOtherRequest` method in `MCPServer` was returning the raw `(error as Error).message` instead of formatting the error safely via `formatErrorForClient(error, correlationId)` for `prompts/get`, `resources/read`, and `completion/complete`.
+
+**Learning:**
+Any catch block handling user requests should never leak the raw error message. `formatErrorForClient` correctly scopes generic Internal errors from ValidationError and others while generating a correlationId, reducing the chance of exposing stack traces and inner path structures.
+
+**Prevention:**
+1. Ensure `this.formatErrorForClient(error, correlationId)` is consistently used to serialize error messages sent in JSON-RPC responses.
+2. Ensure correlationIDs are properly logged and mapped correctly so server operators can search for the original errors.

--- a/src/mcp/mcp-server-apps.test.ts
+++ b/src/mcp/mcp-server-apps.test.ts
@@ -275,14 +275,15 @@ describe('MCPServer apps resources', () => {
       },
     });
 
-    expect(invalidReadResponse.error).toEqual({
+    expect(invalidReadResponse.error).toMatchObject({
       code: -32602,
-      message: 'resources/read requires string parameter "uri"',
     });
-    expect(invalidCompletionResponse.error).toEqual({
+    expect(invalidReadResponse.error.message).toContain('resources/read requires string parameter "uri"');
+
+    expect(invalidCompletionResponse.error).toMatchObject({
       code: -32602,
-      message: 'completion/complete requires a resource ref',
     });
+    expect(invalidCompletionResponse.error.message).toContain('completion/complete requires a resource ref');
   });
 
   it('propagates session context to fetch-backed resource and completion lookups', async () => {

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1858,12 +1858,14 @@ export class MCPServer {
           code = -32601;
         }
 
+        const correlationId = generateCorrelationId();
+        this.logger.error('Prompt get error', error as Error, { correlationId, promptName: (req.params as Record<string, unknown> | undefined)?.name, sessionId });
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }
@@ -1901,12 +1903,14 @@ export class MCPServer {
           result: await this.readResource(params.uri, sessionId, profileId),
         };
       } catch (error) {
+        const correlationId = generateCorrelationId();
+        this.logger.error('Resource read error', error as Error, { correlationId, uri: (req.params as Record<string, unknown> | undefined)?.uri, sessionId });
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code: error instanceof ValidationError ? -32602 : -32601,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }
@@ -1920,12 +1924,14 @@ export class MCPServer {
           result: await this.completeResourceArgument(req as CompleteRequest, sessionId, profileId),
         };
       } catch (error) {
+        const correlationId = generateCorrelationId();
+        this.logger.error('Completion error', error as Error, { correlationId, sessionId });
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code: error instanceof ValidationError ? -32602 : -32601,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }


### PR DESCRIPTION
- Use `formatErrorForClient` in `prompts/get` handler
- Use `formatErrorForClient` in `resources/read` handler
- Use `formatErrorForClient` in `completion/complete` handler
- Add `correlationId` to backend error logs
- Adjust corresponding unit tests to use `toMatchObject` and `toContain`
- Update `.jules/sentinel.md` noting the vulnerability and prevention pattern

---
*PR created automatically by Jules for task [3675699915541424064](https://jules.google.com/task/3675699915541424064) started by @davidruzicka*