### PR TITLE
fix(implementor): deduplicate retry comments

### DIFF
--- a/scripts/github-agent-runtime.test.ts
+++ b/scripts/github-agent-runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   createReviewThreadReply,
+  deleteIssueComment,
   listOpenPullRequests,
   listRecentIssues,
   mapIssueSummaryToProposalCandidate,
@@ -166,6 +167,48 @@ describe('github-agent-runtime listing bounds', () => {
         runId: 'manual-test',
         now: '2026-03-17T12:00:00.000Z',
       })).resolves.toMatchObject([{ number: 21 }, { number: 20 }]);
+    } finally {
+      globalThis.fetch = fetchMock;
+    }
+  });
+});
+
+describe('github-agent-runtime comment deletion', () => {
+  it('ignores 404 responses when deleting issue comments', async () => {
+    const fetchMock = globalThis.fetch;
+    globalThis.fetch = async () => new Response(JSON.stringify({ message: 'Not Found' }), { status: 404 });
+
+    try {
+      await expect(deleteIssueComment({
+        repository: 'davidruzicka/mcp4openapi',
+        token: 'token',
+        apiBaseUrl: 'https://api.github.com',
+        lookbackHours: 48,
+        maxCandidates: 2,
+        agentId: 'implementor',
+        runId: 'manual-test',
+        now: '2026-03-17T12:00:00.000Z',
+      }, 12345)).resolves.toBeUndefined();
+    } finally {
+      globalThis.fetch = fetchMock;
+    }
+  });
+
+  it('rethrows non-404 deletion failures', async () => {
+    const fetchMock = globalThis.fetch;
+    globalThis.fetch = async () => new Response(JSON.stringify({ message: 'Internal Server Error' }), { status: 500 });
+
+    try {
+      await expect(deleteIssueComment({
+        repository: 'davidruzicka/mcp4openapi',
+        token: 'token',
+        apiBaseUrl: 'https://api.github.com',
+        lookbackHours: 48,
+        maxCandidates: 2,
+        agentId: 'implementor',
+        runId: 'manual-test',
+        now: '2026-03-17T12:00:00.000Z',
+      }, 12345)).rejects.toThrow('GitHub API request failed (500) for /repos/davidruzicka/mcp4openapi/issues/comments/12345');
     } finally {
       globalThis.fetch = fetchMock;
     }

--- a/scripts/github-agent-runtime.test.ts
+++ b/scripts/github-agent-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createReviewThreadReply,
   deleteIssueComment,
+  listIssueComments,
   listOpenPullRequests,
   listRecentIssues,
   mapIssueSummaryToProposalCandidate,
@@ -167,6 +168,71 @@ describe('github-agent-runtime listing bounds', () => {
         runId: 'manual-test',
         now: '2026-03-17T12:00:00.000Z',
       })).resolves.toMatchObject([{ number: 21 }, { number: 20 }]);
+    } finally {
+      globalThis.fetch = fetchMock;
+    }
+  });
+});
+
+describe('github-agent-runtime issue comment listing', () => {
+  it('follows pagination links when listing issue comments', async () => {
+    const fetchMock = globalThis.fetch;
+    const requests: string[] = [];
+    globalThis.fetch = async (input) => {
+      requests.push(String(input));
+      if (requests.length === 1) {
+        return new Response(JSON.stringify([{ id: 101 }, { id: 102 }]), {
+          status: 200,
+          headers: {
+            link: '<https://api.github.com/repos/davidruzicka/mcp4openapi/issues/251/comments?per_page=100&page=2>; rel="next", <https://api.github.com/repos/davidruzicka/mcp4openapi/issues/251/comments?per_page=100&page=2>; rel="last"',
+          },
+        });
+      }
+
+      return new Response(JSON.stringify([{ id: 103 }]), { status: 200 });
+    };
+
+    try {
+      await expect(listIssueComments({
+        repository: 'davidruzicka/mcp4openapi',
+        token: 'token',
+        apiBaseUrl: 'https://api.github.com',
+        lookbackHours: 48,
+        maxCandidates: 2,
+        agentId: 'implementor',
+        runId: 'manual-test',
+        now: '2026-03-17T12:00:00.000Z',
+      }, 251)).resolves.toEqual([{ id: 101 }, { id: 102 }, { id: 103 }]);
+    } finally {
+      globalThis.fetch = fetchMock;
+    }
+
+    expect(requests).toEqual([
+      'https://api.github.com/repos/davidruzicka/mcp4openapi/issues/251/comments?per_page=100',
+      'https://api.github.com/repos/davidruzicka/mcp4openapi/issues/251/comments?per_page=100&page=2',
+    ]);
+  });
+
+  it('rejects pagination links that escape the configured API base URL', async () => {
+    const fetchMock = globalThis.fetch;
+    globalThis.fetch = async () => new Response(JSON.stringify([{ id: 101 }]), {
+      status: 200,
+      headers: {
+        link: '<https://evil.example/repos/davidruzicka/mcp4openapi/issues/251/comments?page=2>; rel="next"',
+      },
+    });
+
+    try {
+      await expect(listIssueComments({
+        repository: 'davidruzicka/mcp4openapi',
+        token: 'token',
+        apiBaseUrl: 'https://api.github.com',
+        lookbackHours: 48,
+        maxCandidates: 2,
+        agentId: 'implementor',
+        runId: 'manual-test',
+        now: '2026-03-17T12:00:00.000Z',
+      }, 251)).rejects.toThrow('GitHub pagination link escaped API base URL');
     } finally {
       globalThis.fetch = fetchMock;
     }

--- a/scripts/github-agent-runtime.test.ts
+++ b/scripts/github-agent-runtime.test.ts
@@ -175,7 +175,40 @@ describe('github-agent-runtime listing bounds', () => {
 });
 
 describe('github-agent-runtime issue comment listing', () => {
-  it('follows pagination links when listing issue comments', async () => {
+  it('stops after the first page by default', async () => {
+    const fetchMock = globalThis.fetch;
+    const requests: string[] = [];
+    globalThis.fetch = async (input) => {
+      requests.push(String(input));
+      return new Response(JSON.stringify([{ id: 101 }, { id: 102 }]), {
+        status: 200,
+        headers: {
+          link: '<https://api.github.com/repos/davidruzicka/mcp4openapi/issues/251/comments?per_page=100&page=2>; rel="next", <https://api.github.com/repos/davidruzicka/mcp4openapi/issues/251/comments?per_page=100&page=2>; rel="last"',
+        },
+      });
+    };
+
+    try {
+      await expect(listIssueComments({
+        repository: 'davidruzicka/mcp4openapi',
+        token: 'token',
+        apiBaseUrl: 'https://api.github.com',
+        lookbackHours: 48,
+        maxCandidates: 2,
+        agentId: 'implementor',
+        runId: 'manual-test',
+        now: '2026-03-17T12:00:00.000Z',
+      }, 251)).resolves.toEqual([{ id: 101 }, { id: 102 }]);
+    } finally {
+      globalThis.fetch = fetchMock;
+    }
+
+    expect(requests).toEqual([
+      'https://api.github.com/repos/davidruzicka/mcp4openapi/issues/251/comments?per_page=100',
+    ]);
+  });
+
+  it('follows pagination links when explicitly allowed', async () => {
     const fetchMock = globalThis.fetch;
     const requests: string[] = [];
     globalThis.fetch = async (input) => {
@@ -202,7 +235,7 @@ describe('github-agent-runtime issue comment listing', () => {
         agentId: 'implementor',
         runId: 'manual-test',
         now: '2026-03-17T12:00:00.000Z',
-      }, 251)).resolves.toEqual([{ id: 101 }, { id: 102 }, { id: 103 }]);
+      }, 251, { maxPages: undefined })).resolves.toEqual([{ id: 101 }, { id: 102 }, { id: 103 }]);
     } finally {
       globalThis.fetch = fetchMock;
     }
@@ -232,7 +265,7 @@ describe('github-agent-runtime issue comment listing', () => {
         agentId: 'implementor',
         runId: 'manual-test',
         now: '2026-03-17T12:00:00.000Z',
-      }, 251)).rejects.toThrow('GitHub pagination link escaped API base URL');
+      }, 251, { maxPages: undefined })).rejects.toThrow('GitHub pagination link escaped API base URL');
     } finally {
       globalThis.fetch = fetchMock;
     }

--- a/scripts/github-agent-runtime.test.ts
+++ b/scripts/github-agent-runtime.test.ts
@@ -208,7 +208,7 @@ describe('github-agent-runtime issue comment listing', () => {
     ]);
   });
 
