### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Internal Error Leakage via API Responses in MCP Server

### DIFF
--- a/src/mcp/mcp-server-apps.test.ts
+++ b/src/mcp/mcp-server-apps.test.ts
@@ -277,11 +277,11 @@ describe('MCPServer apps resources', () => {
 
     expect(invalidReadResponse.error).toEqual({
       code: -32602,
-      message: 'resources/read requires string parameter "uri"',
+      message: expect.stringMatching(/^Validation error: resources\/read requires string parameter "uri" \(correlation ID: [a-f0-9-]+\)$/),
     });
     expect(invalidCompletionResponse.error).toEqual({
       code: -32602,
-      message: 'completion/complete requires a resource ref',
+      message: expect.stringMatching(/^Validation error: completion\/complete requires a resource ref \(correlation ID: [a-f0-9-]+\)$/),
     });
   });
 

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1858,12 +1858,18 @@ export class MCPServer {
           code = -32601;
         }
 
+        const correlationId = generateCorrelationId();
+        this.logger.error('prompts/get handler error', error instanceof Error ? error : new Error(String(error)), {
+          correlationId,
+          method: 'prompts/get',
+        });
+
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }
@@ -1901,12 +1907,18 @@ export class MCPServer {
           result: await this.readResource(params.uri, sessionId, profileId),
         };
       } catch (error) {
+        const correlationId = generateCorrelationId();
+        this.logger.error('resources/read handler error', error instanceof Error ? error : new Error(String(error)), {
+          correlationId,
+          method: 'resources/read',
+        });
+
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code: error instanceof ValidationError ? -32602 : -32601,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }
@@ -1920,12 +1932,18 @@ export class MCPServer {
           result: await this.completeResourceArgument(req as CompleteRequest, sessionId, profileId),
         };
       } catch (error) {
+        const correlationId = generateCorrelationId();
+        this.logger.error('completion/complete handler error', error instanceof Error ? error : new Error(String(error)), {
+          correlationId,
+          method: 'completion/complete',
+        });
+
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code: error instanceof ValidationError ? -32602 : -32601,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The MCP server JSON-RPC handlers for `prompts/get`, `resources/read`, and `completion/complete` were catching raw runtime and logic exceptions and leaking the un-sanitized error `message` string directly to the client in the `error.message` field of the JSON-RPC response.
🎯 **Impact:** An attacker or regular client could receive sensitive internal server details, such as database error messages, paths, or service configuration specifics, increasing the attack surface.
🔧 **Fix:** The catch blocks have been updated to securely sanitize these messages using the existing `this.formatErrorForClient(error, correlationId)` method, which prevents leakage of internal errors while passing through "safe" client-facing validation messages. A unique correlation ID is generated and logged alongside the raw error stack trace to allow safe internal debugging.
✅ **Verification:** Updated `src/mcp/mcp-server-apps.test.ts` to assert that the `message` string correctly incorporates the correlation UUID via regex and that validation errors correctly format. All unit and e2e tests were passed using `npm run test`.

---
*PR created automatically by Jules for task [3979447730811687819](https://jules.google.com/task/3979447730811687819) started by @davidruzicka*