### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Path Parameters

### DIFF
--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1100,14 +1100,15 @@ export class MCPServer {
   }
 
   /**
-   * Encode path segment if it contains special characters (like slashes)
+   * Encode path segment if it contains special characters (like slashes or dots)
    *
    * Why: GitLab and other APIs require path parameters (like project paths)
-   * to be URL-encoded when used in URL path.
+   * to be URL-encoded when used in URL path. We must also encode dots to
+   * prevent path traversal.
    */
   private encodePathSegment(value: unknown): string {
     const val = String(value);
-    return val.includes('/') ? encodeURIComponent(val) : val;
+    return val.includes('/') || val.includes('.') ? encodeURIComponent(val).replace(/\./g, '%2E') : val;
   }
 
   /**

--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -65,9 +65,9 @@ describe('CompositeExecutor Security', () => {
 
     // Vulnerable behavior: path contains raw ".."
     // Fixed behavior: path contains encoded "%2E%2E"
-    // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
-    // The slashes inside the injected value are encoded, preventing directory traversal
-    const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
+    // Note: encodeURIComponent('../admin/secrets').replace(/\./g, '%2E') => %2E%2E%2Fadmin%2Fsecrets
+    // The slashes and dots inside the injected value are encoded, preventing directory traversal
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -171,14 +171,14 @@ export class CompositeExecutor {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
+        return encodeURIComponent(String(args[key])).replace(/\./g, '%2E');
       }
 
       // Try aliases from profile
       const possibleAliases = this.parameterAliases[key] || [];
       for (const alias of possibleAliases) {
         if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+          return encodeURIComponent(String(args[alias])).replace(/\./g, '%2E');
         }
       }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path traversal / SSRF via unencoded `.` characters in templated URL path parameters.
🎯 Impact: A user passing `../admin` as an ID could force the server's backend HTTP client to traverse directories, potentially accessing unintended API routes or bypassing proxy restrictions.
🔧 Fix: Applied `.replace(/\./g, '%2E')` after `encodeURIComponent()` anywhere path parameters are resolved dynamically (in `CompositeExecutor.resolvePath` and `MCPServer.encodePathSegment`).
✅ Verification: Confirmed via `npm run test` and explicit updates to `src/tooling/composite-executor-security.test.ts` to assert that `.` is encoded.

---
*PR created automatically by Jules for task [7154718388751806891](https://jules.google.com/task/7154718388751806891) started by @davidruzicka*