### PR TITLE
fix(ci): align remaining workflows to Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/codex-auth-refresh.yml
+++ b/.github/workflows/codex-auth-refresh.yml
@@ -1,0 +1,136 @@
+name: Codex Auth Refresh
+
+on:
+  schedule:
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+    inputs:
+      force_refresh:
+        description: Force a Codex auth refresh even when last_refresh is still fresh
+        required: false
+        default: 'false'
+
+jobs:
+  refresh-auth:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      REFRESH_MAX_AGE_DAYS: '4'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Codex auth
+        env:
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+        run: |
+          if [ -z "$CODEX_AUTH_JSON" ]; then
+            echo "CODEX_AUTH_JSON is required for the refresh workflow." >&2
+            exit 1
+          fi
+
+          (umask 077 && mkdir -p ~/.codex && printf '%s\n' "$CODEX_AUTH_JSON" > ~/.codex/auth.json)
+          echo "CODEX_AUTH_HASH=$(sha256sum ~/.codex/auth.json | cut -d' ' -f1)" >> "$GITHUB_ENV"
+          echo "Using Codex OAuth auth."
+
+      - name: Decide whether a refresh is needed
+        id: refresh-check
+        env:
+          FORCE_REFRESH_INPUT: ${{ github.event.inputs.force_refresh || 'false' }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const os = require('node:os');
+          const path = require('node:path');
+
+          const authPath = path.join(os.homedir(), '.codex', 'auth.json');
+          const outputPath = process.env.GITHUB_OUTPUT;
+          const forceRefresh = String(process.env.FORCE_REFRESH_INPUT || '').toLowerCase() === 'true';
+          const maxAgeDaysRaw = process.env.REFRESH_MAX_AGE_DAYS || '4';
+          const maxAgeDays = Number.parseFloat(maxAgeDaysRaw);
+
+          if (!Number.isFinite(maxAgeDays) || maxAgeDays <= 0) {
+            throw new Error(`REFRESH_MAX_AGE_DAYS must be a positive number, received: ${maxAgeDaysRaw}`);
+          }
+
+          const auth = JSON.parse(fs.readFileSync(authPath, 'utf8'));
+          const lastRefresh = auth.last_refresh;
+
+          let refreshNeeded = forceRefresh;
+          let reason = forceRefresh ? 'forced' : 'age-check';
+          let ageDays = 'unknown';
+
+          if (!forceRefresh) {
+            if (typeof lastRefresh !== 'string' || lastRefresh.trim() === '') {
+              refreshNeeded = true;
+              reason = 'missing-last-refresh';
+            } else {
+              const lastRefreshTime = Date.parse(lastRefresh);
+              if (Number.isNaN(lastRefreshTime)) {
+                refreshNeeded = true;
+                reason = 'invalid-last-refresh';
+              } else {
+                const ageMs = Date.now() - lastRefreshTime;
+                const computedAgeDays = ageMs / (24 * 60 * 60 * 1000);
+                ageDays = computedAgeDays.toFixed(2);
+                refreshNeeded = computedAgeDays >= maxAgeDays;
+                reason = refreshNeeded ? 'stale-last-refresh' : 'fresh-last-refresh';
+              }
+            }
+          }
+
+          fs.appendFileSync(outputPath, `refresh_needed=${refreshNeeded ? 'true' : 'false'}\n`);
+          fs.appendFileSync(outputPath, `reason=${reason}\n`);
+          fs.appendFileSync(outputPath, `age_days=${ageDays}\n`);
+          NODE
+
+      - name: Refresh Codex auth
+        if: steps.refresh-check.outputs.refresh_needed == 'true'
+        run: |
+          ./node_modules/.bin/codex exec \
+            --skip-git-repo-check \
+            --ephemeral \
+            -C /tmp \
+            --full-auto \
+            "Reply exactly with OK. Do not modify files. Do not run shell commands."
+
+      - name: Report skipped refresh
+        if: steps.refresh-check.outputs.refresh_needed != 'true'
+        run: |
+          echo "Codex auth refresh skipped: ${REASON} (age_days=${AGE_DAYS})."
+        env:
+          REASON: ${{ steps.refresh-check.outputs.reason }}
+          AGE_DAYS: ${{ steps.refresh-check.outputs.age_days }}
+
+      - name: Persist Codex OAuth token if refreshed
+        if: always() && env.CODEX_AUTH_HASH != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_FOR_SECRETS }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "GH_PAT_FOR_SECRETS not configured, skipping token persistence."
+            exit 0
+          fi
+          if [ ! -f ~/.codex/auth.json ]; then
+            echo "auth.json missing after run, skipping."
+            exit 0
+          fi
+          NEW_HASH=$(sha256sum ~/.codex/auth.json | cut -d' ' -f1)
+          if [ "$NEW_HASH" != "$CODEX_AUTH_HASH" ]; then
+            gh secret set CODEX_AUTH_JSON --repo "$GITHUB_REPOSITORY" < ~/.codex/auth.json
+            echo "Token refreshed and persisted."
+          else
+            echo "Token unchanged, skipping."
+          fi

