### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF in EnterpriseAuthProvider discovery fetch

### DIFF
--- a/src/auth/enterprise-auth-provider.test.ts
+++ b/src/auth/enterprise-auth-provider.test.ts
@@ -8,6 +8,7 @@ import {
   EnterpriseIssuerDiscoveryError,
   EnterprisePolicyViolationError,
   EnterpriseTokenValidationError,
+  ValidationError,
 } from '../core/errors.js';
 
 const logger = new ConsoleLogger();
@@ -346,5 +347,29 @@ describe('enterprise-auth-provider', () => {
 
     await expect(createProvider().validateAssertion(wrongTypAssertion, 'client-1')).rejects.toThrow(/typ header is not allowed/i);
     await expect(createProvider({ token_exchange: { grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer', required_typ: ['at+jwt'], required_claims: [] } }).validateAssertion(missingSubAssertion, 'client-1')).rejects.toThrow(/missing sub claim/i);
+  });
+
+  it('rejects discovery fetches to private IPs if private network is disabled (SSRF protection)', async () => {
+    // Override the process.env setting specifically for this test
+    const previousAllow = process.env.MCP4_SSRF_ALLOW_PRIVATE_NETWORK;
+    process.env.MCP4_SSRF_ALLOW_PRIVATE_NETWORK = 'false';
+
+    const provider = createProvider({
+      issuer: { issuer: 'http://169.254.169.254', allowed_algs: ['RS256'], trust_mode: 'discovery' },
+    });
+
+    try {
+      await provider['resolveJwksUri']();
+      expect.unreachable('Should have thrown an SSRF error');
+    } catch (err: unknown) {
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as ValidationError).message).toMatch(/IP address not allowed/i);
+    } finally {
+      if (previousAllow === undefined) {
+        delete process.env.MCP4_SSRF_ALLOW_PRIVATE_NETWORK;
+      } else {
+        process.env.MCP4_SSRF_ALLOW_PRIVATE_NETWORK = previousAllow;
+      }
+    }
   });
 });

--- a/src/auth/enterprise-auth-provider.ts
+++ b/src/auth/enterprise-auth-provider.ts
@@ -4,6 +4,7 @@ import type { EnterpriseAuthorizationConfig } from '../types/profile.js';
 import { EnterpriseReplayStore } from './enterprise-replay-store.js';
 import { JwksCache } from './jwks-cache.js';
 import { buildEnterprisePrincipal } from './enterprise-policy.js';
+import { SSRFValidator } from '../security/ssrf-validator.js';
 import {
   EnterpriseIssuerDiscoveryError,
   EnterprisePolicyViolationError,
@@ -26,6 +27,7 @@ export class EnterpriseAuthProvider {
   private readonly jwksCache: JwksCache;
   private readonly replayStore: EnterpriseReplayStore;
   private readonly logger: Logger;
+  private readonly ssrfValidator: SSRFValidator;
 
   constructor(options: EnterpriseAuthProviderOptions) {
     this.profileId = options.profileId;
@@ -33,6 +35,7 @@ export class EnterpriseAuthProvider {
     this.jwksCache = options.jwksCache;
     this.replayStore = options.replayStore;
     this.logger = options.logger;
+    this.ssrfValidator = new SSRFValidator(options.logger);
   }
 
   async validateAssertion(assertion: string, clientId?: string): Promise<AuthorizedPrincipal> {
@@ -102,6 +105,11 @@ export class EnterpriseAuthProvider {
     }
 
     const discoveryUrl = new URL('/.well-known/openid-configuration', this.config.issuer.issuer).toString();
+
+    await this.ssrfValidator.validate(discoveryUrl, {
+      allowPrivateNetwork: process.env.MCP4_SSRF_ALLOW_PRIVATE_NETWORK === 'true',
+    });
+
     const response = await fetch(discoveryUrl, {
       headers: { accept: 'application/json' },
       signal: AbortSignal.timeout(5000),


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix SSRF in EnterpriseAuthProvider discovery fetch

🚨 **Severity:** HIGH
💡 **Vulnerability:** The `resolveJwksUri` method in `EnterpriseAuthProvider` was executing an unvalidated HTTP fetch to a user-supplied (via configuration) issuer domain for OpenID discovery metadata. This could permit Server-Side Request Forgery (SSRF).
🎯 **Impact:** An attacker could craft a malicious profile targeting internal subnets or loopback interfaces to scan for or access unauthorized internal endpoints.
🔧 **Fix:** Integrated the existing `SSRFValidator` to validate the `discoveryUrl` before initiating the fetch.
✅ **Verification:** Added a dedicated unit test in `src/auth/enterprise-auth-provider.test.ts` verifying that fetching from a private IP (e.g., `169.254.169.254`) is securely blocked when `MCP4_SSRF_ALLOW_PRIVATE_NETWORK` is disabled.

---
*PR created automatically by Jules for task [17703178791455399946](https://jules.google.com/task/17703178791455399946) started by @davidruzicka*