### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix internal error leakage in OAuth callback

### DIFF
--- a/src/auth/oauth-provider.test.ts
+++ b/src/auth/oauth-provider.test.ts
@@ -1985,7 +1985,7 @@ describe('ExternalOAuthProvider', () => {
       await provider.handleCallback(mockReq, mockRes);
 
       expect(mockRes.status).toHaveBeenCalledWith(500);
-      expect(mockRes.send).toHaveBeenCalledWith('Internal Server Error during token exchange');
+      expect(mockRes.send).toHaveBeenCalledWith(expect.stringMatching(/^Internal Server Error \(correlation ID: [a-f0-9-]+\)$/));
     });
   });
 

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -16,6 +16,7 @@
 import { randomUUID, createHash, timingSafeEqual } from 'node:crypto';
 import { isIP } from 'node:net';
 import { Request, Response } from 'express';
+import { generateCorrelationId } from '../core/errors.js';
 import type {
   OAuthServerProvider,
   AuthorizationParams,
@@ -867,8 +868,9 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
         res.redirect(clientUrl.toString());
 
     } catch (err) {
-        this.logger.error('Callback handling failed', err as Error);
-        res.status(500).send('Internal Server Error during token exchange');
+        const correlationId = generateCorrelationId();
+        this.logger.error('Callback handling failed', err instanceof Error ? err : new Error(String(err)), { correlationId });
+        res.status(500).send(`Internal Server Error (correlation ID: ${correlationId})`);
     }
   }
 


### PR DESCRIPTION
This PR resolves a Sentinel finding regarding Internal Error Leakage via API Responses (`CWE-209`).

It ensures that any unexpected error occurring during the OAuth token exchange callback phase is sanitized before reaching the user. We now dynamically generate a unique `correlationId` to link the generic client response with the verbose server-side log, without risking exposure of sensitive system internals.

---
*PR created automatically by Jules for task [18158615342972380218](https://jules.google.com/task/18158615342972380218) started by @davidruzicka*