### PR TITLE
feat(oauth): allow approved unregistered authorize clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded the GitHub security profile with Secret Scanning CRUD actions, stricter action-gated parameter validation (`allowed_for`/`forbidden_for`), and an upgraded `retrieve_security_overview` composite across code scanning + Dependabot + secret scanning.
 - Added enterprise managed authorization for HTTP transport with profile-driven `enterprise_authorization`, JWT bearer grant support on `/oauth/token`, bounded JWKS/replay/token stores, metadata extensions, and security-focused validation/redaction coverage.
 - Added env-backed `enterprise_authorization` field resolution for issuer, audience, mode, selected access-policy settings, and claim mappings so deployments can override enterprise auth without editing profiles.
+- Added phase 1 support for approved unregistered OAuth clients so authorize requests can materialize local clients when `redirect_uri` matches an explicit allowlist, improving multi-pod OAuth compatibility without weakening redirect validation.
 
 ### Changed
 - Implementor pipeline now attempts IMPLEMENTOR_FALLBACK_COMMAND on process-level backend failures; @openai/codex moved to devDependencies for cached installs; Codex OAuth auth supported via CODEX_AUTH_JSON with automatic token refresh persistence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened MCP Apps resource loading so `file_path` stays inside the profile directory after normalization and symlink resolution, while keeping `resources/read` output shape consistent across inline, file-backed, and fetch-backed resources.
 - Fixed HTTP single-profile startup to carry `enterprise_authorization` into transport runtime so enterprise JWT bearer exchange and authenticated initialization work outside profile-routing mode, with dedicated E2E coverage.
 - Clarified and locked runtime enterprise authorization behavior so `required` mode enforces trusted enterprise-issued bearer tokens, `optional` mode stays backward-compatible, tool-category policy covers both listing and execution, and invalid env-backed values fail during profile loading.
+- Hardened approved unregistered OAuth client materialization by preserving redirect URI unions for shared compatibility `client_id` values (for example VS Code), bounding stored redirect URI payloads to client-store limits, and rejecting insecure `http://`/`https://` scheme-only allowlist rules.
 
 ## [0.5.7] - 2026-03-03
 

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -370,6 +370,35 @@ If you need a different callback URL:
 
 Allowed redirect hosts accept exact hostnames, wildcard subdomains (`*.example.com`), IPv4 addresses, IPv4 CIDR ranges (e.g., `10.0.0.0/8`), and IPv6 addresses/CIDR ranges (e.g., `2001:db8::/32`) so you can allow whole internal networks without listing individual machines.
 
+### Unregistered OAuth clients for multi-pod deployments
+
+When multiple pods or clusters share the same OAuth authorization surface, the authorize request can land on an instance that does not have the requesting `client_id` registered locally yet. You can allow that authorize request to continue, but only for explicitly approved redirect URI patterns.
+
+```json
+{
+  "oauth_config": {
+    "allow_unregistered_clients": true,
+    "allowed_unregistered_redirect_uris": [
+      "http://localhost",
+      "http://127.0.0.1",
+      "cursor://",
+      "cursor://anysphere.cursor-mcp"
+    ]
+  }
+}
+```
+
+Rules:
+
+- Disabled by default.
+- Only `authorize` requests are relaxed; the client is materialized locally only after its `redirect_uri` matches an approved rule.
+- Loopback approvals such as `http://localhost` and `http://127.0.0.1` allow dynamic callback ports.
+- Scheme-only custom URI approvals such as `cursor://` allow any host for that scheme.
+- Exact custom URI approvals such as `cursor://anysphere.cursor-mcp` restrict callbacks to that host only.
+- Invalid, dangerous, or confusing redirects (for example `javascript:`, `localhost.evil.test`, or `localhost@evil.test`) are rejected.
+
+This is intended as phase 1 compatibility for shared or failover deployments. It does not yet share pending OAuth state, authorization codes, or tokens across pods - use a shared backend such as Redis for that in a later phase.
+
 ### Additional OAuth Endpoints
 
 Optional endpoints for advanced features:

--- a/profile-schema.json
+++ b/profile-schema.json
@@ -1230,6 +1230,17 @@
             "type": "string"
           },
           "description": "Optional: Allowed redirect hosts for OAuth callbacks\nUsed to prevent open redirect vulnerabilities\n\nSupports wildcards: \"*.example.com\" matches any subdomain\nDefaults to [\"localhost\", \"127.0.0.1\"] for security\n\nCan reference MCP4_ALLOWED_ORIGINS environment variable"
+        },
+        "allow_unregistered_clients": {
+          "type": "boolean",
+          "description": "Optional: Allow authorize requests for OAuth client IDs that are not registered on the current instance, but only when redirect_uri matches an approved rule. Disabled by default."
+        },
+        "allowed_unregistered_redirect_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional: Approved redirect URI rules for unregistered OAuth clients. Examples:\n- \"http://localhost\"\n- \"http://127.0.0.1\"\n- \"cursor://\"\n- \"cursor://anysphere.cursor-mcp\""
         }
       },
       "description": "OAuth 2.0 configuration. Must provide EITHER 'issuer' (endpoints auto-derived) OR both 'authorization_endpoint' and 'token_endpoint' (explicit)."
@@ -1408,14 +1419,14 @@
           ]
         },
         "overrides": {
-          "$ref": "#/definitions/Record%3Cstring%2Cstructure-1535101595-20095-20131-1535101595-20080-20132-1535101595-20066-20133-1535101595-19995-20135-1535101595-0-20275%3E"
+          "$ref": "#/definitions/Record%3Cstring%2Cstructure-1535101595-20604-20640-1535101595-20589-20641-1535101595-20575-20642-1535101595-20504-20644-1535101595-0-20784%3E"
         }
       },
       "required": [
         "max_requests_per_minute"
       ]
     },
-    "Record<string,structure-1535101595-20095-20131-1535101595-20080-20132-1535101595-20066-20133-1535101595-19995-20135-1535101595-0-20275>": {
+    "Record<string,structure-1535101595-20604-20640-1535101595-20589-20641-1535101595-20575-20642-1535101595-20504-20644-1535101595-0-20784>": {
       "type": "object",
       "additionalProperties": {
         "type": "object",
@@ -1835,6 +1846,20 @@
             "type": "string"
           }
         }
+      }
+    },
+    "Record<string,structure-1535101595-20095-20131-1535101595-20080-20132-1535101595-20066-20133-1535101595-19995-20135-1535101595-0-20275>": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "max_requests_per_minute": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "max_requests_per_minute"
+        ]
       }
     },
     "Record<string,structure-1535101595-18530-18566-1535101595-18515-18567-1535101595-18501-18568-1535101595-18430-18570-1535101595-0-18710>": {

--- a/src/auth/oauth-provider.test.ts
+++ b/src/auth/oauth-provider.test.ts
@@ -354,25 +354,59 @@ describe('ExternalOAuthProvider', () => {
       ).resolves.toBeUndefined();
     });
 
