### PR TITLE
🛡️ Sentinel: [HIGH] Fix Path Traversal via Parameter Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,8 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2024-05-08 - [Path Traversal / URL Injection in encodePathSegment]
+**Vulnerability:** In `mcp-server.ts`, dot characters (`.`) injected into the URL paths were not encoded by `encodeURIComponent`.
+**Learning:** `encodeURIComponent` ignores `.`. In addition, using a ternary check like `val.includes('/') ? encodeURIComponent(val) : val;` completely bypassed the encoding check if the malicious string was exactly `..` (because it does not contain a slash).
+**Prevention:** Always encode all URL path values without conditional string presence checks (e.g. unconditionally calling `encodeURIComponent(val).replace(/\./g, '%2E')` handles both directory traversal payloads and standard pathing safely).

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1205,7 +1205,7 @@ export class MCPServer {
    */
   private encodePathSegment(value: unknown): string {
     const val = String(value);
-    return val.includes('/') ? encodeURIComponent(val) : val;
+    return encodeURIComponent(val).replace(/\./g, '%2E');
   }
 
   /**

--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -67,7 +67,7 @@ describe('CompositeExecutor Security', () => {
     // Fixed behavior: path contains encoded "%2E%2E"
     // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
     // The slashes inside the injected value are encoded, preventing directory traversal
-    const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -171,14 +171,14 @@ export class CompositeExecutor {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
+        return encodeURIComponent(String(args[key])).replace(/\./g, '%2E');
       }
 
       // Try aliases from profile
       const possibleAliases = this.parameterAliases[key] || [];
       for (const alias of possibleAliases) {
         if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+          return encodeURIComponent(String(args[alias])).replace(/\./g, '%2E');
         }
       }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path traversal / URL injection in path parameters. `encodeURIComponent` ignores `.` which allowed `..` sequences to be injected and bypassed logic that only triggered encoding when a `/` was present.
🎯 Impact: Attackers could inject `..` in a path argument, escaping the intended endpoint scope and triggering API calls to unauthorized upstream paths (e.g., escaping from `/users/..` to `/secrets`).
🔧 Fix: Force string replacement of `.` to `%2E` after `encodeURIComponent` unconditionally in `CompositeExecutor` and `mcp-server.ts` path segment encoder.
✅ Verification: Ran unit tests for updated logic (e.g. `src/tooling/composite-executor-security.test.ts`) and full e2e testing suite. Confirmed the fix handles injections without disrupting normal path resolution.

---
*PR created automatically by Jules for task [7079259237175853541](https://jules.google.com/task/7079259237175853541) started by @davidruzicka*