### PR TITLE
🛡️ Sentinel: [Security Improvement] Prevent input reflection in env config error message

### DIFF
--- a/src/tool-filter/config/env-config-parser.ts
+++ b/src/tool-filter/config/env-config-parser.ts
@@ -100,7 +100,7 @@ export class EnvConfigParser {
       }
 
       throw new ConfigurationError(
-        `MCP4_TOOL_FILTER_ALLOW_CATEGORIES supports only 'list' and 'read', got '${entry}'`
+        `MCP4_TOOL_FILTER_ALLOW_CATEGORIES supports only 'list' and 'read'`
       );
     }
 


### PR DESCRIPTION
🚨 **Severity:** LOW/MEDIUM
💡 **Vulnerability:** The `EnvConfigParser` reflected unvalidated environment variable input (`MCP4_TOOL_FILTER_ALLOW_CATEGORIES`) directly into a thrown `ConfigurationError` message.
🎯 **Impact:** If these error messages are logged or surfaced to a UI, it could lead to accidental leakage of sensitive configuration data mapped to that variable or minor reflection vulnerabilities.
🔧 **Fix:** Removed the interpolation of the raw `entry` value from the `ConfigurationError` in `src/tool-filter/config/env-config-parser.ts`.
✅ **Verification:** Ran `npm run test` and all tests continue to pass.

---
*PR created automatically by Jules for task [10997135582439111945](https://jules.google.com/task/10997135582439111945) started by @davidruzicka*