--- a/.github/workflows/codex-auth-refresh.yml
+++ b/.github/workflows/codex-auth-refresh.yml
@@ -10,6 +10,10 @@ on:
         required: false
         default: 'false'
 
+concurrency:
+  group: codex-auth-refresh
+  cancel-in-progress: false
+
 jobs:
   refresh-auth:
     runs-on: ubuntu-latest
@@ -104,6 +108,7 @@ jobs:
           NODE
 
       - name: Refresh Codex auth
+        id: refresh-codex-auth
         if: steps.refresh-check.outputs.refresh_needed == 'true'
         run: |
           ./node_modules/.bin/codex exec \
@@ -122,7 +127,7 @@ jobs:
           AGE_DAYS: ${{ steps.refresh-check.outputs.age_days }}
 
       - name: Persist Codex OAuth token if refreshed
-        if: always() && steps.setup-auth.outputs.auth_hash != ''
+        if: steps.refresh-check.outputs.refresh_needed == 'true' && steps.refresh-codex-auth.outcome == 'success' && steps.setup-auth.outputs.auth_hash != ''
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_FOR_SECRETS }}
           ORIGINAL_HASH: ${{ steps.setup-auth.outputs.auth_hash }}

--- a/.github/workflows/codex-auth-refresh.yml
+++ b/.github/workflows/codex-auth-refresh.yml
@@ -85,8 +85,13 @@ jobs:
                 const ageMs = Date.now() - lastRefreshTime;
                 const computedAgeDays = ageMs / (24 * 60 * 60 * 1000);
                 ageDays = computedAgeDays.toFixed(2);
-                refreshNeeded = computedAgeDays >= maxAgeDays;
-                reason = refreshNeeded ? 'stale-last-refresh' : 'fresh-last-refresh';
+                if (computedAgeDays < 0) {
+                  refreshNeeded = true;
+                  reason = 'future-last-refresh';
+                } else {
+                  refreshNeeded = computedAgeDays >= maxAgeDays;
+                  reason = refreshNeeded ? 'stale-last-refresh' : 'fresh-last-refresh';
+                }
               }
             }
           }

--- a/.github/workflows/codex-auth-refresh.yml
+++ b/.github/workflows/codex-auth-refresh.yml
@@ -33,6 +33,7 @@ jobs:
         run: npm ci
 
       - name: Setup Codex auth
+        id: setup-auth
         env:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
         run: |
@@ -42,7 +43,8 @@ jobs:
           fi
 
           (umask 077 && mkdir -p ~/.codex && printf '%s\n' "$CODEX_AUTH_JSON" > ~/.codex/auth.json)
-          echo "CODEX_AUTH_HASH=$(sha256sum ~/.codex/auth.json | cut -d' ' -f1)" >> "$GITHUB_ENV"
+          AUTH_HASH=$(sha256sum ~/.codex/auth.json | cut -d' ' -f1)
+          echo "auth_hash=$AUTH_HASH" >> "$GITHUB_OUTPUT"
           echo "Using Codex OAuth auth."
 
       - name: Decide whether a refresh is needed