-    it('should return an existing materialized client without overwriting it', async () => {
+    it('should append a newly approved redirect uri to an existing materialized unregistered client', async () => {
       provider = new ExternalOAuthProvider({
         ...config,
         allow_unregistered_clients: true,
         allowed_unregistered_redirect_uris: ['cursor://'],
       }, mockLogger);
 
-      const existingClient: OAuthClientInformationFull = {
+      await provider.getOrProvisionUnregisteredClient(
+        'cursor-client-id',
+        'cursor://existing-client/oauth/callback',
+      );
+
+      const client = await provider.getOrProvisionUnregisteredClient(
+        'cursor-client-id',
+        'cursor://anysphere.cursor-mcp/oauth/callback',
+      );
+
+      expect(client).toMatchObject({
         client_id: 'cursor-client-id',
-        redirect_uris: ['cursor://existing-client/oauth/callback'],
-        grant_types: ['authorization_code'],
-        response_types: ['code'],
-        scope: 'existing-scope',
-      };
-      await provider.clientsStore.registerClient(existingClient);
+        redirect_uris: [
+          'cursor://existing-client/oauth/callback',
+          'cursor://anysphere.cursor-mcp/oauth/callback',
+        ],
+        scope: 'api read_user',
+      });
+      expect(await provider.clientsStore.getClient('cursor-client-id')).toMatchObject({
+        redirect_uris: [
+          'cursor://existing-client/oauth/callback',
+          'cursor://anysphere.cursor-mcp/oauth/callback',
+        ],
+      });
+    });
+
+    it('should refuse to materialize an oversized unregistered redirect uri payload', async () => {
+      provider = new ExternalOAuthProvider({
+        ...config,
+        allow_unregistered_clients: true,
+        allowed_unregistered_redirect_uris: ['cursor://'],
+      }, mockLogger);
+      const limits = provider.clientsStore.getLimits();
+      const oversizedRedirectUri = `cursor://${'a'.repeat(limits.maxRedirectUriLength + 1)}`;
 
       await expect(
-        provider.getOrProvisionUnregisteredClient('cursor-client-id', 'cursor://anysphere.cursor-mcp/oauth/callback')
-      ).resolves.toBe(existingClient);
+        provider.getOrProvisionUnregisteredClient('cursor-client-id', oversizedRedirectUri),
+      ).resolves.toBeUndefined();
+      await expect(provider.clientsStore.getClient('cursor-client-id')).resolves.toBeUndefined();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Refused to materialize unregistered OAuth client redirect URI: redirect URI too long',
+        expect.objectContaining({
+          redirectUriLength: oversizedRedirectUri.length,
+          maxRedirectUriLength: limits.maxRedirectUriLength,
+        }),
+      );
     });
 
     it('should materialize approved unregistered clients with an empty scope when config scopes are absent', async () => {

--- a/src/auth/oauth-provider.test.ts
+++ b/src/auth/oauth-provider.test.ts
@@ -333,6 +333,91 @@ describe('ExternalOAuthProvider', () => {
     });
   });
 
