### PR TITLE
🛡️ Sentinel: [security improvement] Add missing security headers

### DIFF
--- a/src/transport/http-transport-security.test.ts
+++ b/src/transport/http-transport-security.test.ts
@@ -143,6 +143,8 @@ describe('HttpTransport security behavior (no listen)', () => {
     expect(response.headers['x-content-type-options']).toBe('nosniff');
     expect(response.headers['x-frame-options']).toBe('DENY');
     expect(response.headers['referrer-policy']).toBe('no-referrer');
+    expect(response.headers['strict-transport-security']).toBe('max-age=63072000; includeSubDomains');
+    expect(response.headers['x-xss-protection']).toBe('0');
     expect(response.headers['cross-origin-opener-policy']).toBe('same-origin');
     expect(response.headers['cross-origin-resource-policy']).toBe('same-origin');
     expect(response.headers['x-permitted-cross-domain-policies']).toBe('none');

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -226,6 +226,8 @@ export class HttpTransport {
       res.setHeader('X-Content-Type-Options', 'nosniff');
       res.setHeader('Referrer-Policy', 'no-referrer');
       res.setHeader('Permissions-Policy', 'geolocation=(), microphone=(), camera=(), payment=()');
+      res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
+      res.setHeader('X-XSS-Protection', '0');
 
       // Additional security headers
       res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');


### PR DESCRIPTION
This PR introduces a security enhancement by adding two missing HTTP headers to the `HttpTransport` server:

1. **Strict-Transport-Security (HSTS)** (`max-age=63072000; includeSubDomains`): Enforces secure (HTTP over SSL/TLS) connections to the server for a long duration, protecting against downgrade attacks.
2. **X-XSS-Protection** (`0`): Explicitly disables older browsers' built-in XSS filters. These legacy filters have been found to introduce side-channel vulnerabilities and are superseded by modern `Content-Security-Policy`.

Testing:
- Updated existing `checks for security headers using supertest` test in `http-transport-security.test.ts` to assert that these headers are correctly set by the middleware.

---
*PR created automatically by Jules for task [4887100047544216562](https://jules.google.com/task/4887100047544216562) started by @davidruzicka*