### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in URL interpolation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,14 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2026-03-24 - [CRITICAL] Path Traversal via URL Interpolation with Dots
+
+**Vulnerability:**
+The `encodeURIComponent` function used in URL interpolation (`CompositeExecutor` and `encodePathSegment` in `mcp-server.ts`) does not encode dot (`.`) characters. When user input containing `../` or `..` was processed, it was encoded as `..%2F` or left as `..`. Some HTTP clients and proxy servers normalize these path segments before processing the request, allowing an attacker to traverse directory structures in the API path.
+
+**Learning:**
+Relying solely on standard `encodeURIComponent` is insufficient for preventing path traversal when interpolating user inputs into URL paths, as standard URI encoding specifications do not require encoding of dots.
+
+**Prevention:**
+1.  Always encode dot characters (`.`) explicitly using `.replace(/\./g, '%2E')` after calling `encodeURIComponent()` when interpolating into URL path segments.

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1107,7 +1107,8 @@ export class MCPServer {
    */
   private encodePathSegment(value: unknown): string {
     const val = String(value);
-    return val.includes('/') ? encodeURIComponent(val) : val;
+    // URL-encode slashes and dots to prevent path traversal when interpolating path parameters
+    return (val.includes('/') || val.includes('.')) ? encodeURIComponent(val).replace(/\./g, '%2E') : val;
   }
 
   /**

--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -67,7 +67,7 @@ describe('CompositeExecutor Security', () => {
     // Fixed behavior: path contains encoded "%2E%2E"
     // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
     // The slashes inside the injected value are encoded, preventing directory traversal
-    const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -171,14 +171,14 @@ export class CompositeExecutor {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
+        return encodeURIComponent(String(args[key])).replace(/\./g, '%2E');
       }
 
       // Try aliases from profile
       const possibleAliases = this.parameterAliases[key] || [];
       for (const alias of possibleAliases) {
         if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+          return encodeURIComponent(String(args[alias])).replace(/\./g, '%2E');
         }
       }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path traversal vulnerability when substituting variables in URLs using `encodeURIComponent` which does not escape dots (`.`). This could allow attackers to traverse directories by providing inputs like `../`.
🎯 Impact: Attackers could manipulate API paths to access unintended endpoints or files.
🔧 Fix: Added explicit `.replace(/\./g, '%2E')` after calling `encodeURIComponent()` during URL variable interpolation in `src/tooling/composite-executor.ts` and `src/mcp/mcp-server.ts`. This ensures that dots are properly encoded and treated as part of the segment rather than path traversal directives.
✅ Verification: Ran `npm run test` ensuring the relevant security tests pass and no functionality breaks. Also added a journal entry in `.jules/sentinel.md` documenting this finding.

---
*PR created automatically by Jules for task [13559895342011619317](https://jules.google.com/task/13559895342011619317) started by @davidruzicka*