### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in composite executor

### DIFF
--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -65,9 +65,9 @@ describe('CompositeExecutor Security', () => {
 
     // Vulnerable behavior: path contains raw ".."
     // Fixed behavior: path contains encoded "%2E%2E"
-    // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
+    // Note: encodeURIComponent('../admin/secrets').replace(/\./g, '%2E') => %2E%2E%2Fadmin%2Fsecrets
     // The slashes inside the injected value are encoded, preventing directory traversal
-    const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -171,14 +171,14 @@ export class CompositeExecutor {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
+        return encodeURIComponent(String(args[key])).replace(/\./g, '%2E');
       }
 
       // Try aliases from profile
       const possibleAliases = this.parameterAliases[key] || [];
       for (const alias of possibleAliases) {
         if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+          return encodeURIComponent(String(args[alias])).replace(/\./g, '%2E');
         }
       }
 


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Path Traversal in `CompositeExecutor` during path interpolation. The code was using `encodeURIComponent` which intentionally does not encode the dot character `.`. If malicious user input (e.g., `../admin`) was substituted into a path template (e.g., `/users/{id}`), it would evaluate to `/users/../admin` which standard web routers resolve to `/admin`, potentially bypassing intended scope restrictions.
🎯 **Impact**: Allowed a client to navigate API directory trees and access unintended endpoints if composite steps included paths populated directly by unfiltered user input.
🔧 **Fix**: Updated `src/tooling/composite-executor.ts` to explicitly replace `.` with its url-encoded form `%2E` after the standard `encodeURIComponent` call.
✅ **Verification**: Run `npm run test` which executes the updated `composite-executor-security.test.ts` to ensure path traversals are properly neutralized into `%2E%2E` segments.

---
*PR created automatically by Jules for task [16523618350465977163](https://jules.google.com/task/16523618350465977163) started by @davidruzicka*