### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in composite-executor and mcp-server

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,14 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2026-04-15 - [CRITICAL] Path Traversal Due To Incomplete URL Encoding
+
+**Vulnerability:**
+Both `CompositeExecutor` and `MCPServer` were incorrectly encoding URL path segments, leaving dots (`.`) unencoded (`encodeURIComponent` does not encode dots). This allowed path traversal sequences like `..` to be passed via parameter injection.
+
+**Learning:**
+When injecting user-controlled path parameters, relying solely on JavaScript's built-in `encodeURIComponent` is insufficient if the downstream components decode `%2E` or interpret raw `.` paths.
+
+**Prevention:**
+1. Explicitly encode dot characters `.replace(/\./g, '%2E')` whenever constructing path segments containing user input.

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1107,7 +1107,7 @@ export class MCPServer {
    */
   private encodePathSegment(value: unknown): string {
     const val = String(value);
-    return val.includes('/') ? encodeURIComponent(val) : val;
+    return encodeURIComponent(val).replace(/\./g, '%2E');
   }
 
   /**

--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -65,9 +65,9 @@ describe('CompositeExecutor Security', () => {
 
     // Vulnerable behavior: path contains raw ".."
     // Fixed behavior: path contains encoded "%2E%2E"
-    // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
-    // The slashes inside the injected value are encoded, preventing directory traversal
-    const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
+    // Note: encodeURIComponent('../admin/secrets').replace(/\./g, '%2E') => %2E%2E%2Fadmin%2Fsecrets
+    // The slashes and dots inside the injected value are encoded, preventing directory traversal
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -171,14 +171,14 @@ export class CompositeExecutor {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
+        return encodeURIComponent(String(args[key])).replace(/\./g, '%2E');
       }
 
       // Try aliases from profile
       const possibleAliases = this.parameterAliases[key] || [];
       for (const alias of possibleAliases) {
         if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+          return encodeURIComponent(String(args[alias])).replace(/\./g, '%2E');
         }
       }
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in composite-executor and mcp-server

🚨 Severity: CRITICAL
💡 Vulnerability: User input injected into API path endpoints could contain `..` which `encodeURIComponent` does not encode, causing directory traversal against backend server APIs.
🎯 Impact: Attackers could access unauthorized APIs.
🔧 Fix: Update `encodeURIComponent` to manually `.replace(/\./g, '%2E')` for all dots during parameter interpolation in `mcp-server.ts` and `composite-executor.ts`.
✅ Verification: Ran unit tests covering `CompositeExecutor` security testing showing failure prior and passing post-fix.

---
*PR created automatically by Jules for task [12759696308919767677](https://jules.google.com/task/12759696308919767677) started by @davidruzicka*