### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal via URL interpolation

### DIFF
--- a/src/mcp/mcp-server-security.test.ts
+++ b/src/mcp/mcp-server-security.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { MCPServer } from './mcp-server.js';
+import { OpenAPIParser } from '../openapi/openapi-parser.js';
+
+describe('MCPServer Security', () => {
+  it('vulnerability: path traversal via parameter injection', async () => {
+    // We test MCPServer's encodePathSegment method directly since it's private but we can access it via typing override
+    const server = new MCPServer(
+      {} as any,
+      {} as any,
+      undefined,
+      undefined,
+      undefined
+    );
+
+    const encodePathSegment = (server as any).encodePathSegment.bind(server);
+
+    // It should replace dots with %2E to prevent path traversal
+    expect(encodePathSegment('..')).toBe('%2E%2E');
+    expect(encodePathSegment('.')).toBe('%2E');
+    expect(encodePathSegment('../admin')).toBe('%2E%2E%2Fadmin');
+
+    // Regular characters should remain encoded properly
+    expect(encodePathSegment('regular/path')).toBe('regular%2Fpath');
+    expect(encodePathSegment('hello')).toBe('hello');
+  });
+});

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1205,7 +1205,7 @@ export class MCPServer {
    */
   private encodePathSegment(value: unknown): string {
     const val = String(value);
-    return val.includes('/') ? encodeURIComponent(val) : val;
+    return encodeURIComponent(val).replace(/\./g, '%2E');
   }
 
   /**

--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -67,7 +67,7 @@ describe('CompositeExecutor Security', () => {
     // Fixed behavior: path contains encoded "%2E%2E"
     // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
     // The slashes inside the injected value are encoded, preventing directory traversal
-    const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -171,14 +171,14 @@ export class CompositeExecutor {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
+        return encodeURIComponent(String(args[key])).replace(/\./g, '%2E');
       }
 
       // Try aliases from profile
       const possibleAliases = this.parameterAliases[key] || [];
       for (const alias of possibleAliases) {
         if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+          return encodeURIComponent(String(args[alias])).replace(/\./g, '%2E');
         }
       }
 


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Path traversal via parameter injection
🎯 **Impact**: Path traversal could allow a malicious user to manipulate the URL structure by injecting dot segments (`.`, `..`), potentially allowing them to bypass API paths and access unintended endpoints.
🔧 **Fix**: Updated `encodePathSegment` in `MCPServer` and `resolvePath` in `CompositeExecutor` to replace all `.` characters with `%2E` after invoking `encodeURIComponent()`.
✅ **Verification**: Run `npm run test:unit src/mcp/mcp-server-security.test.ts` and `npm run test:unit src/tooling/composite-executor-security.test.ts` to verify.

---
*PR created automatically by Jules for task [3688443411798855406](https://jules.google.com/task/3688443411798855406) started by @davidruzicka*