### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information leakage in JSON-RPC handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,8 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2024-05-20 - [Information Leakage in JSON-RPC Handlers]
+**Vulnerability:** The MCP Server's JSON-RPC handlers for `prompts/get`, `resources/read`, and `completion/complete` were directly passing internal error messages `(error as Error).message` to the client. This exposed internal error details and potentially sensitive stack traces.
+**Learning:** Even when handling non-tool execution endpoints, error messages must be sanitized before being sent to external clients to prevent information leakage.
+**Prevention:** Always use the `this.formatErrorForClient(error, correlationId)` method in conjunction with generating a `correlationId` to ensure client-facing errors are safely generic (e.g., `Internal error`), while securely logging the detailed internal error using `this.logger.error`.

--- a/src/mcp/mcp-server-apps.test.ts
+++ b/src/mcp/mcp-server-apps.test.ts
@@ -277,11 +277,11 @@ describe('MCPServer apps resources', () => {
 
     expect(invalidReadResponse.error).toEqual({
       code: -32602,
-      message: 'resources/read requires string parameter "uri"',
+      message: expect.stringMatching(/^Validation error: resources\/read requires string parameter "uri" \(correlation ID: .*\)$/),
     });
     expect(invalidCompletionResponse.error).toEqual({
       code: -32602,
-      message: 'completion/complete requires a resource ref',
+      message: expect.stringMatching(/^Validation error: completion\/complete requires a resource ref \(correlation ID: .*\)$/),
     });
   });
 

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -2281,12 +2281,14 @@ export class MCPServer {
           code = -32601;
         }
 
+        const correlationId = generateCorrelationId();
+        this.logger.error('prompts/get handler error', error as Error, { correlationId, sessionId });
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }
@@ -2324,12 +2326,14 @@ export class MCPServer {
           result: await this.readResource(params.uri, sessionId, profileId),
         };
       } catch (error) {
+        const correlationId = generateCorrelationId();
+        this.logger.error('resources/read handler error', error as Error, { correlationId, sessionId });
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code: error instanceof ValidationError ? -32602 : -32601,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }
@@ -2343,12 +2347,14 @@ export class MCPServer {
           result: await this.completeResourceArgument(req as CompleteRequest, sessionId, profileId),
         };
       } catch (error) {
+        const correlationId = generateCorrelationId();
+        this.logger.error('completion/complete handler error', error as Error, { correlationId, sessionId });
         return {
           jsonrpc: '2.0',
           id: req.id,
           error: {
             code: error instanceof ValidationError ? -32602 : -32601,
-            message: (error as Error).message,
+            message: this.formatErrorForClient(error, correlationId),
           },
         };
       }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix information leakage in JSON-RPC handlers

🚨 Severity: MEDIUM
💡 Vulnerability: Information Leakage. The `prompts/get`, `resources/read`, and `completion/complete` JSON-RPC handlers directly returned `(error as Error).message` to clients, potentially leaking internal stack traces or sensitive error details.
🎯 Impact: Attackers could gain insights into the server's internal state, filesystem structure, or backend technologies via verbose error messages.
🔧 Fix: Wrapped the error handling logic to generate a secure `correlationId`, log the raw error internally using `this.logger.error`, and format the client response using `this.formatErrorForClient(error, correlationId)`. Updated related string tests to match the new format.
✅ Verification: Ran `npm run test`, and 3190 tests passed, validating both the functionality and the updated test assertions.

---
*PR created automatically by Jules for task [15313534493480958067](https://jules.google.com/task/15313534493480958067) started by @davidruzicka*