### PR TITLE
🛡️ Sentinel: [MEDIUM] Add correlation ID to OAuth 500 error response

### DIFF
--- a/src/auth/oauth-provider.test.ts
+++ b/src/auth/oauth-provider.test.ts
@@ -1986,7 +1986,7 @@ describe('ExternalOAuthProvider', () => {
       await provider.handleCallback(mockReq, mockRes);
 
       expect(mockRes.status).toHaveBeenCalledWith(500);
-      expect(mockRes.send).toHaveBeenCalledWith('Internal Server Error during token exchange');
+      expect(mockRes.send).toHaveBeenCalledWith(expect.stringMatching(/^Internal Server Error during token exchange \(correlation ID: [a-f0-9-]+\)$/));
     });
   });
 

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -36,6 +36,7 @@ import {
   PROXY_CREDENTIALS,
 } from '../core/constants.js';
 import { escapeHtmlSafe } from '../validation/validation-utils.js';
+import { generateCorrelationId } from '../core/errors.js';
 import { SSRFValidator } from '../security/ssrf-validator.js';
 import { parseOAuthMetadataEndpoints } from './oauth-metadata.js';
 import { InMemoryClientsStore } from './client-store/in-memory-clients-store.js';
@@ -925,8 +926,9 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
         res.redirect(clientUrl.toString());
 
     } catch (err) {
-        this.logger.error('Callback handling failed', err as Error);
-        res.status(500).send('Internal Server Error during token exchange');
+        const correlationId = generateCorrelationId();
+        this.logger.error('Callback handling failed', err as Error, { correlationId });
+        res.status(500).send(`Internal Server Error during token exchange (correlation ID: ${correlationId})`);
     }
   }
 


### PR DESCRIPTION
This PR addresses a missing correlation ID in the 500 Internal Server Error response within `ExternalOAuthProvider`. According to `.jules/sentinel.md`, all 500 responses exposed to clients must use a generic error message alongside a unique correlation ID to securely link client errors with detailed server-side logs.

- Modifies `handleCallback` in `src/auth/oauth-provider.ts` to generate and log a correlation ID.
- Appends the correlation ID to the safe, generic response string.
- Updates the corresponding test in `src/auth/oauth-provider.test.ts` to expect this new format.

---
*PR created automatically by Jules for task [2805209231524317903](https://jules.google.com/task/2805209231524317903) started by @davidruzicka*