-  it('follows pagination links when explicitly allowed', async () => {
+  it('follows pagination links when fetchAll is enabled', async () => {
     const fetchMock = globalThis.fetch;
     const requests: string[] = [];
     globalThis.fetch = async (input) => {
@@ -235,7 +235,7 @@ describe('github-agent-runtime issue comment listing', () => {
         agentId: 'implementor',
         runId: 'manual-test',
         now: '2026-03-17T12:00:00.000Z',
-      }, 251, { maxPages: undefined })).resolves.toEqual([{ id: 101 }, { id: 102 }, { id: 103 }]);
+      }, 251, { fetchAll: true })).resolves.toEqual([{ id: 101 }, { id: 102 }, { id: 103 }]);
     } finally {
       globalThis.fetch = fetchMock;
     }
@@ -265,10 +265,25 @@ describe('github-agent-runtime issue comment listing', () => {
         agentId: 'implementor',
         runId: 'manual-test',
         now: '2026-03-17T12:00:00.000Z',
-      }, 251, { maxPages: undefined })).rejects.toThrow('GitHub pagination link escaped API base URL');
+      }, 251, { fetchAll: true })).rejects.toThrow('GitHub pagination link escaped API base URL');
     } finally {
       globalThis.fetch = fetchMock;
     }
+  });
+
+  it('rejects combining fetchAll with maxPages', async () => {
+    await expect(listIssueComments({
+      repository: 'davidruzicka/mcp4openapi',
+      token: 'token',
+      apiBaseUrl: 'https://api.github.com',
+      lookbackHours: 48,
+      maxCandidates: 2,
+      agentId: 'implementor',
+      runId: 'manual-test',
+      now: '2026-03-17T12:00:00.000Z',
+    }, 251, { fetchAll: true, maxPages: 2 })).rejects.toThrow(
+      'Invalid issue comment paging options: fetchAll cannot be combined with maxPages.',
+    );
   });
 });
 

