### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal via encodeURIComponent bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,14 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2026-04-11 - [HIGH] Path Traversal Mitigation Bypass
+
+**Vulnerability:**
+The `encodeURIComponent` function does not encode the dot (`.`) character. Therefore, when user input containing `..` is substituted into a URL path using only `encodeURIComponent`, the directory traversal vector `..` remains intact, allowing attackers to access unintended endpoints.
+
+**Learning:**
+Relying solely on standard `encodeURIComponent` for path segment substitution is insufficient to prevent path traversal. While it successfully encodes `/` to `%2F`, preventing direct directory climbing in some servers, other servers or proxies may decode `%2F` or process `..` before decoding, leading to traversal.
+
+**Prevention:**
+1. Explicitly encode dot (`.`) characters in path segments after applying `encodeURIComponent`. For example: `encodeURIComponent(value).replace(/\./g, '%2E')`.

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1107,7 +1107,7 @@ export class MCPServer {
    */
   private encodePathSegment(value: unknown): string {
     const val = String(value);
-    return val.includes('/') ? encodeURIComponent(val) : val;
+    return val.includes('/') ? encodeURIComponent(val).replace(/\./g, '%2E') : val;
   }
 
   /**

--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -67,7 +67,7 @@ describe('CompositeExecutor Security', () => {
     // Fixed behavior: path contains encoded "%2E%2E"
     // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
     // The slashes inside the injected value are encoded, preventing directory traversal
-    const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -171,14 +171,14 @@ export class CompositeExecutor {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
+        return encodeURIComponent(String(args[key])).replace(/\./g, '%2E');
       }
 
       // Try aliases from profile
       const possibleAliases = this.parameterAliases[key] || [];
       for (const alias of possibleAliases) {
         if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+          return encodeURIComponent(String(args[alias])).replace(/\./g, '%2E');
         }
       }
 


### PR DESCRIPTION
Fixes a path traversal vulnerability that occurs because `encodeURIComponent` preserves dot characters (`.`). By explicitly replacing dots with `%2E`, we ensure that inputs like `..` cannot bypass directory constraints.

---
*PR created automatically by Jules for task [3082728427786282925](https://jules.google.com/task/3082728427786282925) started by @davidruzicka*