+  describe('getOrProvisionUnregisteredClient', () => {
+    it('should return undefined when unregistered clients are disabled', async () => {
+      provider = new ExternalOAuthProvider(config, mockLogger);
+
+      await expect(
+        provider.getOrProvisionUnregisteredClient('cursor-client-id', 'cursor://anysphere.cursor-mcp/oauth/callback')
+      ).resolves.toBeUndefined();
+    });
+
+    it('should return undefined when redirect uri is not approved', async () => {
+      provider = new ExternalOAuthProvider({
+        ...config,
+        allow_unregistered_clients: true,
+        allowed_unregistered_redirect_uris: ['cursor://'],
+      }, mockLogger);
+
+      await expect(
+        provider.getOrProvisionUnregisteredClient('cursor-client-id', 'https://evil.example.com/callback')
+      ).resolves.toBeUndefined();
+    });
+
+    it('should return an existing materialized client without overwriting it', async () => {
+      provider = new ExternalOAuthProvider({
+        ...config,
+        allow_unregistered_clients: true,
+        allowed_unregistered_redirect_uris: ['cursor://'],
+      }, mockLogger);
+
+      const existingClient: OAuthClientInformationFull = {
+        client_id: 'cursor-client-id',
+        redirect_uris: ['cursor://existing-client/oauth/callback'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+        scope: 'existing-scope',
+      };
+      await provider.clientsStore.registerClient(existingClient);
+
+      await expect(
+        provider.getOrProvisionUnregisteredClient('cursor-client-id', 'cursor://anysphere.cursor-mcp/oauth/callback')
+      ).resolves.toBe(existingClient);
+    });
+
+    it('should materialize approved unregistered clients with an empty scope when config scopes are absent', async () => {
+      provider = new ExternalOAuthProvider({
+        authorization_endpoint: 'https://oauth.example.com/authorize',
+        token_endpoint: 'https://oauth.example.com/token',
+        client_id: 'test-client-id',
+        client_secret: 'test-client-secret',
+        redirect_uri: 'http://localhost:3003/oauth/callback',
+        allow_unregistered_clients: true,
+        allowed_unregistered_redirect_uris: ['cursor://'],
+      }, mockLogger);
+
+      const client = await provider.getOrProvisionUnregisteredClient(
+        'cursor-client-id',
+        'cursor://anysphere.cursor-mcp/oauth/callback',
+      );
+
+      expect(client).toMatchObject({
+        client_id: 'cursor-client-id',
+        redirect_uris: ['cursor://anysphere.cursor-mcp/oauth/callback'],
+        scope: '',
+      });
+    });
+  });
+
+  describe('isAllowedClientRedirectUri', () => {
+    it('should reject unregistered fallback redirects that are not on the materialized client', () => {
+      provider = new ExternalOAuthProvider({
+        ...config,
+        allow_unregistered_clients: true,
+        allowed_unregistered_redirect_uris: ['cursor://'],
+      }, mockLogger);
+
+      const client: OAuthClientInformationFull = {
+        client_id: 'cursor-client-id',
+        redirect_uris: ['cursor://existing-client/oauth/callback'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      };
+
+      expect((provider as any).isAllowedClientRedirectUri(client, 'cursor://other-client/oauth/callback')).toBe(false);
+    });
+  });
+
   describe('authorize', () => {
     let mockRes: Partial<Response>;
 

--- a/src/auth/oauth-provider.test.ts
+++ b/src/auth/oauth-provider.test.ts
@@ -786,6 +786,39 @@ describe('ExternalOAuthProvider', () => {
       expect(redirectUrl).toContain('client_id=');
       expect(redirectUrl).toContain('response_type=code');
     });
+
+    it('should allow approved custom scheme redirects for unregistered clients during authorize', async () => {
+      const unregisteredConfig: OAuthConfig = {
+        ...config,
+        allow_unregistered_clients: true,
+        allowed_unregistered_redirect_uris: ['cursor://'],
+      };
+      provider = new ExternalOAuthProvider(unregisteredConfig, mockLogger);
+
+      const client: OAuthClientInformationFull = {
+        client_id: 'cursor-client-id',
+        redirect_uris: ['cursor://anysphere.cursor-mcp/oauth/callback'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      };
+
+      const mockRes = {
+        redirect: vi.fn(),
+      } as unknown as Response;
+
+      await expect(
+        provider.authorize(client, {
+          redirectUri: 'cursor://anysphere.cursor-mcp/oauth/callback',
+          codeChallenge: 'test-challenge',
+          state: 'original-state',
+          scopes: ['api'],
+        }, mockRes)
+      ).resolves.toBeUndefined();
+
+      expect(mockRes.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('https://oauth.example.com/authorize')
+      );
+    });
   });
 
   describe('challengeForAuthorizationCode', () => {
@@ -1091,6 +1124,57 @@ describe('ExternalOAuthProvider', () => {
         response_types: ['code'],
       };
       (provider as any)._clientsStore.registerClient(client);
+
+      (provider as any).stateStore.set('state123', {
+        clientRedirectUri: 'cursor://anysphere.cursor-mcp/oauth/callback',
+        codeChallenge: 'challenge',
+        originalState: 'orig',
+        clientId: client.client_id,
+        scopes: ['api'],
+      });
+
+      (provider as any).exchangeCodeWithProvider = vi.fn().mockResolvedValue({
+        access_token: 'at',
+        refresh_token: 'rt',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      });
+
+      const mockReq = {
+        query: {
+          code: 'auth-code',
+          state: 'state123',
+        },
+      } as any;
+      const mockRes = {
+        status: vi.fn().mockReturnThis(),
+        send: vi.fn(),
+        redirect: vi.fn(),
+      } as any;
+
+      await provider.handleCallback(mockReq, mockRes);
+
+      expect(mockRes.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('cursor://anysphere.cursor-mcp/oauth/callback?code=')
+      );
+      expect(mockRes.status).not.toHaveBeenCalledWith(400);
+    });
+
+    it('should allow approved custom scheme redirects for unregistered clients during callback', async () => {
+      const unregisteredConfig: OAuthConfig = {
+        ...config,
+        allow_unregistered_clients: true,
+        allowed_unregistered_redirect_uris: ['cursor://'],
+      };
+      provider = new ExternalOAuthProvider(unregisteredConfig, mockLogger);
+
+      const client: OAuthClientInformationFull = {
+        client_id: 'cursor-client-id',
+        redirect_uris: ['cursor://anysphere.cursor-mcp/oauth/callback'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      };
+      await (provider as any)._clientsStore.registerClient(client);
 
       (provider as any).stateStore.set('state123', {
         clientRedirectUri: 'cursor://anysphere.cursor-mcp/oauth/callback',

--- a/src/auth/oauth-provider.test.ts
+++ b/src/auth/oauth-provider.test.ts
@@ -354,6 +354,53 @@ describe('ExternalOAuthProvider', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('should return an existing registered client without mutating it', async () => {
+      provider = new ExternalOAuthProvider({
+        ...config,
+        allow_unregistered_clients: true,
+        allowed_unregistered_redirect_uris: ['cursor://'],
+      }, mockLogger);
+
+      const registeredClient: OAuthClientInformationFull = {
+        client_id: 'cursor-client-id',
+        redirect_uris: ['https://registered.example.com/callback'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      };
+      provider.clientsStore.registerClient(registeredClient);
+
+      const client = await provider.getOrProvisionUnregisteredClient(
+        'cursor-client-id',
+        'cursor://anysphere.cursor-mcp/oauth/callback',
+      );
+
+      expect(client).toEqual(registeredClient);
+      expect(provider.hasMaterializedUnregisteredClient('cursor-client-id')).toBe(false);
+    });
+
+    it('should return an existing materialized client when the redirect uri is already present', async () => {
+      provider = new ExternalOAuthProvider({
+        ...config,
+        allow_unregistered_clients: true,
+        allowed_unregistered_redirect_uris: ['cursor://'],
+      }, mockLogger);
+
+      const firstClient = await provider.getOrProvisionUnregisteredClient(
+        'cursor-client-id',
+        'cursor://existing-client/oauth/callback',
+      );
+
+      const client = await provider.getOrProvisionUnregisteredClient(
+        'cursor-client-id',
+        'cursor://existing-client/oauth/callback',
+      );
+
+      expect(client).toEqual(firstClient);
+      expect(await provider.clientsStore.getClient('cursor-client-id')).toMatchObject({
+        redirect_uris: ['cursor://existing-client/oauth/callback'],
+      });
+    });
+
     it('should append a newly approved redirect uri to an existing materialized unregistered client', async () => {
       provider = new ExternalOAuthProvider({
         ...config,
@@ -385,6 +432,39 @@ describe('ExternalOAuthProvider', () => {
           'cursor://anysphere.cursor-mcp/oauth/callback',
         ],
       });
+    });
+
+    it('should refuse to append an approved redirect uri when the redirect uri count limit would be exceeded', async () => {
+      provider = new ExternalOAuthProvider({
+        ...config,
+        allow_unregistered_clients: true,
+        allowed_unregistered_redirect_uris: ['cursor://'],
+      }, mockLogger);
+
+      const limits = provider.clientsStore.getLimits();
+      const redirectUris = Array.from({ length: limits.maxRedirectUris }, (_, index) => `cursor://client-${index}/oauth/callback`);
+      const materializedClient: OAuthClientInformationFull = {
+        client_id: 'cursor-client-id',
+        redirect_uris: redirectUris,
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      };
+      provider.clientsStore.registerClient(materializedClient);
+      (provider as any).materializedUnregisteredClientIds.add('cursor-client-id');
+
+      const client = await provider.getOrProvisionUnregisteredClient(
+        'cursor-client-id',
+        'cursor://overflow/oauth/callback',
+      );
+
+      expect(client).toBeUndefined();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Refused to materialize unregistered OAuth client redirect URI: max redirect URI count exceeded',
+        expect.objectContaining({
+          redirectUriCount: limits.maxRedirectUris + 1,
+          maxRedirectUris: limits.maxRedirectUris,
+        }),
+      );
     });
 
     it('should refuse to materialize an oversized unregistered redirect uri payload', async () => {
@@ -1031,6 +1111,13 @@ describe('ExternalOAuthProvider', () => {
       provider = new ExternalOAuthProvider(configWithAllowed, mockLogger);
       
       expect((provider as any).isAllowedRedirectHost('http://evil.com/callback')).toBe(false);
+    });
+
+    it('should reject wildcard characters in the hostname or path', () => {
+      provider = new ExternalOAuthProvider(config, mockLogger);
+
+      expect((provider as any).isAllowedRedirectHost('http://local*host:3003/callback')).toBe(false);
+      expect((provider as any).isAllowedRedirectHost('http://localhost:3003/*')).toBe(false);
     });
 
     it('should handle invalid URLs gracefully', () => {

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -28,7 +28,13 @@ import type {
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import type { OAuthConfig } from '../types/profile.js';
 import type { Logger } from '../core/logger.js';
-import { OAUTH_CLEANUP, OAUTH_PATHS, PROXY_CREDENTIALS } from '../core/constants.js';
+import {
+  DEFAULT_ALLOWED_REDIRECT_HOSTS,
+  DEFAULT_OAUTH_LOOPBACK_CALLBACK_URIS,
+  OAUTH_CLEANUP,
+  OAUTH_PATHS,
+  PROXY_CREDENTIALS,
+} from '../core/constants.js';
 import { escapeHtmlSafe } from '../validation/validation-utils.js';
 import { SSRFValidator } from '../security/ssrf-validator.js';
 import { parseOAuthMetadataEndpoints } from './oauth-metadata.js';
@@ -83,6 +89,7 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
   private authorizationCodes = new Map<string, AuthorizationCodeData>();
   private accessTokens = new Map<string, AccessTokenData>();
   private stateStore = new Map<string, AuthorizationState>();
+  private materializedUnregisteredClientIds = new Set<string>();
 
   private endpointsInitialized: boolean = false;
   private initializationPromise: Promise<void> | null = null;
@@ -96,9 +103,12 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
     // Resolve environment variables in OAuth config
     this.config = this.resolveEnvVars(config);
     
-    // Pre-register mcp-proxy-client for VS Code compatibility
-    // VS Code doesn't call /oauth/register endpoint before calling /oauth/authorize
-    // This client has empty redirect_uris, allowing any redirect URI (validated at runtime)
+    // Pre-register mcp-proxy-client for VS Code compatibility.
+    // VS Code does not call /oauth/register before /oauth/authorize and uses one
+    // shared compatibility client_id across installs, so redirect validation must
+    // remain request-scoped instead of relying on a per-install registration record.
+    // Keep redirect_uris empty here to allow runtime validation without pinning one
+    // VS Code instance's redirect_uri onto another instance that reuses the same id.
     const proxyClient: OAuthClientInformationFull = {
       client_id: PROXY_CREDENTIALS.CLIENT_ID,
       client_secret: PROXY_CREDENTIALS.CLIENT_SECRET,
@@ -136,9 +146,8 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
         if (this.config.redirect_uri) {
           allowedUris.push(this.config.redirect_uri);
         }
-        // Also allow common localhost patterns for development/testing
-        allowedUris.push('http://localhost:3003/oauth/callback');
-        allowedUris.push('http://127.0.0.1:3003/oauth/callback');
+        // Also allow common loopback callbacks for development/testing
+        allowedUris.push(...DEFAULT_OAUTH_LOOPBACK_CALLBACK_URIS);
         
         const defaultClient: OAuthClientInformationFull = {
           client_id: this.config.client_id,
@@ -208,23 +217,92 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
 
     const existingClient = await this._clientsStore.getClient(clientId);
     if (existingClient) {
-      return existingClient;
+      if (!this.materializedUnregisteredClientIds.has(clientId)) {
+        return existingClient;
+      }
+
+      if (
+        existingClient.redirect_uris?.length === 0
+        || existingClient.redirect_uris?.includes(redirectUri)
+      ) {
+        return existingClient;
+      }
+
+      const redirectUris = this.buildValidatedUnregisteredRedirectUriList(
+        existingClient.redirect_uris,
+        redirectUri,
+      );
+      if (!redirectUris) {
+        return undefined;
+      }
+
+      // Some desktop clients (notably VS Code compatibility flows) reuse a shared
+      // client_id across installations. Preserve the existing materialized record,
+      // but append newly approved redirect_uris so one instance does not block
+      // another instance that reuses the same client_id with a different callback.
+      const updatedClient: OAuthClientInformationFull = {
+        ...existingClient,
+        redirect_uris: redirectUris,
+      };
+      await this._clientsStore.registerClient(updatedClient);
+      this.logger.info('Appended approved redirect URI to existing OAuth client', {
+        clientId,
+        redirectUri,
+        redirectUriCount: updatedClient.redirect_uris.length,
+      });
+      return updatedClient;
+    }
+
+    const redirectUris = this.buildValidatedUnregisteredRedirectUriList([], redirectUri);
+    if (!redirectUris) {
+      return undefined;
     }
 
     const client: OAuthClientInformationFull = {
       client_id: clientId,
-      redirect_uris: [redirectUri],
+      redirect_uris: redirectUris,
       grant_types: ['authorization_code', 'refresh_token'],
       response_types: ['code'],
       scope: this.config.scopes ? this.config.scopes.join(' ') : '',
     };
 
     await this._clientsStore.registerClient(client);
+    this.materializedUnregisteredClientIds.add(clientId);
     this.logger.info('Materialized approved unregistered OAuth client', {
       clientId,
       redirectUri,
     });
     return client;
+  }
+
+  hasMaterializedUnregisteredClient(clientId: string): boolean {
+    return this.materializedUnregisteredClientIds.has(clientId);
+  }
+
+  private buildValidatedUnregisteredRedirectUriList(
+    existingRedirectUris: readonly string[],
+    nextRedirectUri: string,
+  ): string[] | undefined {
+    const redirectUris = Array.from(new Set([...existingRedirectUris, nextRedirectUri]));
+    const limits = this._clientsStore.getLimits();
+
+    if (redirectUris.length > limits.maxRedirectUris) {
+      this.logger.warn('Refused to materialize unregistered OAuth client redirect URI: max redirect URI count exceeded', {
+        redirectUriCount: redirectUris.length,
+        maxRedirectUris: limits.maxRedirectUris,
+      });
+      return undefined;
+    }
+
+    if (nextRedirectUri.length > limits.maxRedirectUriLength) {
+      this.logger.warn('Refused to materialize unregistered OAuth client redirect URI: redirect URI too long', {
+        redirectUriLength: nextRedirectUri.length,
+        maxRedirectUriLength: limits.maxRedirectUriLength,
+      });
+      return undefined;
+    }
+
+    return redirectUris;
   }
 
   /**
@@ -349,9 +427,12 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
       }
 
       const hostname = url.hostname;
+      if (hostname.includes('*') || url.pathname.includes('*')) {
+        return false;
+      }
       
-      // Default to localhost only if not configured
-      const allowedHosts = this.config.allowed_redirect_hosts || ['localhost', '127.0.0.1'];
+      // Default to loopback hosts only if not configured
+      const allowedHosts = this.config.allowed_redirect_hosts || [...DEFAULT_ALLOWED_REDIRECT_HOSTS];
       
       for (const allowed of allowedHosts) {
         if (this.matchRedirectHost(hostname, allowed)) {
@@ -622,7 +703,7 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
     if (!this.isAllowedClientRedirectUri(client, params.redirectUri)) {
       this.logger.error('Redirect URI not allowed', undefined, {
         providedUri: params.redirectUri,
-        allowedHosts: this.config.allowed_redirect_hosts || ['localhost', '127.0.0.1'],
+        allowedHosts: this.config.allowed_redirect_hosts || [...DEFAULT_ALLOWED_REDIRECT_HOSTS],
         allowedUnregisteredRedirectUris: this.config.allowed_unregistered_redirect_uris,
       });
       throw new Error('Redirect URI not allowed');
@@ -748,7 +829,7 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
         if (!this.isAllowedClientRedirectUri(client, storedState.clientRedirectUri)) {
             this.logger.error('Redirect URI not allowed (callback)', undefined, {
                 storedUri: storedState.clientRedirectUri,
-                allowedHosts: this.config.allowed_redirect_hosts || ['localhost', '127.0.0.1'],
+                allowedHosts: this.config.allowed_redirect_hosts || [...DEFAULT_ALLOWED_REDIRECT_HOSTS],
                 allowedUnregisteredRedirectUris: this.config.allowed_unregistered_redirect_uris,
             });
             res.status(400).send('Redirect URI not allowed');

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -202,11 +202,7 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
       return undefined;
     }
 
-    if (!isApprovedUnregisteredClientRedirectUri(
-      redirectUri,
-      this.config.allowed_unregistered_redirect_uris,
-      this.logger,
-    )) {
+    if (!this.isApprovedUnregisteredClientRedirectUri(redirectUri)) {
       return undefined;
     }
 
@@ -368,6 +364,33 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
       // Invalid URL
       return false;
     }
+  }
+
+  private isApprovedUnregisteredClientRedirectUri(redirectUri: string): boolean {
+    return isApprovedUnregisteredClientRedirectUri(
+      redirectUri,
+      this.config.allowed_unregistered_redirect_uris,
+      this.logger,
+    );
+  }
+
+  private isAllowedClientRedirectUri(
+    client: OAuthClientInformationFull,
+    redirectUri: string,
+  ): boolean {
+    if (this.isAllowedRedirectHost(redirectUri)) {
+      return true;
+    }
+
+    if (!this.config.allow_unregistered_clients) {
+      return false;
+    }
+
+    if (!client.redirect_uris?.includes(redirectUri)) {
+      return false;
+    }
+
+    return this.isApprovedUnregisteredClientRedirectUri(redirectUri);
   }
 
   /**
@@ -595,11 +618,12 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
       throw new Error('Unregistered redirect_uri');
     }
 
-    // Validate redirect host against allowlist to prevent open redirect
-    if (!this.isAllowedRedirectHost(params.redirectUri)) {
+    // Validate redirect against configured policies to prevent open redirect
+    if (!this.isAllowedClientRedirectUri(client, params.redirectUri)) {
       this.logger.error('Redirect URI not allowed', undefined, {
         providedUri: params.redirectUri,
         allowedHosts: this.config.allowed_redirect_hosts || ['localhost', '127.0.0.1'],
+        allowedUnregisteredRedirectUris: this.config.allowed_unregistered_redirect_uris,
       });
       throw new Error('Redirect URI not allowed');
     }
@@ -720,11 +744,12 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
         });
         this._clientsStore.markAuthCodeOpened(client.client_id);
 
-        // Re-validate redirect URI host + registration before redirect (defense-in-depth)
-        if (!this.isAllowedRedirectHost(storedState.clientRedirectUri)) {
+        // Re-validate redirect URI policy + registration before redirect (defense-in-depth)
+        if (!this.isAllowedClientRedirectUri(client, storedState.clientRedirectUri)) {
             this.logger.error('Redirect URI not allowed (callback)', undefined, {
                 storedUri: storedState.clientRedirectUri,
                 allowedHosts: this.config.allowed_redirect_hosts || ['localhost', '127.0.0.1'],
+                allowedUnregisteredRedirectUris: this.config.allowed_unregistered_redirect_uris,
             });
             res.status(400).send('Redirect URI not allowed');
             return;

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -33,6 +33,7 @@ import { escapeHtmlSafe } from '../validation/validation-utils.js';
 import { SSRFValidator } from '../security/ssrf-validator.js';
 import { parseOAuthMetadataEndpoints } from './oauth-metadata.js';
 import { InMemoryClientsStore } from './client-store/in-memory-clients-store.js';
+import { isApprovedUnregisteredClientRedirectUri } from './unregistered-client-redirect-policy.js';
 export { InMemoryClientsStore };
 export type { InMemoryClientsStoreOptions } from './client-store/types.js';
 
@@ -191,6 +192,43 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
 
   get scopes(): string[] {
     return this.config.scopes || [];
+  }
+
+  async getOrProvisionUnregisteredClient(
+    clientId: string,
+    redirectUri: string,
+  ): Promise<OAuthClientInformationFull | undefined> {
+    if (!this.config.allow_unregistered_clients) {
+      return undefined;
+    }
+
+    if (!isApprovedUnregisteredClientRedirectUri(
+      redirectUri,
+      this.config.allowed_unregistered_redirect_uris,
+      this.logger,
+    )) {
+      return undefined;
+    }
+
+    const existingClient = await this._clientsStore.getClient(clientId);
+    if (existingClient) {
+      return existingClient;
+    }
+
+    const client: OAuthClientInformationFull = {
+      client_id: clientId,
+      redirect_uris: [redirectUri],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      scope: this.config.scopes ? this.config.scopes.join(' ') : '',
+    };
+
+    await this._clientsStore.registerClient(client);
+    this.logger.info('Materialized approved unregistered OAuth client', {
+      clientId,
+      redirectUri,
+    });
+    return client;
   }
 
   /**

--- a/src/auth/unregistered-client-redirect-policy.test.ts
+++ b/src/auth/unregistered-client-redirect-policy.test.ts
@@ -12,6 +12,13 @@ function createLogger(): Logger {
 }
 
 describe('isApprovedUnregisteredClientRedirectUri', () => {
+  it('rejects missing approval rules', () => {
+    const logger = createLogger();
+
+    expect(isApprovedUnregisteredClientRedirectUri('http://localhost/callback', undefined, logger)).toBe(false);
+    expect(isApprovedUnregisteredClientRedirectUri('http://localhost/callback', [], logger)).toBe(false);
+  });
+
   it('allows loopback origin rules with dynamic ports', () => {
     const logger = createLogger();
 
@@ -26,6 +33,39 @@ describe('isApprovedUnregisteredClientRedirectUri', () => {
       isApprovedUnregisteredClientRedirectUri(
         'http://127.0.0.1:3000/oauth/callback',
         ['http://127.0.0.1'],
+        logger,
+      ),
+    ).toBe(true);
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'https://service.example.com/callback',
+        ['https://service.example.com'],
+        logger,
+      ),
+    ).toBe(true);
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'http://service.example.com/callback',
+        ['http://service.example.com'],
+        logger,
+      ),
+    ).toBe(true);
+  });
+
+  it('requires exact ports for non-loopback approvals', () => {
+    const logger = createLogger();
+
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'https://service.example.com:8443/callback',
+        ['https://service.example.com'],
+        logger,
+      ),
+    ).toBe(false);
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'https://service.example.com:8443/callback',
+        ['https://service.example.com:8443'],
         logger,
       ),
     ).toBe(true);
@@ -86,5 +126,56 @@ describe('isApprovedUnregisteredClientRedirectUri', () => {
         logger,
       ),
     ).toBe(false);
+  });
+
+  it('supports approved path prefixes and rejects sibling or protocol-mismatched paths', () => {
+    const logger = createLogger();
+
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'https://service.example.com/oauth/callback/child',
+        ['https://service.example.com/oauth/callback'],
+        logger,
+      ),
+    ).toBe(true);
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'https://service.example.com/oauth/other',
+        ['https://service.example.com/oauth/callback'],
+        logger,
+      ),
+    ).toBe(false);
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'https://service.example.com/oauth/callback',
+        ['http://service.example.com/oauth/callback'],
+        logger,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects invalid or dangerous redirect URIs', () => {
+    const logger = createLogger();
+
+    expect(isApprovedUnregisteredClientRedirectUri('not-a-url', ['http://localhost'], logger)).toBe(false);
+    expect(isApprovedUnregisteredClientRedirectUri('javascript:alert(1)', ['javascript://'], logger)).toBe(false);
+    expect(isApprovedUnregisteredClientRedirectUri('cursor://client/callback#fragment', ['cursor://'], logger)).toBe(false);
+    expect(isApprovedUnregisteredClientRedirectUri('http:/callback', ['http://localhost'], logger)).toBe(false);
+  });
+
+  it('ignores invalid approval rules and logs a warning', () => {
+    const logger = createLogger();
+
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'https://service.example.com/callback',
+        ['not-a-url', 'https://service.example.com/callback'],
+        logger,
+      ),
+    ).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Ignoring invalid approved unregistered OAuth redirect URI rule',
+      { rule: 'not-a-url' },
+    );
   });
 });

--- a/src/auth/unregistered-client-redirect-policy.test.ts
+++ b/src/auth/unregistered-client-redirect-policy.test.ts
@@ -161,6 +161,15 @@ describe('isApprovedUnregisteredClientRedirectUri', () => {
     expect(isApprovedUnregisteredClientRedirectUri('javascript:alert(1)', ['javascript://'], logger)).toBe(false);
     expect(isApprovedUnregisteredClientRedirectUri('cursor://client/callback#fragment', ['cursor://'], logger)).toBe(false);
     expect(isApprovedUnregisteredClientRedirectUri('http:/callback', ['http://localhost'], logger)).toBe(false);
+    expect(isApprovedUnregisteredClientRedirectUri('https://user:secret@service.example.com/callback', ['https://service.example.com'], logger)).toBe(false);
+  });
+
+  it('allows non-hierarchical custom scheme redirects but rejects empty-host http-style approvals', () => {
+    const logger = createLogger();
+
+    expect(isApprovedUnregisteredClientRedirectUri('custom:/oauth/callback', ['custom://'], logger)).toBe(true);
+    expect(isApprovedUnregisteredClientRedirectUri('custom:path', ['custom://'], logger)).toBe(true);
+    expect(isApprovedUnregisteredClientRedirectUri('custom:/oauth/callback', ['http://'], logger)).toBe(false);
   });
 
   it('ignores invalid approval rules and logs a warning', () => {

--- a/src/auth/unregistered-client-redirect-policy.test.ts
+++ b/src/auth/unregistered-client-redirect-policy.test.ts
@@ -109,7 +109,7 @@ describe('isApprovedUnregisteredClientRedirectUri', () => {
     ).toBe(false);
   });
 
-  it('supports explicit scheme-only approvals', () => {
+  it('supports explicit scheme-only approvals for custom schemes only', () => {
     const logger = createLogger();
 
     expect(
@@ -126,6 +126,17 @@ describe('isApprovedUnregisteredClientRedirectUri', () => {
         logger,
       ),
     ).toBe(false);
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'http://localhost:43123/oauth/callback',
+        ['http://'],
+        logger,
+      ),
+    ).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Ignoring insecure scheme-only unregistered OAuth redirect URI rule',
+      { rule: 'http://' },
+    );
   });
 
   it('supports approved path prefixes and rejects sibling or protocol-mismatched paths', () => {
@@ -162,6 +173,8 @@ describe('isApprovedUnregisteredClientRedirectUri', () => {
     expect(isApprovedUnregisteredClientRedirectUri('cursor://client/callback#fragment', ['cursor://'], logger)).toBe(false);
     expect(isApprovedUnregisteredClientRedirectUri('http:/callback', ['http://localhost'], logger)).toBe(false);
     expect(isApprovedUnregisteredClientRedirectUri('https://user:secret@service.example.com/callback', ['https://service.example.com'], logger)).toBe(false);
+    expect(isApprovedUnregisteredClientRedirectUri('cursor://*/oauth/callback', ['cursor://'], logger)).toBe(false);
+    expect(isApprovedUnregisteredClientRedirectUri('cursor://client/*', ['cursor://'], logger)).toBe(false);
   });
 
   it('allows non-hierarchical custom scheme redirects but rejects empty-host http-style approvals', () => {

--- a/src/auth/unregistered-client-redirect-policy.test.ts
+++ b/src/auth/unregistered-client-redirect-policy.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Logger } from '../core/logger.js';
+import { isApprovedUnregisteredClientRedirectUri } from './unregistered-client-redirect-policy.js';
+
+function createLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe('isApprovedUnregisteredClientRedirectUri', () => {
+  it('allows loopback origin rules with dynamic ports', () => {
+    const logger = createLogger();
+
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'http://localhost:43123/oauth/callback',
+        ['http://localhost'],
+        logger,
+      ),
+    ).toBe(true);
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'http://127.0.0.1:3000/oauth/callback',
+        ['http://127.0.0.1'],
+        logger,
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects host confusion attacks for loopback approvals', () => {
+    const logger = createLogger();
+
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'http://localhost.evil.test/callback',
+        ['http://localhost'],
+        logger,
+      ),
+    ).toBe(false);
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'http://localhost@evil.test/callback',
+        ['http://localhost'],
+        logger,
+      ),
+    ).toBe(false);
+  });
+
+  it('supports exact custom-scheme host approvals', () => {
+    const logger = createLogger();
+
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'cursor://anysphere.cursor-mcp/oauth/callback',
+        ['cursor://anysphere.cursor-mcp'],
+        logger,
+      ),
+    ).toBe(true);
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'cursor://other-client/oauth/callback',
+        ['cursor://anysphere.cursor-mcp'],
+        logger,
+      ),
+    ).toBe(false);
+  });
+
+  it('supports explicit scheme-only approvals', () => {
+    const logger = createLogger();
+
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'cursor://any-client/oauth/callback',
+        ['cursor://'],
+        logger,
+      ),
+    ).toBe(true);
+    expect(
+      isApprovedUnregisteredClientRedirectUri(
+        'vscode://mcp/callback',
+        ['cursor://'],
+        logger,
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/auth/unregistered-client-redirect-policy.ts
+++ b/src/auth/unregistered-client-redirect-policy.ts
@@ -72,15 +72,7 @@ function parseSafeRedirectUri(value: string): URL | null {
     return null;
   }
 
-  if (parsed.hostname.length === 0 && !isNonHierarchicalCustomScheme(parsed)) {
-    return null;
-  }
-
   return parsed;
-}
-
-function isNonHierarchicalCustomScheme(url: URL): boolean {
-  return !url.protocol.startsWith('http') && url.hostname.length === 0;
 }
 
 function matchesPort(candidate: URL, approved: URL): boolean {

--- a/src/auth/unregistered-client-redirect-policy.ts
+++ b/src/auth/unregistered-client-redirect-policy.ts
@@ -1,0 +1,120 @@
+import type { Logger } from '../core/logger.js';
+
+const DANGEROUS_REDIRECT_SCHEMES = new Set(['javascript:', 'data:', 'vbscript:', 'file:', 'blob:', 'about:']);
+const SCHEME_ONLY_RULE = /^([a-zA-Z][a-zA-Z0-9+.-]*):\/\/$/;
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+
+export function isApprovedUnregisteredClientRedirectUri(
+  redirectUri: string,
+  approvedRedirects: string[] | undefined,
+  logger: Logger,
+): boolean {
+  if (!Array.isArray(approvedRedirects) || approvedRedirects.length === 0) {
+    return false;
+  }
+
+  const candidate = parseSafeRedirectUri(redirectUri);
+  if (!candidate) {
+    return false;
+  }
+
+  return approvedRedirects.some((rule) => matchesApprovedRedirectRule(candidate, rule, logger));
+}
+
+function matchesApprovedRedirectRule(candidate: URL, rule: string, logger: Logger): boolean {
+  const schemeOnly = SCHEME_ONLY_RULE.exec(rule);
+  if (schemeOnly) {
+    return candidate.protocol === `${schemeOnly[1].toLowerCase()}:`;
+  }
+
+  const approved = parseSafeRedirectUri(rule);
+  if (!approved) {
+    logger.warn('Ignoring invalid approved unregistered OAuth redirect URI rule', { rule });
+    return false;
+  }
+
+  if (candidate.protocol !== approved.protocol) {
+    return false;
+  }
+
+  if (candidate.hostname.toLowerCase() !== approved.hostname.toLowerCase()) {
+    return false;
+  }
+
+  if (!matchesPort(candidate, approved)) {
+    return false;
+  }
+
+  if (!matchesPathPrefix(candidate, approved)) {
+    return false;
+  }
+
+  return true;
+}
+
+function parseSafeRedirectUri(value: string): URL | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+
+  if (DANGEROUS_REDIRECT_SCHEMES.has(parsed.protocol.toLowerCase())) {
+    return null;
+  }
+
+  if ((parsed.username && parsed.username.length > 0) || (parsed.password && parsed.password.length > 0)) {
+    return null;
+  }
+
+  if (parsed.hash && parsed.hash.length > 0) {
+    return null;
+  }
+
+  if (parsed.hostname.length === 0 && !isNonHierarchicalCustomScheme(parsed)) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function isNonHierarchicalCustomScheme(url: URL): boolean {
+  return !url.protocol.startsWith('http') && url.hostname.length === 0;
+}
+
+function matchesPort(candidate: URL, approved: URL): boolean {
+  if (approved.port.length > 0) {
+    return normalizedPort(candidate) === normalizedPort(approved);
+  }
+
+  if (LOOPBACK_HOSTS.has(approved.hostname.toLowerCase())) {
+    return true;
+  }
+
+  return normalizedPort(candidate) === normalizedPort(approved);
+}
+
+function matchesPathPrefix(candidate: URL, approved: URL): boolean {
+  if (!approved.pathname || approved.pathname === '/') {
+    return true;
+  }
+
+  return candidate.pathname === approved.pathname
+    || candidate.pathname.startsWith(`${approved.pathname.replace(/\/$/, '')}/`);
+}
+
+function normalizedPort(url: URL): string {
+  if (url.port.length > 0) {
+    return url.port;
+  }
+
+  if (url.protocol === 'http:') {
+    return '80';
+  }
+  if (url.protocol === 'https:') {
+    return '443';
+  }
+
+  return '';
+}

--- a/src/auth/unregistered-client-redirect-policy.ts
+++ b/src/auth/unregistered-client-redirect-policy.ts
@@ -24,7 +24,15 @@ export function isApprovedUnregisteredClientRedirectUri(
 function matchesApprovedRedirectRule(candidate: URL, rule: string, logger: Logger): boolean {
   const schemeOnly = SCHEME_ONLY_RULE.exec(rule);
   if (schemeOnly) {
-    return candidate.protocol === `${schemeOnly[1].toLowerCase()}:`;
+    const scheme = schemeOnly[1].toLowerCase();
+    if (scheme === 'http' || scheme === 'https') {
+      logger.warn('Ignoring insecure scheme-only unregistered OAuth redirect URI rule', { rule });
+      return false;
+    }
+    // Scheme-only approvals are intentionally limited to custom schemes.
+    // They do not support wildcard host/path matching; runtime redirect URIs
+    // must still be concrete callback URLs without "*" components.
+    return candidate.protocol === `${scheme}:`;
   }
 
   const approved = parseSafeRedirectUri(rule);
@@ -69,6 +77,10 @@ function parseSafeRedirectUri(value: string): URL | null {
   }
 
   if (parsed.hash && parsed.hash.length > 0) {
+    return null;
+  }
+
+  if (parsed.hostname.includes('*') || parsed.pathname.includes('*')) {
     return null;
   }
 

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -69,6 +69,17 @@ export const OAUTH_PATHS = {
 } as const;
 
 /**
+ * Default loopback redirect allowances for local OAuth clients.
+ *
+ * Why: Keep loopback host defaults centralized so logs, validation, and
+ * compatibility fallbacks stay aligned without scattering hardcoded hosts.
+ */
+export const DEFAULT_ALLOWED_REDIRECT_HOSTS = ['localhost', '127.0.0.1'] as const;
+export const DEFAULT_OAUTH_LOOPBACK_CALLBACK_URIS = DEFAULT_ALLOWED_REDIRECT_HOSTS.map(
+  (host) => `http://${host}:3003${OAUTH_PATHS.CALLBACK}`,
+);
+
+/**
  * Default timeout and interval values (in milliseconds)
  * 
  * Why: Centralized timing configuration for sessions, heartbeats, and cleanup.

--- a/src/generated-schemas.ts
+++ b/src/generated-schemas.ts
@@ -171,7 +171,9 @@ export const oAuthConfigSchema = z.object({
     registration_endpoint: z.string().optional(),
     introspection_endpoint: z.string().optional(),
     revocation_endpoint: z.string().optional(),
-    allowed_redirect_hosts: z.array(z.string()).optional()
+    allowed_redirect_hosts: z.array(z.string()).optional(),
+    allow_unregistered_clients: z.boolean().optional(),
+    allowed_unregistered_redirect_uris: z.array(z.string()).optional()
 });
 
 export const sessionCookieConfigSchema = z.object({

--- a/src/transport/http-transport.test.ts
+++ b/src/transport/http-transport.test.ts
@@ -2434,13 +2434,69 @@ describeIfListen('HttpTransport', () => {
 	      expect(response.status).toBe(302);
 	      expect(response.headers.location).toContain('https://auth.example.com/oauth/authorize');
 
-	      const provider = (oauthTransport as any).profileStates.get('default').oauthProvider;
-	      const materializedClient = await provider.clientsStore.getClient('cursor-client-id');
-	      expect(materializedClient).toMatchObject({
-	        client_id: 'cursor-client-id',
-	        redirect_uris: ['http://localhost:43123/oauth/callback'],
-	      });
-	    });
+      const provider = (oauthTransport as any).profileStates.get('default').oauthProvider;
+      const materializedClient = await provider.clientsStore.getClient('cursor-client-id');
+      expect(materializedClient).toMatchObject({
+        client_id: 'cursor-client-id',
+        redirect_uris: ['http://localhost:43123/oauth/callback'],
+      });
+    });
+
+    it('should append approved loopback redirects for an existing materialized unregistered OAuth client', async () => {
+      await oauthTransport.stop();
+
+      oauthTransport = new HttpTransport({
+        host: '127.0.0.1',
+        port: 0,
+        sessionTimeoutMs: 1800000,
+        heartbeatEnabled: false,
+        heartbeatIntervalMs: 30000,
+        metricsEnabled: false,
+        metricsPath: '/metrics',
+        oauthConfig: {
+          issuer: 'https://auth.example.com',
+          client_id: 'test-client',
+          client_secret: 'test-secret',
+          redirect_uri: 'http://127.0.0.1:3003/oauth/callback',
+          scopes: ['read', 'write'],
+          allow_unregistered_clients: true,
+          allowed_unregistered_redirect_uris: ['http://localhost'],
+        },
+      }, logger);
+      oauthApp = (oauthTransport as any).app;
+
+      await request(oauthApp)
+        .get('/oauth/authorize')
+        .query({
+          response_type: 'code',
+          client_id: 'cursor-client-id',
+          redirect_uri: 'http://localhost:43123/oauth/callback',
+          code_challenge: 'challenge',
+          code_challenge_method: 'S256',
+        })
+        .expect(302);
+
+      await request(oauthApp)
+        .get('/oauth/authorize')
+        .query({
+          response_type: 'code',
+          client_id: 'cursor-client-id',
+          redirect_uri: 'http://localhost:43124/oauth/callback',
+          code_challenge: 'challenge-2',
+          code_challenge_method: 'S256',
+        })
+        .expect(302);
+
+      const provider = (oauthTransport as any).profileStates.get('default').oauthProvider;
+      const materializedClient = await provider.clientsStore.getClient('cursor-client-id');
+      expect(materializedClient).toMatchObject({
+        client_id: 'cursor-client-id',
+        redirect_uris: [
+          'http://localhost:43123/oauth/callback',
+          'http://localhost:43124/oauth/callback',
+        ],
+      });
+    });
 
 	    it('should allow approved custom scheme redirects for unregistered OAuth clients', async () => {
 	      await oauthTransport.stop();

--- a/src/transport/http-transport.test.ts
+++ b/src/transport/http-transport.test.ts
@@ -2397,6 +2397,50 @@ describeIfListen('HttpTransport', () => {
 
 	      expect(response.status).toBe(400);
 	    });
+
+	    it('should allow approved unregistered OAuth clients for authorize requests', async () => {
+	      await oauthTransport.stop();
+
+	      oauthTransport = new HttpTransport({
+	        host: '127.0.0.1',
+	        port: 0,
+	        sessionTimeoutMs: 1800000,
+	        heartbeatEnabled: false,
+	        heartbeatIntervalMs: 30000,
+	        metricsEnabled: false,
+	        metricsPath: '/metrics',
+	        oauthConfig: {
+	          issuer: 'https://auth.example.com',
+	          client_id: 'test-client',
+	          client_secret: 'test-secret',
+	          redirect_uri: 'http://127.0.0.1:3003/oauth/callback',
+	          scopes: ['read', 'write'],
+	          allow_unregistered_clients: true,
+	          allowed_unregistered_redirect_uris: ['http://localhost', 'cursor://'],
+	        },
+	      }, logger);
+	      oauthApp = (oauthTransport as any).app;
+
+	      const response = await request(oauthApp)
+	        .get('/oauth/authorize')
+	        .query({
+	          response_type: 'code',
+	          client_id: 'cursor-client-id',
+	          redirect_uri: 'http://localhost:43123/oauth/callback',
+	          code_challenge: 'challenge',
+	          code_challenge_method: 'S256',
+	        });
+
+	      expect(response.status).toBe(302);
+	      expect(response.headers.location).toContain('https://auth.example.com/oauth/authorize');
+
+	      const provider = (oauthTransport as any).profileStates.get('default').oauthProvider;
+	      const materializedClient = await provider.clientsStore.getClient('cursor-client-id');
+	      expect(materializedClient).toMatchObject({
+	        client_id: 'cursor-client-id',
+	        redirect_uris: ['http://localhost:43123/oauth/callback'],
+	      });
+	    });
 	  });
 
   describe('OAuth Well-Known Endpoint', () => {

--- a/src/transport/http-transport.test.ts
+++ b/src/transport/http-transport.test.ts
@@ -2441,6 +2441,50 @@ describeIfListen('HttpTransport', () => {
 	        redirect_uris: ['http://localhost:43123/oauth/callback'],
 	      });
 	    });
+
+	    it('should allow approved custom scheme redirects for unregistered OAuth clients', async () => {
+	      await oauthTransport.stop();
+
+	      oauthTransport = new HttpTransport({
+	        host: '127.0.0.1',
+	        port: 0,
+	        sessionTimeoutMs: 1800000,
+	        heartbeatEnabled: false,
+	        heartbeatIntervalMs: 30000,
+	        metricsEnabled: false,
+	        metricsPath: '/metrics',
+	        oauthConfig: {
+	          issuer: 'https://auth.example.com',
+	          client_id: 'test-client',
+	          client_secret: 'test-secret',
+	          redirect_uri: 'http://127.0.0.1:3003/oauth/callback',
+	          scopes: ['read', 'write'],
+	          allow_unregistered_clients: true,
+	          allowed_unregistered_redirect_uris: ['cursor://'],
+	        },
+	      }, logger);
+	      oauthApp = (oauthTransport as any).app;
+
+	      const response = await request(oauthApp)
+	        .get('/oauth/authorize')
+	        .query({
+	          response_type: 'code',
+	          client_id: 'cursor-client-id',
+	          redirect_uri: 'cursor://anysphere.cursor-mcp/oauth/callback',
+	          code_challenge: 'challenge',
+	          code_challenge_method: 'S256',
+	        });
+
+	      expect(response.status).toBe(302);
+	      expect(response.headers.location).toContain('https://auth.example.com/oauth/authorize');
+
+	      const provider = (oauthTransport as any).profileStates.get('default').oauthProvider;
+	      const materializedClient = await provider.clientsStore.getClient('cursor-client-id');
+	      expect(materializedClient).toMatchObject({
+	        client_id: 'cursor-client-id',
+	        redirect_uris: ['cursor://anysphere.cursor-mcp/oauth/callback'],
+	      });
+	    });
 	  });
 
   describe('OAuth Well-Known Endpoint', () => {

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -39,7 +39,15 @@ import { redactAuthPayload } from '../auth/auth-redaction.js';
 import { OAuthGrantRouter } from './oauth-grant-router.js';
 import { SSRFValidator } from '../security/ssrf-validator.js';
 import type { AuthInterceptor, OAuthConfig } from '../types/profile.js';
-import { HTTP_STATUS, MIME_TYPES, OAUTH_PATHS, TIMEOUTS, OAUTH_RATE_LIMIT, PROXY_CREDENTIALS } from '../core/constants.js';
+import {
+  DEFAULT_ALLOWED_REDIRECT_HOSTS,
+  HTTP_STATUS,
+  MIME_TYPES,
+  OAUTH_PATHS,
+  TIMEOUTS,
+  OAUTH_RATE_LIMIT,
+  PROXY_CREDENTIALS,
+} from '../core/constants.js';
 import { escapeHtmlSafe, isSafePropertyName } from '../validation/validation-utils.js';
 import type { OAuthClientInformationFull, OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js';
 import {
@@ -255,7 +263,7 @@ export class HttpTransport {
       const hostCfg = this.config.host?.toLowerCase();
       if (hostCfg === 'localhost' || hostCfg === '127.0.0.1') {
         const hostHeader = (req.headers['host'] || '').toString().toLowerCase();
-        const expectedHosts = new Set(['localhost', '127.0.0.1']);
+        const expectedHosts = new Set<string>(DEFAULT_ALLOWED_REDIRECT_HOSTS);
         const headerHostOnly = hostHeader.split(':')[0];
         if (!expectedHosts.has(headerHostOnly)) {
           this.logger.warn('DNS rebinding protection: invalid Host header', {
@@ -1963,8 +1971,20 @@ export class HttpTransport {
       return undefined;
     }
 
+    const shouldTryUnregisteredProvisioning =
+      typeof redirectUri === 'string'
+      && redirectUri.length > 0
+      && typeof profileState.oauthProvider.getOrProvisionUnregisteredClient === 'function';
+
     const client = await profileState.oauthProvider.clientsStore.getClient(clientId);
     if (client) {
+      if (
+        shouldTryUnregisteredProvisioning
+        && typeof profileState.oauthProvider.hasMaterializedUnregisteredClient === 'function'
+        && profileState.oauthProvider.hasMaterializedUnregisteredClient(clientId)
+      ) {
+        return profileState.oauthProvider.getOrProvisionUnregisteredClient(clientId, redirectUri);
+      }
       return client;
     }
 
@@ -1974,11 +1994,7 @@ export class HttpTransport {
       return profileState.oauthProvider.clientsStore.getClient(PROXY_CREDENTIALS.CLIENT_ID);
     }
 
-    if (
-      typeof redirectUri === 'string'
-      && redirectUri.length > 0
-      && typeof profileState.oauthProvider.getOrProvisionUnregisteredClient === 'function'
-    ) {
+    if (shouldTryUnregisteredProvisioning) {
       return profileState.oauthProvider.getOrProvisionUnregisteredClient(clientId, redirectUri);
     }
 

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -1782,7 +1782,7 @@ export class HttpTransport {
       }
 
       await profileState.oauthProvider.ensureEndpointsInitialized();
-      const client = await this.resolveOAuthClientForRequest(profileState, client_id);
+      const client = await this.resolveOAuthClientForRequest(profileState, client_id, redirect_uri);
       if (!client) {
         this.logger.warn('OAuth authorize rejected invalid client_id', {
           profileId: profileState.profileId,
@@ -1956,7 +1956,8 @@ export class HttpTransport {
 
   private async resolveOAuthClientForRequest(
     profileState: ProfileRuntimeState,
-    clientId: string
+    clientId: string,
+    redirectUri?: string,
   ): Promise<OAuthClientInformationFull | undefined> {
     if (!profileState.oauthProvider) {
       return undefined;
@@ -1971,6 +1972,14 @@ export class HttpTransport {
     // even when MCP_PROXY_CLIENT_ID is overridden in environment.
     if (clientId === 'mcp-proxy-client' && PROXY_CREDENTIALS.CLIENT_ID !== 'mcp-proxy-client') {
       return profileState.oauthProvider.clientsStore.getClient(PROXY_CREDENTIALS.CLIENT_ID);
+    }
+
+    if (
+      typeof redirectUri === 'string'
+      && redirectUri.length > 0
+      && typeof profileState.oauthProvider.getOrProvisionUnregisteredClient === 'function'
+    ) {
+      return profileState.oauthProvider.getOrProvisionUnregisteredClient(clientId, redirectUri);
     }
 
     return undefined;

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -562,6 +562,23 @@ export interface OAuthConfig {
    * Can reference MCP4_ALLOWED_ORIGINS environment variable
    */
   allowed_redirect_hosts?: string[];
+
+  /**
+   * Optional: Allow authorize requests for OAuth client IDs that are not registered
+   * on the current instance, but only when redirect_uri matches an approved rule.
+   * Disabled by default.
+   */
+  allow_unregistered_clients?: boolean;
+
+  /**
+   * Optional: Approved redirect URI rules for unregistered OAuth clients.
+   * Examples:
+   * - "http://localhost"
+   * - "http://127.0.0.1"
+   * - "cursor://"
+   * - "cursor://anysphere.cursor-mcp"
+   */
+  allowed_unregistered_redirect_uris?: string[];
 }
 
 export interface EnterpriseAuthorizationConfig {


### PR DESCRIPTION
## Summary
- allow authorize requests to provision a local OAuth client when the `client_id` is not registered but the `redirect_uri` matches an explicit allowlist
- apply the same redirect policy during authorize and callback so approved custom-scheme redirects (for example `cursor://...`) work end-to-end
- add regression coverage for loopback and custom-scheme callbacks in provider and HTTP transport tests

## Testing
- [x] `npm test -- src/auth/oauth-provider.test.ts src/transport/http-transport.test.ts`

Agent-authored PR.