--- a/scripts/github-agent-runtime.ts
+++ b/scripts/github-agent-runtime.ts
@@ -171,6 +171,12 @@ export async function createIssueComment(config: IssueRuntimeConfig, issueNumber
   });
 }
 
+export async function deleteIssueComment(config: IssueRuntimeConfig, commentId: number): Promise<void> {
+  await githubRequest(config, `/repos/${config.repository}/issues/comments/${commentId}`, {
+    method: 'DELETE',
+  });
+}
+
 export async function createRepositoryIssue(
   config: IssueRuntimeConfig,
   input: CreateRepositoryIssueInput,

--- a/scripts/github-agent-runtime.ts
+++ b/scripts/github-agent-runtime.ts
@@ -134,6 +134,7 @@ export async function listRecentClosedIssues(config: IssueRuntimeConfig): Promis
 }
 
 export interface ListIssueCommentsOptions {
+  readonly fetchAll?: boolean;
   readonly maxPages?: number;
 }
 
@@ -142,13 +143,24 @@ export async function listIssueComments(
   issueNumber: number,
   options: ListIssueCommentsOptions = {},
 ): Promise<GitHubIssueComment[]> {
-  const maxPages = Object.prototype.hasOwnProperty.call(options, 'maxPages') ? options.maxPages : 1;
+  const maxPages = resolveIssueCommentPageLimit(options);
   return githubRequestPaginated<GitHubIssueComment>(
     config,
     `/repos/${config.repository}/issues/${issueNumber}/comments?per_page=100`,
     undefined,
     { maxPages },
   );
+}
+
+function resolveIssueCommentPageLimit(options: ListIssueCommentsOptions): number | undefined {
+  if (options.fetchAll) {
+    if (options.maxPages !== undefined) {
+      throw new Error('Invalid issue comment paging options: fetchAll cannot be combined with maxPages.');
+    }
+    return undefined;
+  }
+
+  return options.maxPages ?? 1;
 }
 
 export async function addIssueLabels(config: IssueRuntimeConfig, issueNumber: number, labels: readonly string[]): Promise<void> {

--- a/scripts/github-agent-runtime.ts
+++ b/scripts/github-agent-runtime.ts
@@ -172,9 +172,16 @@ export async function createIssueComment(config: IssueRuntimeConfig, issueNumber
 }
 
 export async function deleteIssueComment(config: IssueRuntimeConfig, commentId: number): Promise<void> {
-  await githubRequest(config, `/repos/${config.repository}/issues/comments/${commentId}`, {
-    method: 'DELETE',
-  });
+  try {
+    await githubRequest(config, `/repos/${config.repository}/issues/comments/${commentId}`, {
+      method: 'DELETE',
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('(404)')) {
+      return;
+    }
+    throw error;
+  }
 }
 
 export async function createRepositoryIssue(

--- a/scripts/github-agent-runtime.ts
+++ b/scripts/github-agent-runtime.ts
@@ -134,7 +134,10 @@ export async function listRecentClosedIssues(config: IssueRuntimeConfig): Promis
 }
 
 export async function listIssueComments(config: IssueRuntimeConfig, issueNumber: number): Promise<GitHubIssueComment[]> {
-  return githubRequest<GitHubIssueComment[]>(config, `/repos/${config.repository}/issues/${issueNumber}/comments?per_page=100`);
+  return githubRequestPaginated<GitHubIssueComment>(
+    config,
+    `/repos/${config.repository}/issues/${issueNumber}/comments?per_page=100`,
+  );
 }
 
 export async function addIssueLabels(config: IssueRuntimeConfig, issueNumber: number, labels: readonly string[]): Promise<void> {
@@ -345,6 +348,67 @@ async function githubRequest<T = unknown>(config: IssueRuntimeConfig, path: stri
   }
 
   return response.json() as Promise<T>;
+}
+
+async function githubRequestPaginated<T>(config: IssueRuntimeConfig, path: string, init: RequestInit = {}): Promise<T[]> {
+  const results: T[] = [];
+  let nextPath: string | undefined = path;
+
+  while (nextPath) {
+    const response = await fetch(`${config.apiBaseUrl}${nextPath}`, {
+      ...init,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${config.token}`,
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        ...init.headers,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub API request failed (${response.status}) for ${nextPath}: ${await response.text()}`);
+    }
+
+    const page = await response.json() as T[];
+    if (!Array.isArray(page)) {
+      throw new Error(`GitHub API request returned a non-array response for ${nextPath}.`);
+    }
+
+    results.push(...page);
+    nextPath = parseNextLinkPath(response.headers.get('link'), config.apiBaseUrl);
+  }
+
+  return results;
+}
+
+function parseNextLinkPath(linkHeader: string | null, apiBaseUrl: string): string | undefined {
+  if (!linkHeader) {
+    return undefined;
+  }
+
+  const nextLink = linkHeader
+    .split(',')
+    .map((segment) => segment.trim())
+    .find((segment) => segment.endsWith('rel="next"'));
+  if (!nextLink) {
+    return undefined;
+  }
+
+  const match = nextLink.match(/<([^>]+)>/);
+  if (!match?.[1]) {
+    return undefined;
+  }
+
+  const nextUrl = new URL(match[1]);
+  const apiBase = new URL(apiBaseUrl);
+  if (nextUrl.origin !== apiBase.origin || !nextUrl.pathname.startsWith(apiBase.pathname)) {
+    throw new Error(`GitHub pagination link escaped API base URL: ${match[1]}`);
+  }
+
+  const relativePathname = nextUrl.pathname.slice(apiBase.pathname.length) || '/';
+  const normalizedPathname = relativePathname.startsWith('/') ? relativePathname : `/${relativePathname}`;
+  return `${normalizedPathname}${nextUrl.search}`;
 }
 
 async function githubGraphQlRequest<T = unknown>(config: IssueRuntimeConfig, payload: Record<string, unknown>): Promise<T> {

--- a/scripts/github-agent-runtime.ts
+++ b/scripts/github-agent-runtime.ts
@@ -153,15 +153,17 @@ export async function listIssueComments(
 }
 
 function resolveIssueCommentPageLimit(options: ListIssueCommentsOptions): number | undefined {
+  if (options.fetchAll && options.maxPages !== undefined) {
+    throw new Error('Invalid issue comment paging options: fetchAll cannot be combined with maxPages.');
+  }
+
   if (options.fetchAll) {
-    if (options.maxPages !== undefined) {
-      throw new Error('Invalid issue comment paging options: fetchAll cannot be combined with maxPages.');
-    }
     return undefined;
   }
 
   return options.maxPages ?? 1;
 }
+
 
 export async function addIssueLabels(config: IssueRuntimeConfig, issueNumber: number, labels: readonly string[]): Promise<void> {
   if (labels.length === 0) {

--- a/scripts/github-agent-runtime.ts
+++ b/scripts/github-agent-runtime.ts
@@ -133,10 +133,21 @@ export async function listRecentClosedIssues(config: IssueRuntimeConfig): Promis
   return listRecentIssueSummaries(config, 'closed');
 }
 
-export async function listIssueComments(config: IssueRuntimeConfig, issueNumber: number): Promise<GitHubIssueComment[]> {
+export interface ListIssueCommentsOptions {
+  readonly maxPages?: number;
+}
+
+export async function listIssueComments(
+  config: IssueRuntimeConfig,
+  issueNumber: number,
+  options: ListIssueCommentsOptions = {},
+): Promise<GitHubIssueComment[]> {
+  const maxPages = Object.prototype.hasOwnProperty.call(options, 'maxPages') ? options.maxPages : 1;
   return githubRequestPaginated<GitHubIssueComment>(
     config,
     `/repos/${config.repository}/issues/${issueNumber}/comments?per_page=100`,
+    undefined,
+    { maxPages },
   );
 }
 
@@ -350,11 +361,18 @@ async function githubRequest<T = unknown>(config: IssueRuntimeConfig, path: stri
   return response.json() as Promise<T>;
 }
 
-async function githubRequestPaginated<T>(config: IssueRuntimeConfig, path: string, init: RequestInit = {}): Promise<T[]> {
+async function githubRequestPaginated<T>(
+  config: IssueRuntimeConfig,
+  path: string,
+  init: RequestInit = {},
+  options: { maxPages?: number } = {},
+): Promise<T[]> {
   const results: T[] = [];
   let nextPath: string | undefined = path;
+  let pageCount = 0;
 
   while (nextPath) {
+    pageCount += 1;
     const response = await fetch(`${config.apiBaseUrl}${nextPath}`, {
       ...init,
       headers: {
@@ -376,7 +394,8 @@ async function githubRequestPaginated<T>(config: IssueRuntimeConfig, path: strin
     }
 
     results.push(...page);
-    nextPath = parseNextLinkPath(response.headers.get('link'), config.apiBaseUrl);
+    const nextLinkPath = parseNextLinkPath(response.headers.get('link'), config.apiBaseUrl);
+    nextPath = options.maxPages !== undefined && pageCount >= options.maxPages ? undefined : nextLinkPath;
   }
 
   return results;

--- a/scripts/run-implementor.ts
+++ b/scripts/run-implementor.ts
@@ -5,6 +5,7 @@ import {
   collectImplementorAssignments,
   planImplementorResultLabels,
   selectLatestTrustedPlannerArtifact,
+  selectStaleImplementorCommentIds,
   type ImplementorCommandResult,
   type ImplementorTaskPayload,
 } from '../src/automation/implementor-runner.js';
@@ -17,6 +18,7 @@ import {
   buildOpenPullRequestsByIssueNumber,
   createIssueComment,
   createReviewThreadReply,
+  deleteIssueComment,
   getPullRequest,
   listIssueComments,
   listOpenPullRequests,
@@ -146,6 +148,8 @@ for (const assignment of assignments.slice(0, runtimeConfig.maxCandidates)) {
     reviewFollowUpItems,
   }));
 
+  await cleanupImplementorComments(runtimeConfig, assignment.issueNumber);
+
   if (hasImplementorPullRequest(result)) {
     const pullRequestNumber = result.pullRequest.number;
 
@@ -167,6 +171,17 @@ for (const assignment of assignments.slice(0, runtimeConfig.maxCandidates)) {
 }
 
 process.stdout.write(`Implementor runner completed. Processed ${Math.min(assignments.length, runtimeConfig.maxCandidates)} issue(s).\n`);
+
+async function cleanupImplementorComments(
+  runtimeConfig: IssueRuntimeConfig,
+  issueNumber: number,
+): Promise<void> {
+  const latestComments = (await listIssueComments(runtimeConfig, issueNumber)).map(mapIssueComment);
+  const staleCommentIds = selectStaleImplementorCommentIds(latestComments);
+  for (const commentId of staleCommentIds) {
+    await deleteIssueComment(runtimeConfig, commentId);
+  }
+}
 
 async function postImplementorReviewThreadReplies(
   runtimeConfig: IssueRuntimeConfig,

--- a/scripts/run-implementor.ts
+++ b/scripts/run-implementor.ts
@@ -176,10 +176,15 @@ async function cleanupImplementorComments(
   runtimeConfig: IssueRuntimeConfig,
   issueNumber: number,
 ): Promise<void> {
-  const latestComments = (await listIssueComments(runtimeConfig, issueNumber)).map(mapIssueComment);
-  const staleCommentIds = selectStaleImplementorCommentIds(latestComments);
-  for (const commentId of staleCommentIds) {
-    await deleteIssueComment(runtimeConfig, commentId);
+  try {
+    const latestComments = (await listIssueComments(runtimeConfig, issueNumber, { maxPages: undefined })).map(mapIssueComment);
+    const staleCommentIds = selectStaleImplementorCommentIds(latestComments);
+    for (const commentId of staleCommentIds) {
+      await deleteIssueComment(runtimeConfig, commentId);
+    }
+  } catch (error) {
+    const summary = error instanceof Error ? error.message : 'unknown cleanup error';
+    process.stdout.write(`Implementor comment cleanup skipped for issue #${issueNumber}: ${summary}.\n`);
   }
 }
 

--- a/scripts/run-implementor.ts
+++ b/scripts/run-implementor.ts
@@ -177,7 +177,7 @@ async function cleanupImplementorComments(
   issueNumber: number,
 ): Promise<void> {
   try {
-    const latestComments = (await listIssueComments(runtimeConfig, issueNumber, { maxPages: undefined })).map(mapIssueComment);
+    const latestComments = (await listIssueComments(runtimeConfig, issueNumber, { fetchAll: true })).map(mapIssueComment);
     const staleCommentIds = selectStaleImplementorCommentIds(latestComments);
     for (const commentId of staleCommentIds) {
       await deleteIssueComment(runtimeConfig, commentId);

--- a/src/automation/implementor-runner.test.ts
+++ b/src/automation/implementor-runner.test.ts
@@ -753,6 +753,27 @@ describe('implementor-runner', () => {
         }),
       ], strictTrustConfig)).toBeUndefined();
     });
+
+    it('returns undefined when trusted agent IDs are required but agent-id metadata is missing', () => {
+      expect(selectLatestTrustedPlannerArtifact([
+        buildComment([
+          '🤖 Agent plan (planner)',
+          '',
+          buildSignedPlannerArtifact(),
+          '',
+          '<!-- AGENT-METADATA',
+          'agent-stage: planner',
+          'status: planned',
+          '-->',
+        ].join('\n'), {
+          id: 3,
+          createdAt: '2026-03-14T13:10:00Z',
+          updatedAt: '2026-03-14T13:10:00Z',
+        }),
+      ], strictTrustConfig, {
+        trustedAgentIds: ['planner'],
+      })).toBeUndefined();
+    });
   });
 
   describe('parseImplementorTaskPayload', () => {
@@ -1493,6 +1514,76 @@ describe('implementor-runner', () => {
       }), { id: 23, createdAt: '2026-03-14T12:06:00Z', updatedAt: '2026-03-14T12:06:00Z' });
 
       expect(selectStaleImplementorCommentIds([authFailureOne, authFailureTwo, malformedFailure])).toEqual([21]);
+    });
+
+    it('keeps non-failed implementor result comments untouched', () => {
+      const blockedResult = buildComment(buildImplementorResultComment({
+        repository: 'davidruzicka/mcp4openapi',
+        issueNumber: 161,
+        agentId: 'implementor',
+        runId: 'run-blocked',
+        timestamp: '2026-03-14T12:15:00Z',
+        result: {
+          outcome: 'blocked',
+          summary: 'Needs a human decision.',
+        },
+      }), { id: 30, createdAt: '2026-03-14T12:15:00Z', updatedAt: '2026-03-14T12:15:00Z' });
+
+      expect(selectStaleImplementorCommentIds([blockedResult])).toEqual([]);
+    });
+
+    it('deduplicates malformed failure comments even when the summary line is missing', () => {
+      const missingSummaryOne = buildComment([
+        '🤖 Agent implementation note (implementor)',
+        '',
+        'Implementation result: failed',
+        '',
+        '<!-- AGENT-METADATA',
+        'agent-stage: implementor',
+        'status: failed',
+        'timestamp: 2026-03-14T12:00:00Z',
+        '-->',
+      ].join('\n'), { id: 33, createdAt: '2026-03-14T12:00:00Z', updatedAt: '2026-03-14T12:00:00Z' });
+      const missingSummaryTwo = buildComment([
+        '🤖 Agent implementation note (implementor)',
+        '',
+        'Implementation result: failed',
+        '',
+        '<!-- AGENT-METADATA',
+        'agent-stage: implementor',
+        'status: failed',
+        'timestamp: 2026-03-14T12:05:00Z',
+        '-->',
+      ].join('\n'), { id: 34, createdAt: '2026-03-14T12:05:00Z', updatedAt: '2026-03-14T12:05:00Z' });
+
+      expect(selectStaleImplementorCommentIds([missingSummaryOne, missingSummaryTwo])).toEqual([33]);
+    });
+
+    it('deduplicates generic failure signatures after normalizing volatile values', () => {
+      const genericFailureOne = buildComment(buildImplementorResultComment({
+        repository: 'davidruzicka/mcp4openapi',
+        issueNumber: 161,
+        agentId: 'implementor',
+        runId: 'run-generic-1',
+        timestamp: '2026-03-14T12:20:00Z',
+        result: {
+          outcome: 'failed',
+          summary: 'Unexpected backend crash at 2026-03-14T12:20:01Z in /tmp/mcp4openapi-abc123/worktree (cf-ray: deadbeef).',
+        },
+      }), { id: 35, createdAt: '2026-03-14T12:20:00Z', updatedAt: '2026-03-14T12:20:00Z' });
+      const genericFailureTwo = buildComment(buildImplementorResultComment({
+        repository: 'davidruzicka/mcp4openapi',
+        issueNumber: 161,
+        agentId: 'implementor',
+        runId: 'run-generic-2',
+        timestamp: '2026-03-14T12:25:00Z',
+        result: {
+          outcome: 'failed',
+          summary: 'Unexpected backend crash at 2026-03-14T12:25:09Z in /tmp/mcp4openapi-xyz999/worktree (cf-ray: feedface).',
+        },
+      }), { id: 36, createdAt: '2026-03-14T12:25:00Z', updatedAt: '2026-03-14T12:25:00Z' });
+
+      expect(selectStaleImplementorCommentIds([genericFailureOne, genericFailureTwo])).toEqual([35]);
     });
 
     it('does not delete human comments or non-implementor bot comments', () => {

--- a/src/automation/implementor-runner.test.ts
+++ b/src/automation/implementor-runner.test.ts
@@ -8,6 +8,7 @@ import {
   parseImplementorTaskPayload,
   planImplementorResultLabels,
   selectLatestTrustedPlannerArtifact,
+  selectStaleImplementorCommentIds,
   type ImplementorIssue,
   type ImplementorIssueComment,
 } from './implementor-runner.js';
@@ -1433,6 +1434,83 @@ describe('implementor-runner', () => {
         issueLabelsToRemove: ['agent:implementing'],
         pullRequestLabelsToAdd: [],
       });
+    });
+  });
+
+  describe('selectStaleImplementorCommentIds', () => {
+    it('keeps only the latest implementor lease comment', () => {
+      const leaseOne = buildComment(buildImplementorLeaseComment({
+        repository: 'davidruzicka/mcp4openapi',
+        issueNumber: 161,
+        agentId: 'implementor',
+        runId: 'run-1',
+        timestamp: '2026-03-14T12:00:00Z',
+      }), { id: 11, createdAt: '2026-03-14T12:00:00Z', updatedAt: '2026-03-14T12:00:00Z' });
+      const leaseTwo = buildComment(buildImplementorLeaseComment({
+        repository: 'davidruzicka/mcp4openapi',
+        issueNumber: 161,
+        agentId: 'implementor',
+        runId: 'run-2',
+        timestamp: '2026-03-14T12:10:00Z',
+      }), { id: 12, createdAt: '2026-03-14T12:10:00Z', updatedAt: '2026-03-14T12:10:00Z' });
+
+      expect(selectStaleImplementorCommentIds([leaseOne, leaseTwo])).toEqual([11]);
+    });
+
+    it('keeps the latest comment per distinct implementor failure signature', () => {
+      const authFailureOne = buildComment(buildImplementorResultComment({
+        repository: 'davidruzicka/mcp4openapi',
+        issueNumber: 161,
+        agentId: 'implementor',
+        runId: 'run-1',
+        timestamp: '2026-03-14T12:00:00Z',
+        result: {
+          outcome: 'failed',
+          summary: 'Implementor command failed: ERROR 2026-03-14T12:00:01Z failed to connect to websocket: HTTP error: 500 Internal Server Error. request id: req_abc123def456',
+        },
+      }), { id: 21, createdAt: '2026-03-14T12:00:00Z', updatedAt: '2026-03-14T12:00:00Z' });
+      const authFailureTwo = buildComment(buildImplementorResultComment({
+        repository: 'davidruzicka/mcp4openapi',
+        issueNumber: 161,
+        agentId: 'implementor',
+        runId: 'run-2',
+        timestamp: '2026-03-14T12:05:00Z',
+        result: {
+          outcome: 'failed',
+          summary: 'Implementor command failed: ERROR 2026-03-14T12:05:02Z failed to connect to websocket: HTTP error: 500 Internal Server Error. request id: req_xyz999uvw888',
+        },
+      }), { id: 22, createdAt: '2026-03-14T12:05:00Z', updatedAt: '2026-03-14T12:05:00Z' });
+      const malformedFailure = buildComment(buildImplementorResultComment({
+        repository: 'davidruzicka/mcp4openapi',
+        issueNumber: 161,
+        agentId: 'implementor',
+        runId: 'run-3',
+        timestamp: '2026-03-14T12:06:00Z',
+        result: {
+          outcome: 'failed',
+          summary: 'Codex backend returned malformed result (Invalid implementor command result: expected JSON object.). Output preview: "Plan: I updated tests".',
+        },
+      }), { id: 23, createdAt: '2026-03-14T12:06:00Z', updatedAt: '2026-03-14T12:06:00Z' });
+
+      expect(selectStaleImplementorCommentIds([authFailureOne, authFailureTwo, malformedFailure])).toEqual([21]);
+    });
+
+    it('does not delete human comments or non-implementor bot comments', () => {
+      const humanComment = buildComment('Human investigation note.', {
+        id: 31,
+        authorLogin: 'davidruzicka',
+      });
+      const plannerComment = buildComment([
+        '🤖 Agent plan (planner)',
+        '',
+        '<!-- AGENT-METADATA',
+        'agent-stage: planner',
+        'status: planned',
+        'timestamp: 2026-03-14T12:00:00Z',
+        '-->',
+      ].join('\n'), { id: 32 });
+
+      expect(selectStaleImplementorCommentIds([humanComment, plannerComment])).toEqual([]);
     });
   });
 

--- a/src/automation/implementor-runner.ts
+++ b/src/automation/implementor-runner.ts
@@ -205,6 +205,76 @@ function buildReviewFollowUpCountLine(reviewFollowUpItems: readonly ReviewFollow
   return `Review follow-up items: ${reviewFollowUpItems.length}`;
 }
 
+export function selectStaleImplementorCommentIds(comments: readonly ImplementorIssueComment[]): number[] {
+  const latestCommentIdByClass = new Map<string, number>();
+  const commentsOldestFirst = [...comments].sort((left, right) => {
+    const timestampDelta = Date.parse(left.createdAt) - Date.parse(right.createdAt);
+    return timestampDelta !== 0 ? timestampDelta : left.id - right.id;
+  });
+
+  for (const comment of commentsOldestFirst) {
+    const classification = classifyImplementorComment(comment);
+    if (!classification) {
+      continue;
+    }
+
+    latestCommentIdByClass.set(classification, comment.id);
+  }
+
+  return commentsOldestFirst
+    .filter((comment) => {
+      const classification = classifyImplementorComment(comment);
+      return classification !== undefined && latestCommentIdByClass.get(classification) !== comment.id;
+    })
+    .map((comment) => comment.id);
+}
+
+function classifyImplementorComment(comment: ImplementorIssueComment): string | undefined {
+  if (comment.authorLogin !== 'github-actions[bot]') {
+    return undefined;
+  }
+
+  const metadata = parseAgentMetadata(comment.body);
+  if (metadata?.['agent-stage'] !== 'implementor') {
+    return undefined;
+  }
+
+  if (comment.body.includes('Implementation lease acquired for issue #')) {
+    return 'implementor-lease';
+  }
+
+  if (!comment.body.includes('Implementation result: failed')) {
+    return undefined;
+  }
+
+  const summaryLine = comment.body.split('\n').find((line) => line.startsWith('Summary: '));
+  if (!summaryLine) {
+    return 'implementor-failed:missing-summary';
+  }
+
+  return `implementor-failed:${normalizeImplementorFailureSignature(summaryLine.slice('Summary: '.length))}`;
+}
+
+function normalizeImplementorFailureSignature(summary: string): string {
+  const normalized = summary
+    .replace(/github-actions-\d+/g, 'github-actions-[id]')
+    .replace(/\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\b/g, '[timestamp]')
+    .replace(/\breq_[A-Za-z0-9]+\b/g, 'req_[id]')
+    .replace(/\bcf-ray:\s*[^,\s]+/gi, 'cf-ray:[id]')
+    .replace(/\/tmp\/mcp4openapi-[^\s)]+/g, '/tmp/mcp4openapi-[temp]')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (normalized.includes('Codex backend returned malformed result')) {
+    return 'codex-malformed-result';
+  }
+  if (normalized.includes('failed to connect to websocket') || normalized.includes('401 Unauthorized')) {
+    return 'codex-auth-transport';
+  }
+
+  return normalized;
+}
+
 export interface ParseImplementorTaskPayloadOptions {
   readonly trustConfig?: ArtifactTrustConfig;
 }

--- a/src/automation/implementor-runner.ts
+++ b/src/automation/implementor-runner.ts
@@ -211,22 +211,24 @@ export function selectStaleImplementorCommentIds(comments: readonly ImplementorI
     const timestampDelta = Date.parse(left.createdAt) - Date.parse(right.createdAt);
     return timestampDelta !== 0 ? timestampDelta : left.id - right.id;
   });
+  const classifiedComments = commentsOldestFirst.map((comment) => ({
+    id: comment.id,
+    classification: classifyImplementorComment(comment),
+  }));
 
-  for (const comment of commentsOldestFirst) {
-    const classification = classifyImplementorComment(comment);
+  for (const { id, classification } of classifiedComments) {
     if (!classification) {
       continue;
     }
 
-    latestCommentIdByClass.set(classification, comment.id);
+    latestCommentIdByClass.set(classification, id);
   }
 
-  return commentsOldestFirst
-    .filter((comment) => {
-      const classification = classifyImplementorComment(comment);
-      return classification !== undefined && latestCommentIdByClass.get(classification) !== comment.id;
-    })
-    .map((comment) => comment.id);
+  return classifiedComments
+    .filter(
+      ({ id, classification }) => classification !== undefined && latestCommentIdByClass.get(classification) !== id,
+    )
+    .map(({ id }) => id);
 }
 
 function classifyImplementorComment(comment: ImplementorIssueComment): string | undefined {


### PR DESCRIPTION
Agent authored:

## Summary
- add implementor-side comment hygiene that deletes stale bot lease/failure comments after each run
- classify implementor failures by normalized signature so repeated auth/transport and malformed-result retries collapse to a single latest representative
- add runtime support for deleting issue comments and targeted tests for the deduplication behavior

## Testing
- `npx vitest run src/automation/implementor-runner.test.ts src/automation/implementor-codex.test.ts scripts/workflow-security.test.ts`
- `npm run typecheck`
- `git diff --check`

Closes #250
