### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in composite-executor

### DIFF
--- a/src/testing/dynamic-mock-server.ts
+++ b/src/testing/dynamic-mock-server.ts
@@ -14,7 +14,7 @@ export interface CapturedRequest {
 
 export class DynamicMockEngine {
   private parser: OpenAPIParser;
-  private server: SetupServerApi;
+  private server: ReturnType<typeof setupServer>;
   private baseUrl: string;
   private capturedRequests: CapturedRequest[] = [];
 

--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -67,7 +67,7 @@ describe('CompositeExecutor Security', () => {
     // Fixed behavior: path contains encoded "%2E%2E"
     // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
     // The slashes inside the injected value are encoded, preventing directory traversal
-    const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -171,14 +171,14 @@ export class CompositeExecutor {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
+        return encodeURIComponent(String(args[key])).replace(/\./g, '%2E');
       }
 
       // Try aliases from profile
       const possibleAliases = this.parameterAliases[key] || [];
       for (const alias of possibleAliases) {
         if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+          return encodeURIComponent(String(args[alias])).replace(/\./g, '%2E');
         }
       }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When substituting URL path parameters, `encodeURIComponent` was used. However, `encodeURIComponent` does not encode dot (`.`) characters. This means an attacker passing an argument like `../admin/secrets` could bypass parameter validation and perform directory traversal since the request ultimately becomes `..%2Fadmin%2Fsecrets` instead of being strictly confined to the parameter URL space.
🎯 Impact: This allows bypassing URL resolution confines and can lead to path traversal in HTTP clients.
🔧 Fix: I modified `resolvePath` in `src/tooling/composite-executor.ts` to execute `.replace(/\./g, '%2E')` on top of `encodeURIComponent`, forcing dot characters to be appropriately sanitized. Additionally, fixed a type mismatch in `dynamic-mock-server.ts` to allow typechecking to pass. 
✅ Verification: Ran test suites successfully. Tests confirm that dots are appropriately `%2E` encoded.

---
*PR created automatically by Jules for task [11035553148992209503](https://jules.google.com/task/11035553148992209503) started by @davidruzicka*