### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix path traversal vulnerability in CompositeExecutor

### DIFF
--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -65,9 +65,9 @@ describe('CompositeExecutor Security', () => {
 
     // Vulnerable behavior: path contains raw ".."
     // Fixed behavior: path contains encoded "%2E%2E"
-    // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
-    // The slashes inside the injected value are encoded, preventing directory traversal
-    const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
+    // Note: encodeURIComponent('../admin/secrets') => %2E%2E%2Fadmin%2Fsecrets
+    // The slashes and dots inside the injected value are encoded, preventing directory traversal
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -171,14 +171,14 @@ export class CompositeExecutor {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
+        return encodeURIComponent(String(args[key])).replace(/\./g, '%2E');
       }
 
       // Try aliases from profile
       const possibleAliases = this.parameterAliases[key] || [];
       for (const alias of possibleAliases) {
         if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+          return encodeURIComponent(String(args[alias])).replace(/\./g, '%2E');
         }
       }
 


### PR DESCRIPTION
Fix path traversal vulnerability in CompositeExecutor

In `src/tooling/composite-executor.ts`, parameter values for path template
substitutions were URL encoded using `encodeURIComponent`. However, this
function does not encode dot (`.`) characters. When substituting a value
like `../admin`, the dots remained unencoded, potentially resulting in
a client-side path traversal (e.g., `GET /users/../admin/profile` being
normalized by HTTP clients to `GET /admin/profile`).

This patch chains `.replace(/\./g, '%2E')` onto the `encodeURIComponent`
calls in the `resolvePath` method to explicitly encode dots, ensuring
that injected parameters cannot traverse directory boundaries. The security
test in `src/tooling/composite-executor-security.test.ts` was also updated
to assert the fully encoded path output.

---
*PR created automatically by Jules for task [2171459544460059120](https://jules.google.com/task/2171459544460059120) started by @davidruzicka*