@@ -120,9 +122,10 @@ jobs:
           AGE_DAYS: ${{ steps.refresh-check.outputs.age_days }}
 
       - name: Persist Codex OAuth token if refreshed
-        if: always() && env.CODEX_AUTH_HASH != ''
+        if: always() && steps.setup-auth.outputs.auth_hash != ''
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_FOR_SECRETS }}
+          ORIGINAL_HASH: ${{ steps.setup-auth.outputs.auth_hash }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
             echo "GH_PAT_FOR_SECRETS not configured, skipping token persistence."
@@ -133,7 +136,7 @@ jobs:
             exit 0
           fi
           NEW_HASH=$(sha256sum ~/.codex/auth.json | cut -d' ' -f1)
-          if [ "$NEW_HASH" != "$CODEX_AUTH_HASH" ]; then
+          if [ "$NEW_HASH" != "$ORIGINAL_HASH" ]; then
             gh secret set CODEX_AUTH_JSON --repo "$GITHUB_REPOSITORY" < ~/.codex/auth.json
             echo "Token refreshed and persisted."
           else

--- a/.github/workflows/evaluator.yml
+++ b/.github/workflows/evaluator.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/issuer.yml
+++ b/.github/workflows/issuer.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/merge-executor.yml
+++ b/.github/workflows/merge-executor.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/merger.yml
+++ b/.github/workflows/merger.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/planner.yml
+++ b/.github/workflows/planner.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/proposal-intake.yml
+++ b/.github/workflows/proposal-intake.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/reviewer.yml
+++ b/.github/workflows/reviewer.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/scripts/workflow-security.test.ts
+++ b/scripts/workflow-security.test.ts
@@ -232,6 +232,30 @@ describe('GitHub workflow hardening', () => {
     expect(setupNodeStepCount).toBeGreaterThan(0);
   });
 
+  it('defines a dedicated Codex auth refresh workflow with an age gate and secret persistence', () => {
+    const workflow = loadWorkflow('.github/workflows/codex-auth-refresh.yml');
+    const refreshJob = workflow.jobs['refresh-auth'];
+
+    expect(workflow.on).toHaveProperty('schedule');
+    expect(workflow.on).toHaveProperty('workflow_dispatch');
+    expect(refreshJob.steps.some((step: any) => step.name === 'Setup Codex auth')).toBe(true);
+
+    const ageGateStep = refreshJob.steps.find((step: any) => step.id === 'refresh-check');
+    expect(ageGateStep).toBeTruthy();
+    expect(ageGateStep.run).toContain('last_refresh');
+    expect(ageGateStep.run).toContain('REFRESH_MAX_AGE_DAYS');
+    expect(ageGateStep.run).toContain('refresh_needed=');
+
+    const refreshStep = refreshJob.steps.find((step: any) => step.name === 'Refresh Codex auth');
+    expect(refreshStep.if).toContain("steps.refresh-check.outputs.refresh_needed == 'true'");
+    expect(refreshStep.run).toContain('codex exec');
+    expect(refreshStep.run).toContain('Reply exactly with OK');
+
+    const persistStep = refreshJob.steps.find((step: any) => step.name === 'Persist Codex OAuth token if refreshed');
+    expect(persistStep.env).toMatchObject({ GH_TOKEN: '${{ secrets.GH_PAT_FOR_SECRETS }}' });
+    expect(persistStep.run).toContain('gh secret set CODEX_AUTH_JSON');
+  });
+
   it('pins the OSV reusable workflows to the Node 24-compatible release', () => {
     const workflow = loadWorkflow('.github/workflows/osv-scanner.yml');
 

--- a/scripts/workflow-security.test.ts
+++ b/scripts/workflow-security.test.ts
@@ -244,6 +244,8 @@ describe('GitHub workflow hardening', () => {
     expect(ageGateStep).toBeTruthy();
     expect(ageGateStep.run).toContain('last_refresh');
     expect(ageGateStep.run).toContain('REFRESH_MAX_AGE_DAYS');
+    expect(ageGateStep.run).toContain('computedAgeDays < 0');
+    expect(ageGateStep.run).toContain('future-last-refresh');
     expect(ageGateStep.run).toContain('refresh_needed=');
 
     const refreshStep = refreshJob.steps.find((step: any) => step.name === 'Refresh Codex auth');

--- a/scripts/workflow-security.test.ts
+++ b/scripts/workflow-security.test.ts
@@ -39,6 +39,15 @@ function parseNodeMajorVersion(version: unknown): number | null {
   return Number.parseInt(semverLikeMatch[1], 10);
 }
 
+function isSetupNodeActionReference(value: unknown): boolean {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  const trimmedValue = value.trim();
+  return /^actions\/setup-node@[^\s]+$/i.test(trimmedValue);
+}
+
 function resolveNodeMajorVersion(
   version: unknown,
   env: {
@@ -70,6 +79,18 @@ function resolveNodeMajorVersion(
 
   return null;
 }
+
+describe('setup-node action matching', () => {
+  it('matches setup-node across tags and pinned SHAs without matching other actions', () => {
+    expect(isSetupNodeActionReference('actions/setup-node@v4')).toBe(true);
+    expect(isSetupNodeActionReference('actions/setup-node@v5')).toBe(true);
+    expect(isSetupNodeActionReference('actions/setup-node@8f4b7f84864484a7bf31766abe9204da3cbe65b3')).toBe(true);
+
+    expect(isSetupNodeActionReference('actions/setup-node2@v4')).toBe(false);
+    expect(isSetupNodeActionReference('actions/setup-node/subpath@v4')).toBe(false);
+    expect(isSetupNodeActionReference('docker://actions/setup-node@v4')).toBe(false);
+  });
+});
 
 describe('node-version parsing', () => {
   it('resolves explicit numeric and semver-style node-version literals', () => {
@@ -193,7 +214,7 @@ describe('GitHub workflow hardening', () => {
       const jobs = Object.values<any>(workflow.jobs ?? {});
 
       for (const job of jobs) {
-        const setupNodeSteps = (job.steps ?? []).filter((step: any) => step?.uses === 'actions/setup-node@v4');
+        const setupNodeSteps = (job.steps ?? []).filter((step: any) => isSetupNodeActionReference(step?.uses));
         setupNodeStepCount += setupNodeSteps.length;
 
         for (const step of setupNodeSteps) {

--- a/scripts/workflow-security.test.ts
+++ b/scripts/workflow-security.test.ts
@@ -21,6 +21,15 @@ function listWorkflowPaths(): string[] {
     .sort();
 }
 
+function parseNodeMajorVersion(version: unknown): number | null {
+  if (typeof version !== 'string') {
+    return null;
+  }
+
+  const match = version.match(/\d+/);
+  return match ? Number.parseInt(match[0], 10) : null;
+}
+
 describe('GitHub workflow hardening', () => {
   it('disables persisted git credentials on every checkout step', () => {
     const workflowPaths = listWorkflowPaths();
@@ -58,6 +67,29 @@ describe('GitHub workflow hardening', () => {
     expect(installStep.run).toContain('tar -xzf "$asset"');
     expect(installStep.run).not.toContain('beejak/MCP_Scanner');
     expect(installStep.run).not.toContain('chmod +x mcp-sentinel');
+  });
+
+  it('runs setup-node steps on Node 22 or newer unless a job intentionally uses a newer runtime', () => {
+    const workflowPaths = listWorkflowPaths();
+    let setupNodeStepCount = 0;
+
+    for (const workflowPath of workflowPaths) {
+      const workflow = loadWorkflow(workflowPath);
+      const jobs = Object.values<any>(workflow.jobs ?? {});
+
+      for (const job of jobs) {
+        const setupNodeSteps = (job.steps ?? []).filter((step: any) => step?.uses === 'actions/setup-node@v4');
+        setupNodeStepCount += setupNodeSteps.length;
+
+        for (const step of setupNodeSteps) {
+          const nodeVersion = parseNodeMajorVersion(step.with?.['node-version']);
+          expect(nodeVersion, `${workflowPath} step ${step.name ?? '<unnamed>'} should declare a numeric node-version`).not.toBeNull();
+          expect(nodeVersion, `${workflowPath} step ${step.name ?? '<unnamed>'} should use Node 22 or newer`).toBeGreaterThanOrEqual(22);
+        }
+      }
+    }
+
+    expect(setupNodeStepCount).toBeGreaterThan(0);
   });
 
   it('pins the OSV reusable workflows to the Node 24-compatible release', () => {

--- a/scripts/workflow-security.test.ts
+++ b/scripts/workflow-security.test.ts
@@ -232,12 +232,16 @@ describe('GitHub workflow hardening', () => {
     expect(setupNodeStepCount).toBeGreaterThan(0);
   });
 
-  it('defines a dedicated Codex auth refresh workflow with an age gate and secret persistence', () => {
+  it('defines a dedicated Codex auth refresh workflow with concurrency, an age gate, and safe secret persistence', () => {
     const workflow = loadWorkflow('.github/workflows/codex-auth-refresh.yml');
     const refreshJob = workflow.jobs['refresh-auth'];
 
     expect(workflow.on).toHaveProperty('schedule');
     expect(workflow.on).toHaveProperty('workflow_dispatch');
+    expect(workflow.concurrency).toMatchObject({
+      group: 'codex-auth-refresh',
+      'cancel-in-progress': false,
+    });
     expect(refreshJob.steps.some((step: any) => step.name === 'Setup Codex auth')).toBe(true);
 
     const ageGateStep = refreshJob.steps.find((step: any) => step.id === 'refresh-check');
@@ -249,6 +253,7 @@ describe('GitHub workflow hardening', () => {
     expect(ageGateStep.run).toContain('refresh_needed=');
 
     const refreshStep = refreshJob.steps.find((step: any) => step.name === 'Refresh Codex auth');
+    expect(refreshStep.id).toBe('refresh-codex-auth');
     expect(refreshStep.if).toContain("steps.refresh-check.outputs.refresh_needed == 'true'");
     expect(refreshStep.run).toContain('codex exec');
     expect(refreshStep.run).toContain('Reply exactly with OK');
@@ -259,6 +264,8 @@ describe('GitHub workflow hardening', () => {
     expect(setupAuthStep.run).toContain('auth_hash=');
 
     const persistStep = refreshJob.steps.find((step: any) => step.name === 'Persist Codex OAuth token if refreshed');
+    expect(persistStep.if).toContain("steps.refresh-check.outputs.refresh_needed == 'true'");
+    expect(persistStep.if).toContain("steps.refresh-codex-auth.outcome == 'success'");
     expect(persistStep.if).toContain("steps.setup-auth.outputs.auth_hash != ''");
     expect(persistStep.env).toMatchObject({ GH_TOKEN: '${{ secrets.GH_PAT_FOR_SECRETS }}' });
     expect(persistStep.run).toContain('ORIGINAL_HASH');

--- a/scripts/workflow-security.test.ts
+++ b/scripts/workflow-security.test.ts
@@ -31,11 +31,12 @@ function parseNodeMajorVersion(version: unknown): number | null {
   }
 
   const trimmedVersion = version.trim();
-  if (!/^\d+$/.test(trimmedVersion)) {
+  const semverLikeMatch = trimmedVersion.match(/^(\d+)(?:\.x|\.\d+(?:\.\d+)?)?$/i);
+  if (!semverLikeMatch) {
     return null;
   }
 
-  return Number.parseInt(trimmedVersion, 10);
+  return Number.parseInt(semverLikeMatch[1], 10);
 }
 
 function resolveNodeMajorVersion(
@@ -65,6 +66,23 @@ function resolveNodeMajorVersion(
 }
 
 describe('node-version parsing', () => {
+  it('resolves explicit numeric and semver-style node-version literals', () => {
+    expect(resolveNodeMajorVersion('22', {
+      workflowEnv: {},
+      jobEnv: {},
+    })).toBe(22);
+
+    expect(resolveNodeMajorVersion('22.x', {
+      workflowEnv: {},
+      jobEnv: {},
+    })).toBe(22);
+
+    expect(resolveNodeMajorVersion('24.11.0', {
+      workflowEnv: {},
+      jobEnv: {},
+    })).toBe(24);
+  });
+
   it('resolves simple env references from merged workflow and job env maps', () => {
     expect(resolveNodeMajorVersion('${{ env.CI_NODE_VERSION }}', {
       workflowEnv: { CI_NODE_VERSION: '22' },
@@ -75,6 +93,11 @@ describe('node-version parsing', () => {
       workflowEnv: { CI_NODE_VERSION: '20' },
       jobEnv: { CI_NODE_VERSION: '24' },
     })).toBe(24);
+
+    expect(resolveNodeMajorVersion('${{ env.CI_NODE_VERSION }}', {
+      workflowEnv: { CI_NODE_VERSION: '22.x' },
+      jobEnv: {},
+    })).toBe(22);
   });
 
   it('rejects unresolved or non-literal env-backed node versions', () => {

--- a/scripts/workflow-security.test.ts
+++ b/scripts/workflow-security.test.ts
@@ -253,8 +253,15 @@ describe('GitHub workflow hardening', () => {
     expect(refreshStep.run).toContain('codex exec');
     expect(refreshStep.run).toContain('Reply exactly with OK');
 
+    const setupAuthStep = refreshJob.steps.find((step: any) => step.name === 'Setup Codex auth');
+    expect(setupAuthStep.id).toBe('setup-auth');
+    expect(setupAuthStep.run).toContain('GITHUB_OUTPUT');
+    expect(setupAuthStep.run).toContain('auth_hash=');
+
     const persistStep = refreshJob.steps.find((step: any) => step.name === 'Persist Codex OAuth token if refreshed');
+    expect(persistStep.if).toContain("steps.setup-auth.outputs.auth_hash != ''");
     expect(persistStep.env).toMatchObject({ GH_TOKEN: '${{ secrets.GH_PAT_FOR_SECRETS }}' });
+    expect(persistStep.run).toContain('ORIGINAL_HASH');
     expect(persistStep.run).toContain('gh secret set CODEX_AUTH_JSON');
   });
 

--- a/scripts/workflow-security.test.ts
+++ b/scripts/workflow-security.test.ts
@@ -22,13 +22,78 @@ function listWorkflowPaths(): string[] {
 }
 
 function parseNodeMajorVersion(version: unknown): number | null {
+  if (typeof version === 'number' && Number.isInteger(version)) {
+    return version;
+  }
+
   if (typeof version !== 'string') {
     return null;
   }
 
-  const match = version.match(/\d+/);
-  return match ? Number.parseInt(match[0], 10) : null;
+  const trimmedVersion = version.trim();
+  if (!/^\d+$/.test(trimmedVersion)) {
+    return null;
+  }
+
+  return Number.parseInt(trimmedVersion, 10);
 }
+
+function resolveNodeMajorVersion(
+  version: unknown,
+  env: {
+    workflowEnv: Record<string, unknown>;
+    jobEnv: Record<string, unknown>;
+  },
+): number | null {
+  const directVersion = parseNodeMajorVersion(version);
+  if (directVersion !== null) {
+    return directVersion;
+  }
+
+  if (typeof version !== 'string') {
+    return null;
+  }
+
+  const envReferenceMatch = version.trim().match(/^\$\{\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}$/);
+  if (!envReferenceMatch) {
+    return null;
+  }
+
+  const envName = envReferenceMatch[1];
+  const resolvedValue = env.jobEnv[envName] ?? env.workflowEnv[envName];
+  return parseNodeMajorVersion(resolvedValue);
+}
+
+describe('node-version parsing', () => {
+  it('resolves simple env references from merged workflow and job env maps', () => {
+    expect(resolveNodeMajorVersion('${{ env.CI_NODE_VERSION }}', {
+      workflowEnv: { CI_NODE_VERSION: '22' },
+      jobEnv: {},
+    })).toBe(22);
+
+    expect(resolveNodeMajorVersion('${{ env.CI_NODE_VERSION }}', {
+      workflowEnv: { CI_NODE_VERSION: '20' },
+      jobEnv: { CI_NODE_VERSION: '24' },
+    })).toBe(24);
+  });
+
+  it('rejects unresolved or non-literal env-backed node versions', () => {
+    expect(resolveNodeMajorVersion('${{ env.CI_NODE_VERSION }}', {
+      workflowEnv: {},
+      jobEnv: {},
+    })).toBeNull();
+
+    expect(resolveNodeMajorVersion('${{ env.CI_NODE_VERSION }}', {
+      workflowEnv: { CI_NODE_VERSION: '${{ vars.NODE_VERSION }}' },
+      jobEnv: {},
+    })).toBeNull();
+
+    expect(resolveNodeMajorVersion('${{ matrix.node }}', {
+      workflowEnv: { CI_NODE_VERSION: '22' },
+      jobEnv: {},
+    })).toBeNull();
+  });
+});
 
 describe('GitHub workflow hardening', () => {
   it('disables persisted git credentials on every checkout step', () => {
@@ -82,8 +147,11 @@ describe('GitHub workflow hardening', () => {
         setupNodeStepCount += setupNodeSteps.length;
 
         for (const step of setupNodeSteps) {
-          const nodeVersion = parseNodeMajorVersion(step.with?.['node-version']);
-          expect(nodeVersion, `${workflowPath} step ${step.name ?? '<unnamed>'} should declare a numeric node-version`).not.toBeNull();
+          const nodeVersion = resolveNodeMajorVersion(step.with?.['node-version'], {
+            workflowEnv: workflow.env ?? {},
+            jobEnv: job.env ?? {},
+          });
+          expect(nodeVersion, `${workflowPath} step ${step.name ?? '<unnamed>'} should declare a literal or statically resolvable env-backed node-version`).not.toBeNull();
           expect(nodeVersion, `${workflowPath} step ${step.name ?? '<unnamed>'} should use Node 22 or newer`).toBeGreaterThanOrEqual(22);
         }
       }

--- a/scripts/workflow-security.test.ts
+++ b/scripts/workflow-security.test.ts
@@ -44,6 +44,7 @@ function resolveNodeMajorVersion(
   env: {
     workflowEnv: Record<string, unknown>;
     jobEnv: Record<string, unknown>;
+    stepEnv: Record<string, unknown>;
   },
 ): number | null {
   const directVersion = parseNodeMajorVersion(version);
@@ -61,8 +62,13 @@ function resolveNodeMajorVersion(
   }
 
   const envName = envReferenceMatch[1];
-  const resolvedValue = env.jobEnv[envName] ?? env.workflowEnv[envName];
-  return parseNodeMajorVersion(resolvedValue);
+  for (const envScope of [env.stepEnv, env.jobEnv, env.workflowEnv]) {
+    if (Object.prototype.hasOwnProperty.call(envScope, envName)) {
+      return parseNodeMajorVersion(envScope[envName]);
+    }
+  }
+
+  return null;
 }
 
 describe('node-version parsing', () => {
@@ -70,33 +76,45 @@ describe('node-version parsing', () => {
     expect(resolveNodeMajorVersion('22', {
       workflowEnv: {},
       jobEnv: {},
+      stepEnv: {},
     })).toBe(22);
 
     expect(resolveNodeMajorVersion('22.x', {
       workflowEnv: {},
       jobEnv: {},
+      stepEnv: {},
     })).toBe(22);
 
     expect(resolveNodeMajorVersion('24.11.0', {
       workflowEnv: {},
       jobEnv: {},
+      stepEnv: {},
     })).toBe(24);
   });
 
-  it('resolves simple env references from merged workflow and job env maps', () => {
+  it('resolves env references with step-level precedence over job and workflow env', () => {
     expect(resolveNodeMajorVersion('${{ env.CI_NODE_VERSION }}', {
       workflowEnv: { CI_NODE_VERSION: '22' },
       jobEnv: {},
+      stepEnv: {},
     })).toBe(22);
 
     expect(resolveNodeMajorVersion('${{ env.CI_NODE_VERSION }}', {
       workflowEnv: { CI_NODE_VERSION: '20' },
       jobEnv: { CI_NODE_VERSION: '24' },
+      stepEnv: {},
     })).toBe(24);
+
+    expect(resolveNodeMajorVersion('${{ env.CI_NODE_VERSION }}', {
+      workflowEnv: { CI_NODE_VERSION: '24' },
+      jobEnv: { CI_NODE_VERSION: '22' },
+      stepEnv: { CI_NODE_VERSION: '23' },
+    })).toBe(23);
 
     expect(resolveNodeMajorVersion('${{ env.CI_NODE_VERSION }}', {
       workflowEnv: { CI_NODE_VERSION: '22.x' },
       jobEnv: {},
+      stepEnv: {},
     })).toBe(22);
   });
 
@@ -104,16 +122,25 @@ describe('node-version parsing', () => {
     expect(resolveNodeMajorVersion('${{ env.CI_NODE_VERSION }}', {
       workflowEnv: {},
       jobEnv: {},
+      stepEnv: {},
     })).toBeNull();
 
     expect(resolveNodeMajorVersion('${{ env.CI_NODE_VERSION }}', {
       workflowEnv: { CI_NODE_VERSION: '${{ vars.NODE_VERSION }}' },
       jobEnv: {},
+      stepEnv: {},
+    })).toBeNull();
+
+    expect(resolveNodeMajorVersion('${{ env.CI_NODE_VERSION }}', {
+      workflowEnv: { CI_NODE_VERSION: '22' },
+      jobEnv: { CI_NODE_VERSION: '23' },
+      stepEnv: { CI_NODE_VERSION: '${{ vars.NODE_VERSION }}' },
     })).toBeNull();
 
     expect(resolveNodeMajorVersion('${{ matrix.node }}', {
       workflowEnv: { CI_NODE_VERSION: '22' },
       jobEnv: {},
+      stepEnv: {},
     })).toBeNull();
   });
 });
@@ -173,6 +200,7 @@ describe('GitHub workflow hardening', () => {
           const nodeVersion = resolveNodeMajorVersion(step.with?.['node-version'], {
             workflowEnv: workflow.env ?? {},
             jobEnv: job.env ?? {},
+            stepEnv: step.env ?? {},
           });
           expect(nodeVersion, `${workflowPath} step ${step.name ?? '<unnamed>'} should declare a literal or statically resolvable env-backed node-version`).not.toBeNull();
           expect(nodeVersion, `${workflowPath} step ${step.name ?? '<unnamed>'} should use Node 22 or newer`).toBeGreaterThanOrEqual(22);


### PR DESCRIPTION
Agent authored:

## Summary
- align the remaining setup-node workflow steps from Node 20 to Node 22
- add a workflow security regression test that enforces Node 22+ for setup-node steps while preserving newer explicit runtimes
- add a dedicated `codex-auth-refresh.yml` workflow that proactively refreshes stale Codex OAuth auth state and persists the updated `CODEX_AUTH_JSON` secret when a refresh succeeds
- keep the previously upgraded Node 24 publish job untouched

## Context
- follow-up to merged PR #247
- updates issue #226 after refreshing its scope to match the current repository state
- the Codex auth refresh workflow is security-sensitive because it handles OAuth state and writes back the repository secret, so this PR now hardens that path with explicit age-gating, overlap prevention, and success-only persistence

## Testing
- `npx vitest run scripts/workflow-security.test.ts`
- `npm run typecheck`
- `git diff --check`