### PR TITLE
🛡️ Sentinel: [MEDIUM] Add missing Strict-Transport-Security and X-XSS-Protection headers

### DIFF
--- a/src/transport/http-transport-security.test.ts
+++ b/src/transport/http-transport-security.test.ts
@@ -147,6 +147,8 @@ describe('HttpTransport security behavior (no listen)', () => {
     expect(response.headers['cross-origin-resource-policy']).toBe('same-origin');
     expect(response.headers['x-permitted-cross-domain-policies']).toBe('none');
     expect(response.headers['x-dns-prefetch-control']).toBe('off');
+    expect(response.headers['strict-transport-security']).toBe('max-age=63072000; includeSubDomains');
+    expect(response.headers['x-xss-protection']).toBe('0');
     await transport.stop();
   });
 

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -253,6 +253,8 @@ export class HttpTransport {
       res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
       res.setHeader('X-Permitted-Cross-Domain-Policies', 'none');
       res.setHeader('X-DNS-Prefetch-Control', 'off');
+      res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
+      res.setHeader('X-XSS-Protection', '0');
 
       next();
     });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing `Strict-Transport-Security` header to enforce HTTPS and missing `X-XSS-Protection: 0` to disable legacy browser auditors (which is the current industry best practice recommended by OWASP).
🎯 Impact: Without HSTS, clients may be vulnerable to downgrade attacks. Without `X-XSS-Protection: 0`, older browsers with flawed built-in auditors can sometimes be exploited.
🔧 Fix: Appended both headers to the middleware that sets security headers in `src/transport/http-transport.ts`.
✅ Verification: Ran unit tests `src/transport/http-transport-security.test.ts` to ensure headers are verified correctly, and ran the full suite via `npm run test` to verify no regressions.

---
*PR created automatically by Jules for task [462714723753174629](https://jules.google.com/task/462714723753174629) started by @davidruzicka*