### PR TITLE
Fix Internal Error Leakage in HTTP Transport Layer

### DIFF
--- a/src/transport/http-transport-security.test.ts
+++ b/src/transport/http-transport-security.test.ts
@@ -696,7 +696,7 @@ describe('HttpTransport security behavior (no listen)', () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(500);
-    expect(String(res.body)).toContain('OAuth authorization failed');
+    expect(String(res.body)).toMatch(/^Internal error \(correlation ID: [a-f0-9-]+\)$/);
 
     await transport.stop();
   });
@@ -1387,7 +1387,7 @@ describe('HttpTransport security behavior (no listen)', () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(500);
-    expect(String(res.body)).toContain('OAuth callback failed');
+    expect(String(res.body)).toMatch(/^Internal error \(correlation ID: [a-f0-9-]+\)$/);
 
     await transport.stop();
   });
@@ -1601,7 +1601,8 @@ describe('HttpTransport security behavior (no listen)', () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(500);
-    expect(res.body).toMatchObject({ error: 'server_error', error_description: 'Registration failed' });
+    expect((res.body as any).error).toBe('server_error');
+    expect((res.body as any).error_description).toMatch(/^Internal error \(correlation ID: [a-f0-9-]+\)$/);
 
     await transport.stop();
   });
@@ -1734,7 +1735,8 @@ describe('HttpTransport security behavior (no listen)', () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(500);
-    expect(res.body).toMatchObject({ error: 'server_error', error_description: 'Registration failed' });
+    expect((res.body as any).error).toBe('server_error');
+    expect((res.body as any).error_description).toMatch(/^Internal error \(correlation ID: [a-f0-9-]+\)$/);
 
     await transport.stop();
   });

--- a/src/transport/http-transport.test.ts
+++ b/src/transport/http-transport.test.ts
@@ -2385,7 +2385,7 @@ describeIfListen('HttpTransport', () => {
         .query({ code: 'test-code' });
 
       expect(response.status).toBe(500);
-      expect(response.text).toBe('OAuth callback failed');
+      expect(response.text).toMatch(/^Internal error \(correlation ID: [a-f0-9-]+\)$/);
     });
   });
 

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -1723,10 +1723,12 @@ export class HttpTransport {
     try {
       profiles = await this.profileIndexProvider();
     } catch (error) {
-      this.logger.error('Failed to load profile index', error instanceof Error ? error : new Error(String(error)));
+      const correlationId = generateCorrelationId();
+      this.logger.error('Failed to load profile index', error instanceof Error ? error : new Error(String(error)), { correlationId });
       res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({
         error: 'Internal Server Error',
-        message: 'Failed to load profile index',
+        message: `Internal error (correlation ID: ${correlationId})`,
+        correlationId
       });
       return;
     }
@@ -1921,8 +1923,9 @@ export class HttpTransport {
 
       await profileState.oauthProvider.authorize(client, params, res);
     } catch (error) {
-      this.logger.error('OAuth authorize error', error instanceof Error ? error : new Error(String(error)));
-      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send('OAuth authorization failed');
+      const correlationId = generateCorrelationId();
+      this.logger.error('OAuth authorize error', error instanceof Error ? error : new Error(String(error)), { correlationId });
+      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send(`Internal error (correlation ID: ${correlationId})`);
     }
   }
 
@@ -2195,9 +2198,10 @@ export class HttpTransport {
 
       await profileState.oauthProvider.handleCallback(req, res);
     } catch (error) {
-      this.logger.error('OAuth callback error', error instanceof Error ? error : new Error(String(error)));
+      const correlationId = generateCorrelationId();
+      this.logger.error('OAuth callback error', error instanceof Error ? error : new Error(String(error)), { correlationId });
       if (!res.headersSent) {
-        res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send('OAuth callback failed');
+        res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send(`Internal error (correlation ID: ${correlationId})`);
       }
     }
   }
@@ -2231,8 +2235,9 @@ export class HttpTransport {
       };
       res.json(buildAuthorizationServerMetadata(metadata, profileState.context.enterpriseAuthorization));
     } catch (error) {
-      this.logger.error('OAuth authorization server metadata error', error instanceof Error ? error : new Error(String(error)));
-      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send('OAuth metadata failed');
+      const correlationId = generateCorrelationId();
+      this.logger.error('OAuth authorization server metadata error', error instanceof Error ? error : new Error(String(error)), { correlationId });
+      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send(`Internal error (correlation ID: ${correlationId})`);
     }
   }
 
@@ -2298,8 +2303,9 @@ export class HttpTransport {
         return;
       }
 
-      this.logger.error('Client registration failed', error instanceof Error ? error : new Error(String(error)));
-      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({ error: 'server_error', error_description: 'Registration failed' });
+      const correlationId = generateCorrelationId();
+      this.logger.error('Client registration failed', error instanceof Error ? error : new Error(String(error)), { correlationId });
+      res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({ error: 'server_error', error_description: `Internal error (correlation ID: ${correlationId})`, correlationId });
     }
   }
 
@@ -2808,7 +2814,9 @@ export class HttpTransport {
       // If contains requests, process and return response
       if (messageType === 'request') {
         if (!this.messageHandler) {
-          res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({ error: 'Internal Server Error', message: 'Message handler not configured' });
+          const correlationId = generateCorrelationId();
+          this.logger.error('Message handler not configured', new Error('Message handler not configured'), { correlationId });
+          res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({ error: 'Internal Server Error', message: `Internal error (correlation ID: ${correlationId})`, correlationId });
           return;
         }
 


### PR DESCRIPTION
This commit prevents internal information leakage in `src/transport/http-transport.ts` by ensuring that unhandled or fatal errors generate a generic response alongside a tracked correlation ID, meeting Sentinel's secure error handling criteria.

---
*PR created automatically by Jules for task [11411060694546832511](https://jules.google.com/task/11411060694546832511) started by @davidruzicka*