### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Input Leakage in Configuration Error Messages

### DIFF
--- a/src/tool-filter/config/env-config-parser.ts
+++ b/src/tool-filter/config/env-config-parser.ts
@@ -100,7 +100,7 @@ export class EnvConfigParser {
       }
 
       throw new ConfigurationError(
-        `MCP4_TOOL_FILTER_ALLOW_CATEGORIES supports only 'list' and 'read', got '${entry}'`
+        `MCP4_TOOL_FILTER_ALLOW_CATEGORIES supports only 'list' and 'read'`
       );
     }
 

--- a/src/tool-filter/config/header-config-parser.ts
+++ b/src/tool-filter/config/header-config-parser.ts
@@ -63,8 +63,8 @@ export class HeaderConfigParser {
     for (const part of parts) {
       if (part.length > MAX_HEADER_ENTRY_LENGTH) {
         throw new ValidationError(
-          `X-Mcp4-Tools entry exceeds ${MAX_HEADER_ENTRY_LENGTH} chars: ` +
-          `'${part}' (${part.length} chars)`
+          `X-Mcp4-Tools entry exceeds ${MAX_HEADER_ENTRY_LENGTH} chars ` +
+          `(${part.length} chars)`
         );
       }
     }


### PR DESCRIPTION
Modifies `env-config-parser.ts` to stop interpolating the raw environment variable value (`entry`) when rejecting an invalid category. Modifies `header-config-parser.ts` to stop echoing the raw header entry (`part`) when it exceeds the maximum length limit. Both changes use a generic error message, mitigating potential information leakage and injection vulnerabilities where sensitive user inputs or configuration values might otherwise be exposed in server error logs or client responses.

---
*PR created automatically by Jules for task [18378798515867092083](https://jules.google.com/task/18378798515867092083) started by @davidruzicka*