### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix internal error leakage in MCP server handlers

### DIFF
--- a/src/mcp/mcp-server-apps.test.ts
+++ b/src/mcp/mcp-server-apps.test.ts
@@ -275,14 +275,11 @@ describe('MCPServer apps resources', () => {
       },
     });
 
-    expect(invalidReadResponse.error).toEqual({
-      code: -32602,
-      message: 'resources/read requires string parameter "uri"',
-    });
-    expect(invalidCompletionResponse.error).toEqual({
-      code: -32602,
-      message: 'completion/complete requires a resource ref',
-    });
+    expect(invalidReadResponse.error.code).toBe(-32602);
+    expect(invalidReadResponse.error.message).toContain('resources/read requires string parameter "uri"');
+
+    expect(invalidCompletionResponse.error.code).toBe(-32602);
+    expect(invalidCompletionResponse.error.message).toContain('completion/complete requires a resource ref');
   });
 
   it('propagates session context to fetch-backed resource and completion lookups', async () => {

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1858,12 +1858,15 @@ export class MCPServer {
           code = -32601;
         }
 
+        const correlationId = generateCorrelationId();
+        this.logger.error('Prompt get error', error as Error, { correlationId });
+
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }
@@ -1901,12 +1904,15 @@ export class MCPServer {
           result: await this.readResource(params.uri, sessionId, profileId),
         };
       } catch (error) {
+        const correlationId = generateCorrelationId();
+        this.logger.error('Resource read error', error as Error, { correlationId });
+
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code: error instanceof ValidationError ? -32602 : -32601,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }
@@ -1920,12 +1926,15 @@ export class MCPServer {
           result: await this.completeResourceArgument(req as CompleteRequest, sessionId, profileId),
         };
       } catch (error) {
+        const correlationId = generateCorrelationId();
+        this.logger.error('Completion error', error as Error, { correlationId });
+
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code: error instanceof ValidationError ? -32602 : -32601,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix internal error leakage in MCP server handlers

🚨 Severity: MEDIUM
💡 Vulnerability: The `prompts/get`, `resources/read`, and `completion/complete` handlers in `src/mcp/mcp-server.ts` were catching exceptions and returning raw error messages directly to the client in JSON-RPC error responses. This could expose internal details like paths, connection strings, or stack traces if unexpected runtime errors occurred.
🎯 Impact: An attacker could potentially gain insights into the application's internal workings or infrastructure details, which could aid in further attacks.
🔧 Fix: Updated the catch blocks for these handlers to generate a `correlationId` using `generateCorrelationId()`, log the actual error securely server-side, and return a sanitized, client-safe error message using `this.formatErrorForClient(error, correlationId)`.
✅ Verification: Ran `npm run test`, `npm run lint`, and `npm run typecheck` to ensure the changes are correct and don't introduce regressions. The `mcp-server-apps.test.ts` file correctly tests these handlers.

---
*PR created automatically by Jules for task [8447276285264022519](https://jules.google.com/task/8447276285264022519) started by @davidruzicka*