### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix internal error leakage via JSON-RPC responses

### DIFF
--- a/src/mcp/mcp-server-apps.test.ts
+++ b/src/mcp/mcp-server-apps.test.ts
@@ -275,14 +275,10 @@ describe('MCPServer apps resources', () => {
       },
     });
 
-    expect(invalidReadResponse.error).toEqual({
-      code: -32602,
-      message: 'resources/read requires string parameter "uri"',
-    });
-    expect(invalidCompletionResponse.error).toEqual({
-      code: -32602,
-      message: 'completion/complete requires a resource ref',
-    });
+    expect(invalidReadResponse.error?.code).toEqual(-32602);
+    expect(invalidReadResponse.error?.message).toMatch(/^Validation error: resources\/read requires string parameter "uri" \(correlation ID: [a-f0-9-]+\)$/);
+    expect(invalidCompletionResponse.error?.code).toEqual(-32602);
+    expect(invalidCompletionResponse.error?.message).toMatch(/^Validation error: completion\/complete requires a resource ref \(correlation ID: [a-f0-9-]+\)$/);
   });
 
   it('propagates session context to fetch-backed resource and completion lookups', async () => {

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1851,6 +1851,9 @@ export class MCPServer {
           result: promptResult,
         };
       } catch (error) {
+        const correlationId = generateCorrelationId();
+        this.logger.error('prompts/get handler error', error instanceof Error ? error : new Error(String(error)), { correlationId });
+
         let code = -32603;
         if (error instanceof ValidationError) {
           code = -32602;
@@ -1863,7 +1866,7 @@ export class MCPServer {
           id: req.id,
           error: {
             code,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }
@@ -1901,12 +1904,14 @@ export class MCPServer {
           result: await this.readResource(params.uri, sessionId, profileId),
         };
       } catch (error) {
+        const correlationId = generateCorrelationId();
+        this.logger.error('resources/read handler error', error instanceof Error ? error : new Error(String(error)), { correlationId });
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code: error instanceof ValidationError ? -32602 : -32601,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }
@@ -1920,12 +1925,14 @@ export class MCPServer {
           result: await this.completeResourceArgument(req as CompleteRequest, sessionId, profileId),
         };
       } catch (error) {
+        const correlationId = generateCorrelationId();
+        this.logger.error('completion/complete handler error', error instanceof Error ? error : new Error(String(error)), { correlationId });
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code: error instanceof ValidationError ? -32602 : -32601,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The MCP server's `handleOtherRequest` method was catching exceptions and returning the raw error message directly to the client in JSON-RPC responses for methods like `prompts/get`, `resources/read`, and `completion/complete`.
🎯 **Impact:** Exposing raw internal errors to clients can leak sensitive information such as file paths, database structures, or underlying software configurations, aiding attackers in reconnaissance.
🔧 **Fix:** I updated the `catch` blocks for these handlers to generate a correlation ID, log the raw error securely server-side, and return a sanitized, generic message to the client using `this.formatErrorForClient(error, correlationId)`.
✅ **Verification:** Verified by running the full test suite (`npm run test`), which asserts that `Validation error:` responses include the dynamic correlation ID and do not expose stack traces.

---
*PR created automatically by Jules for task [12616939701943940330](https://jules.google.com/task/12616939701943940330) started by @davidruzicka*