### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix error observability for OAuth callback responses

### DIFF
--- a/src/auth/oauth-provider.test.ts
+++ b/src/auth/oauth-provider.test.ts
@@ -1985,7 +1985,7 @@ describe('ExternalOAuthProvider', () => {
       await provider.handleCallback(mockReq, mockRes);
 
       expect(mockRes.status).toHaveBeenCalledWith(500);
-      expect(mockRes.send).toHaveBeenCalledWith('Internal Server Error during token exchange');
+      expect(mockRes.send).toHaveBeenCalledWith(expect.stringContaining('Internal Server Error during token exchange (correlation ID:'));
     });
   });
 

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -37,6 +37,7 @@ import {
 } from '../core/constants.js';
 import { escapeHtmlSafe } from '../validation/validation-utils.js';
 import { SSRFValidator } from '../security/ssrf-validator.js';
+import { generateCorrelationId } from '../core/errors.js';
 import { parseOAuthMetadataEndpoints } from './oauth-metadata.js';
 import { InMemoryClientsStore } from './client-store/in-memory-clients-store.js';
 import { isApprovedUnregisteredClientRedirectUri } from './unregistered-client-redirect-policy.js';
@@ -867,8 +868,9 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
         res.redirect(clientUrl.toString());
 
     } catch (err) {
-        this.logger.error('Callback handling failed', err as Error);
-        res.status(500).send('Internal Server Error during token exchange');
+        const correlationId = generateCorrelationId();
+        this.logger.error('Callback handling failed', err as Error, { correlationId });
+        res.status(500).send(`Internal Server Error during token exchange (correlation ID: ${correlationId})`);
     }
   }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential un-traced server-side error and lack of observability via the OAuth callback flow response for clients. The application returned generic 500 error messages without tying them back to internal log events via correlation ID.
🎯 Impact: Inability to properly trace generic errors client-side back to specific, detailed internal logs. This breaks standard troubleshooting and debugging observability principles established for this application framework.
🔧 Fix: Used `generateCorrelationId()` in the callback exception handler of `ExternalOAuthProvider`, logged the `err` object alongside the `correlationId`, and securely appended the correlation ID to the safe, generic internal server error client response.
✅ Verification: Ran `npm run test` which succeeded, executing the updated coverage for correlation ID error handling tests.

---
*PR created automatically by Jules for task [3620838790017427947](https://jules.google.com/task/3620838790017427947) started by @davidruzicka*