### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in API path parameters

### DIFF
--- a/src/mcp/mcp-server.test.ts
+++ b/src/mcp/mcp-server.test.ts
@@ -1064,6 +1064,26 @@ paths:
       expect(result).toBe('/projects/group%2Fmcp%252Fapp');
     });
 
+
+    it('throws ValidationError for raw dot segments in path parameters', () => {
+      const localServer = new MCPServer();
+      (localServer as any).profile = {
+        profile_name: 'test',
+        description: 'test profile',
+        tools: [],
+        interceptors: { auth: [] },
+        parameter_aliases: { id: ['project_id'] },
+      };
+
+      expect(() => {
+        (localServer as any).resolvePath('/projects/{id}', { project_id: '.' });
+      }).toThrow('Invalid path parameter value: .');
+
+      expect(() => {
+        (localServer as any).resolvePath('/projects/{id}', { id: '..' });
+      }).toThrow('Invalid path parameter value: ..');
+    });
+
     it('encodes raw slashes in path parameters', () => {
       const localServer = new MCPServer();
       (localServer as any).profile = {

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1205,6 +1205,9 @@ export class MCPServer {
    */
   private encodePathSegment(value: unknown): string {
     const val = String(value);
+    if (val === '.' || val === '..') {
+      throw new ValidationError(`Invalid path parameter value: ${val}`);
+    }
     return val.includes('/') ? encodeURIComponent(val) : val;
   }
 

--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -71,4 +71,12 @@ describe('CompositeExecutor Security', () => {
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });
+
+  it('should throw an error for dot path parameters', async () => {
+    const steps: CompositeStep[] = [
+      { call: 'GET /users/{id}/profile', store_as: 'result' },
+    ];
+    await expect(executor.execute(steps, { id: '.' })).rejects.toThrow('Invalid path parameter value: .');
+    await expect(executor.execute(steps, { id: '..' })).rejects.toThrow('Invalid path parameter value: ..');
+  });
 });

--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -64,9 +64,9 @@ describe('CompositeExecutor Security', () => {
     await executor.execute(steps, { id: maliciousId });
 
     // Vulnerable behavior: path contains raw ".."
-    // Fixed behavior: path contains encoded "%2E%2E"
+    // Fixed behavior: path contains encoded "..%2F" instead of raw "../"
+    // which prevents directory traversal as the slashes are encoded.
     // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
-    // The slashes inside the injected value are encoded, preventing directory traversal
     const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -169,23 +169,34 @@ export class CompositeExecutor {
    */
   private resolvePath(template: string, args: Record<string, unknown>): string {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
+      let value: string | undefined;
+
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
-      }
+        value = String(args[key]);
+      } else {
+        // Try aliases from profile
+        const possibleAliases = this.parameterAliases[key] || [];
+        for (const alias of possibleAliases) {
+          if (args[alias] !== undefined) {
+            value = String(args[alias]);
+            break;
+          }
+        }
 
-      // Try aliases from profile
-      const possibleAliases = this.parameterAliases[key] || [];
-      for (const alias of possibleAliases) {
-        if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+        if (value === undefined) {
+          throw new Error(
+            `Missing path parameter: ${key}` +
+            (possibleAliases.length > 0 ? `. Tried aliases: ${possibleAliases.join(', ')}` : '')
+          );
         }
       }
 
-      throw new Error(
-        `Missing path parameter: ${key}` +
-        (possibleAliases.length > 0 ? `. Tried aliases: ${possibleAliases.join(', ')}` : '')
-      );
+      if (value === '.' || value === '..') {
+        throw new Error(`Invalid path parameter value: ${value}`);
+      }
+
+      return encodeURIComponent(value);
     });
   }
 


### PR DESCRIPTION
Fixes a high-severity path traversal vulnerability via `.` and `..` escaping `encodeURIComponent` encoding.

---
*PR created automatically by Jules for task [10398325748182832109](https://jules.google.com/task/10398325748182832109) started by @davidruzicka*