### PR TITLE
🛡️ Sentinel: [SECURITY ENHANCEMENT] Add security headers

### DIFF
--- a/src/transport/http-transport-security.test.ts
+++ b/src/transport/http-transport-security.test.ts
@@ -147,6 +147,8 @@ describe('HttpTransport security behavior (no listen)', () => {
     expect(response.headers['cross-origin-resource-policy']).toBe('same-origin');
     expect(response.headers['x-permitted-cross-domain-policies']).toBe('none');
     expect(response.headers['x-dns-prefetch-control']).toBe('off');
+    expect(response.headers['strict-transport-security']).toBe('max-age=63072000; includeSubDomains');
+    expect(response.headers['x-xss-protection']).toBe('0');
     await transport.stop();
   });
 

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -285,6 +285,8 @@ export class HttpTransport {
       res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
       res.setHeader('X-Permitted-Cross-Domain-Policies', 'none');
       res.setHeader('X-DNS-Prefetch-Control', 'off');
+      res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
+      res.setHeader('X-XSS-Protection', '0');
 
       next();
     });


### PR DESCRIPTION
🛡️ Sentinel: [SECURITY ENHANCEMENT] Add security headers

🚨 Severity: LOW
💡 Vulnerability: Missing `Strict-Transport-Security` and `X-XSS-Protection` security headers on HTTP responses.
🎯 Impact: Helps prevent downgrade attacks by enforcing HTTPS (HSTS) and explicitly disables legacy XSS auditors which can introduce cross-site scripting vulnerabilities.
🔧 Fix: Added `Strict-Transport-Security` and `X-XSS-Protection` headers to global middleware in `http-transport.ts`. Also updated `http-transport-security.test.ts` to assert they are present.
✅ Verification: Ran `npm run test` and `npx vitest run src/transport/http-transport-security.test.ts` successfully.

---
*PR created automatically by Jules for task [11172213805879646190](https://jules.google.com/task/11172213805879646190) started by @davidruzicka*