### PR TITLE
fix(ci): replace company registry URLs in lockfile, pin public registry; fix token-validation tests

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/package-lock.json
+++ b/package-lock.json
@@ -694,7 +694,7 @@
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
-      "resolved": "https://npm.repo.ops.iszn.cz/@hono/node-server/-/node-server-1.19.14.tgz",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
@@ -874,7 +874,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
-      "resolved": "https://npm.repo.ops.iszn.cz/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
@@ -1162,7 +1162,7 @@
     },
     "node_modules/@mswjs/http-middleware/node_modules/path-to-regexp": {
       "version": "0.1.13",
-      "resolved": "https://npm.repo.ops.iszn.cz/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "dev": true,
       "license": "MIT"
@@ -2750,7 +2750,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
-      "resolved": "https://npm.repo.ops.iszn.cz/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
@@ -3704,7 +3704,7 @@
     },
     "node_modules/express-rate-limit": {
       "version": "8.5.0",
-      "resolved": "https://npm.repo.ops.iszn.cz/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
       "integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
       "license": "MIT",
       "dependencies": {
@@ -4134,7 +4134,7 @@
     },
     "node_modules/hono": {
       "version": "4.12.17",
-      "resolved": "https://npm.repo.ops.iszn.cz/hono/-/hono-4.12.17.tgz",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
       "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
       "license": "MIT",
       "engines": {
@@ -4222,7 +4222,7 @@
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
-      "resolved": "https://npm.repo.ops.iszn.cz/ip-address/-/ip-address-10.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
@@ -5088,7 +5088,7 @@
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://npm.repo.ops.iszn.cz/picomatch/-/picomatch-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -5110,7 +5110,7 @@
     },
     "node_modules/postcss": {
       "version": "8.5.14",
-      "resolved": "https://npm.repo.ops.iszn.cz/postcss/-/postcss-8.5.14.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
       "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
@@ -5358,7 +5358,7 @@
     },
     "node_modules/router/node_modules/path-to-regexp": {
       "version": "8.4.2",
-      "resolved": "https://npm.repo.ops.iszn.cz/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
@@ -6327,7 +6327,7 @@
     },
     "node_modules/vite": {
       "version": "6.4.2",
-      "resolved": "https://npm.repo.ops.iszn.cz/vite/-/vite-6.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
@@ -6612,7 +6612,7 @@
     },
     "node_modules/yaml": {
       "version": "2.8.4",
-      "resolved": "https://npm.repo.ops.iszn.cz/yaml/-/yaml-2.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "license": "ISC",
       "bin": {

--- a/src/testing/token-validation.test.ts
+++ b/src/testing/token-validation.test.ts
@@ -259,7 +259,7 @@ describeIfListen('Token Validation Integration', () => {
             clientInfo: { name: 'test', version: '1.0.0' },
           },
         })
-        .expect(401);
+        .expect(200);
 
       // Validation should have been called
       expect(validationCallCount).toBe(1);
@@ -267,8 +267,9 @@ describeIfListen('Token Validation Integration', () => {
 
       // Should not create session
       expect(response.headers['mcp-session-id']).toBeUndefined();
-      expect(response.body.error).toBe('Unauthorized');
-      expect(response.body.message).toContain('Invalid or expired');
+      // JSON-RPC error response (HTTP 200 to avoid triggering OAuth flow in clients)
+      expect(response.body.error).toBeDefined();
+      expect(response.body.error.message).toContain('invalid or expired');
     });
 
     it('should reject expired token', async () => {
@@ -289,10 +290,12 @@ describeIfListen('Token Validation Integration', () => {
             clientInfo: { name: 'test', version: '1.0.0' },
           },
         })
-        .expect(401);
+        .expect(200);
 
       expect(validationCallCount).toBe(1);
-      expect(response.body.error).toBe('Unauthorized');
+      // JSON-RPC error response (HTTP 200 to avoid triggering OAuth flow in clients)
+      expect(response.body.error).toBeDefined();
+      expect(response.body.error.message).toContain('invalid or expired');
     });
   });
 
@@ -355,9 +358,11 @@ describeIfListen('Token Validation Integration', () => {
             clientInfo: { name: 'test', version: '1.0.0' },
           },
         })
-        .expect(401);
+        .expect(200);
 
-      expect(response.body.error).toBe('Unauthorized');
+      // JSON-RPC error response (HTTP 200 to avoid triggering OAuth flow in clients)
+      expect(response.body.error).toBeDefined();
+      expect(response.body.error.message).toContain('invalid or expired');
     });
   });
 


### PR DESCRIPTION
Agent authored:

## Summary

- 12 packages in `package-lock.json` had `resolved` URLs pointing to `npm.repo.ops.iszn.cz` (company-internal registry, unreachable from GitHub Actions runners)
- Root cause: `npm audit fix` run locally with company registry configured globally rewrote lockfile resolved URLs
- Add `.npmrc` with `registry=https://registry.npmjs.org` so future local `npm install`/`npm audit fix` always uses the public registry
- Fix pre-existing test failures in `token-validation.test.ts`: commit `2fa6fd8` intentionally changed invalid-token rejection from HTTP 401 to JSON-RPC HTTP 200 (to avoid triggering OAuth flow in degraded OAuth state), but tests were not updated

## Test plan

- [x] CI `npm ci` passes (no more ENOTFOUND for npm.repo.ops.iszn.cz)
- [x] `token-validation` tests pass (8/8)
- [x] All other tests pass