### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent internal error leakage in OAuth callback

### DIFF
--- a/src/auth/oauth-provider.test.ts
+++ b/src/auth/oauth-provider.test.ts
@@ -1985,7 +1985,7 @@ describe('ExternalOAuthProvider', () => {
       await provider.handleCallback(mockReq, mockRes);
 
       expect(mockRes.status).toHaveBeenCalledWith(500);
-      expect(mockRes.send).toHaveBeenCalledWith('Internal Server Error during token exchange');
+      expect(mockRes.send).toHaveBeenCalledWith(expect.stringMatching(/^Internal error \(correlation ID: [a-f0-9-]+\)$/));
     });
   });
 

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -37,6 +37,7 @@ import {
 } from '../core/constants.js';
 import { escapeHtmlSafe } from '../validation/validation-utils.js';
 import { SSRFValidator } from '../security/ssrf-validator.js';
+import { generateCorrelationId } from '../core/errors.js';
 import { parseOAuthMetadataEndpoints } from './oauth-metadata.js';
 import { InMemoryClientsStore } from './client-store/in-memory-clients-store.js';
 import { isApprovedUnregisteredClientRedirectUri } from './unregistered-client-redirect-policy.js';
@@ -867,8 +868,9 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
         res.redirect(clientUrl.toString());
 
     } catch (err) {
-        this.logger.error('Callback handling failed', err as Error);
-        res.status(500).send('Internal Server Error during token exchange');
+        const correlationId = generateCorrelationId();
+        this.logger.error('Callback handling failed', err as Error, { correlationId });
+        res.status(500).send(`Internal error (correlation ID: ${correlationId})`);
     }
   }
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Prevent internal error leakage in OAuth callback

💡 Vulnerability: The `handleCallback` method in `ExternalOAuthProvider` was returning a raw string `Internal Server Error during token exchange` upon catch blocks, lacking a correlation ID and not strictly adhering to the standard 500 error format requested by Sentinel guidelines (which mandates logging a correlation ID and presenting a generic client message referencing it).
🎯 Impact: This missing structured logging makes debugging harder and diverges from the internal error leakage policy outlined in `.jules/sentinel.md`.
🔧 Fix: Imported `generateCorrelationId` and used it to log the full error stack with the `correlationId` internally, and sent back a sanitized `Internal error (correlation ID: <id>)` string to the client. Updated the test mock expectation.
✅ Verification: Ran `npm run test` and `vitest run --config vitest.config.ts src/auth/oauth-provider.test.ts`. Tests pass correctly.

---
*PR created automatically by Jules for task [1982166344946449096](https://jules.google.com/task/1982166344946449096) started by @davidruzicka*