### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix internal error leakage in 500 responses

### DIFF
--- a/src/auth/oauth-provider.test.ts
+++ b/src/auth/oauth-provider.test.ts
@@ -1985,7 +1985,7 @@ describe('ExternalOAuthProvider', () => {
       await provider.handleCallback(mockReq, mockRes);
 
       expect(mockRes.status).toHaveBeenCalledWith(500);
-      expect(mockRes.send).toHaveBeenCalledWith('Internal Server Error during token exchange');
+      expect(mockRes.send).toHaveBeenCalledWith(expect.stringMatching(/^Internal error \(correlation ID: [a-f0-9-]+\)$/));
     });
   });
 

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -40,6 +40,7 @@ import { SSRFValidator } from '../security/ssrf-validator.js';
 import { parseOAuthMetadataEndpoints } from './oauth-metadata.js';
 import { InMemoryClientsStore } from './client-store/in-memory-clients-store.js';
 import { isApprovedUnregisteredClientRedirectUri } from './unregistered-client-redirect-policy.js';
+import { generateCorrelationId } from '../core/errors.js';
 export { InMemoryClientsStore };
 export type { InMemoryClientsStoreOptions } from './client-store/types.js';
 
@@ -867,8 +868,9 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
         res.redirect(clientUrl.toString());
 
     } catch (err) {
-        this.logger.error('Callback handling failed', err as Error);
-        res.status(500).send('Internal Server Error during token exchange');
+        const correlationId = generateCorrelationId();
+        this.logger.error('Callback handling failed', err as Error, { correlationId });
+        res.status(500).send(`Internal error (correlation ID: ${correlationId})`);
     }
   }
 

--- a/src/transport/http-transport-security.test.ts
+++ b/src/transport/http-transport-security.test.ts
@@ -692,7 +692,7 @@ describe('HttpTransport security behavior (no listen)', () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(500);
-    expect(String(res.body)).toContain('OAuth authorization failed');
+    expect(String(res.body)).toMatch(/^Internal error \(correlation ID: [a-f0-9-]+\)$/);
 
     await transport.stop();
   });
@@ -1378,7 +1378,7 @@ describe('HttpTransport security behavior (no listen)', () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(500);
-    expect(String(res.body)).toContain('OAuth callback failed');
+    expect(String(res.body)).toMatch(/^Internal error \(correlation ID: [a-f0-9-]+\)$/);
 
     await transport.stop();
   });
@@ -1592,7 +1592,7 @@ describe('HttpTransport security behavior (no listen)', () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(500);
-    expect(res.body).toMatchObject({ error: 'server_error', error_description: 'Registration failed' });
+    expect(res.body).toMatchObject({ error: 'server_error', error_description: expect.stringMatching(/^Internal error \(correlation ID: [a-f0-9-]+\)$/) });
 
     await transport.stop();
   });
@@ -1724,7 +1724,7 @@ describe('HttpTransport security behavior (no listen)', () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(500);
-    expect(res.body).toMatchObject({ error: 'server_error', error_description: 'Registration failed' });
+    expect(res.body).toMatchObject({ error: 'server_error', error_description: expect.stringMatching(/^Internal error \(correlation ID: [a-f0-9-]+\)$/) });
 
     await transport.stop();
   });

--- a/src/transport/http-transport.test.ts
+++ b/src/transport/http-transport.test.ts
@@ -2340,7 +2340,7 @@ describeIfListen('HttpTransport', () => {
         .query({ code: 'test-code' });
 
       expect(response.status).toBe(500);
-      expect(response.text).toBe('OAuth callback failed');
+      expect(response.text).toMatch(/^Internal error \(correlation ID: [a-f0-9-]+\)$/);
     });
   });
 

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -1625,10 +1625,11 @@ export class HttpTransport {
     try {
       profiles = await this.profileIndexProvider();
     } catch (error) {
-      this.logger.error('Failed to load profile index', error instanceof Error ? error : new Error(String(error)));
+      const correlationId = generateCorrelationId();
+      this.logger.error('Failed to load profile index', error instanceof Error ? error : new Error(String(error)), { correlationId });
       res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({
         error: 'Internal Server Error',
-        message: 'Failed to load profile index',
+        message: `Internal error (correlation ID: ${correlationId})`,
       });
       return;
     }
@@ -1814,8 +1815,9 @@ export class HttpTransport {
 
       await profileState.oauthProvider.authorize(client, params, res);
     } catch (error) {
-      this.logger.error('OAuth authorize error', error instanceof Error ? error : new Error(String(error)));
-      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send('OAuth authorization failed');
+      const correlationId = generateCorrelationId();
+      this.logger.error('OAuth authorize error', error instanceof Error ? error : new Error(String(error)), { correlationId });
+      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send(`Internal error (correlation ID: ${correlationId})`);
     }
   }
 
@@ -2077,9 +2079,10 @@ export class HttpTransport {
 
       await profileState.oauthProvider.handleCallback(req, res);
     } catch (error) {
-      this.logger.error('OAuth callback error', error instanceof Error ? error : new Error(String(error)));
+      const correlationId = generateCorrelationId();
+      this.logger.error('OAuth callback error', error instanceof Error ? error : new Error(String(error)), { correlationId });
       if (!res.headersSent) {
-        res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send('OAuth callback failed');
+        res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send(`Internal error (correlation ID: ${correlationId})`);
       }
     }
   }
@@ -2113,8 +2116,9 @@ export class HttpTransport {
       };
       res.json(buildAuthorizationServerMetadata(metadata, profileState.context.enterpriseAuthorization));
     } catch (error) {
-      this.logger.error('OAuth authorization server metadata error', error instanceof Error ? error : new Error(String(error)));
-      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send('OAuth metadata failed');
+      const correlationId = generateCorrelationId();
+      this.logger.error('OAuth authorization server metadata error', error instanceof Error ? error : new Error(String(error)), { correlationId });
+      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send(`Internal error (correlation ID: ${correlationId})`);
     }
   }
 
@@ -2180,8 +2184,9 @@ export class HttpTransport {
         return;
       }
 
-      this.logger.error('Client registration failed', error instanceof Error ? error : new Error(String(error)));
-      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({ error: 'server_error', error_description: 'Registration failed' });
+      const correlationId = generateCorrelationId();
+      this.logger.error('Client registration failed', error instanceof Error ? error : new Error(String(error)), { correlationId });
+      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({ error: 'server_error', error_description: `Internal error (correlation ID: ${correlationId})` });
     }
   }
 
@@ -2690,7 +2695,9 @@ export class HttpTransport {
       // If contains requests, process and return response
       if (messageType === 'request') {
         if (!this.messageHandler) {
-          res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({ error: 'Internal Server Error', message: 'Message handler not configured' });
+          const correlationId = generateCorrelationId();
+          this.logger.error('Message handler not configured', undefined, { correlationId });
+          res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({ error: 'Internal Server Error', message: `Internal error (correlation ID: ${correlationId})` });
           return;
         }
 


### PR DESCRIPTION
Added `generateCorrelationId()` to all 500 Internal Server Error responses in `src/auth/oauth-provider.ts` and `src/transport/http-transport.ts` to prevent the leakage of sensitive internal error details. Responses now return a generic message along with a correlation ID, while the full error details are logged securely on the backend. Updated related test assertions to expect the new response format.

---
*PR created automatically by Jules for task [7384753000065337055](https://jules.google.com/task/7384753000065337055) started by @davidruzicka*