### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix error message leakage in JSON-RPC handlers

### DIFF
--- a/src/mcp/mcp-server-apps.test.ts
+++ b/src/mcp/mcp-server-apps.test.ts
@@ -275,14 +275,14 @@ describe('MCPServer apps resources', () => {
       },
     });
 
-    expect(invalidReadResponse.error).toEqual({
+    expect(invalidReadResponse.error).toMatchObject({
       code: -32602,
-      message: 'resources/read requires string parameter "uri"',
     });
-    expect(invalidCompletionResponse.error).toEqual({
+    expect(invalidReadResponse.error?.message).toMatch(/resources\/read requires string parameter "uri"/);
+    expect(invalidCompletionResponse.error).toMatchObject({
       code: -32602,
-      message: 'completion/complete requires a resource ref',
     });
+    expect(invalidCompletionResponse.error?.message).toMatch(/completion\/complete requires a resource ref/);
   });
 
   it('propagates session context to fetch-backed resource and completion lookups', async () => {

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1858,12 +1858,14 @@ export class MCPServer {
           code = -32601;
         }
 
+        const correlationId = generateCorrelationId();
+        this.logger.error('Prompt retrieval error', error instanceof Error ? error : new Error(String(error)), { correlationId });
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error instanceof Error ? error : new Error(String(error)), correlationId),
           },
         };
       }
@@ -1901,12 +1903,14 @@ export class MCPServer {
           result: await this.readResource(params.uri, sessionId, profileId),
         };
       } catch (error) {
+        const correlationId = generateCorrelationId();
+        this.logger.error('Resource retrieval error', error instanceof Error ? error : new Error(String(error)), { correlationId });
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code: error instanceof ValidationError ? -32602 : -32601,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error instanceof Error ? error : new Error(String(error)), correlationId),
           },
         };
       }
@@ -1920,12 +1924,14 @@ export class MCPServer {
           result: await this.completeResourceArgument(req as CompleteRequest, sessionId, profileId),
         };
       } catch (error) {
+        const correlationId = generateCorrelationId();
+        this.logger.error('Completion generation error', error instanceof Error ? error : new Error(String(error)), { correlationId });
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code: error instanceof ValidationError ? -32602 : -32601,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error instanceof Error ? error : new Error(String(error)), correlationId),
           },
         };
       }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix error message leakage in JSON-RPC handlers

**Severity:** MEDIUM

**Vulnerability:** The JSON-RPC handlers in `src/mcp/mcp-server.ts` (`handleOtherRequest` for `prompts/get`, `resources/read`, and `completion/complete`) were catching errors and returning `(error as Error).message` directly to the client. This exposed raw internal error messages, potentially leaking sensitive backend details (e.g., file paths, database identifiers, or stack traces masquerading as messages).

**Impact:** An attacker could exploit errors in resource retrieval or tool completion to gain insights into the application's internal structure or configuration, aiding further attacks.

**Fix:** Updated the `catch` blocks in these handlers to:
1. Generate a unique `correlationId`.
2. Log the raw error on the backend using `this.logger.error` alongside the `correlationId`.
3. Sanitize the client-facing error message using `this.formatErrorForClient(error, correlationId)`.

**Verification:** Ran the full Vitest suite (`npm run test`) and verified that the `mcp-server.test.ts` and `mcp-server-apps.test.ts` tests still pass, meaning functionality remains intact while the error message format is updated. Also successfully ran `npm run typecheck` to ensure no TypeScript compilation errors.

---
*PR created automatically by Jules for task [15902161839511542132](https://jules.google.com/task/15902161839511542132) started by @davidruzicka*