### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix internal error leakage in OAuth callback

### DIFF
--- a/src/auth/oauth-provider.test.ts
+++ b/src/auth/oauth-provider.test.ts
@@ -1986,7 +1986,9 @@ describe('ExternalOAuthProvider', () => {
       await provider.handleCallback(mockReq, mockRes);
 
       expect(mockRes.status).toHaveBeenCalledWith(500);
-      expect(mockRes.send).toHaveBeenCalledWith('Internal Server Error during token exchange');
+      expect(mockRes.send).toHaveBeenCalledWith(
+        expect.stringMatching(/^Internal Server Error \(correlation ID: [a-f0-9-]+\)$/)
+      );
     });
   });
 

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -35,6 +35,7 @@ import {
   OAUTH_PATHS,
   PROXY_CREDENTIALS,
 } from '../core/constants.js';
+import { generateCorrelationId } from '../core/errors.js';
 import { escapeHtmlSafe } from '../validation/validation-utils.js';
 import { SSRFValidator } from '../security/ssrf-validator.js';
 import { parseOAuthMetadataEndpoints } from './oauth-metadata.js';
@@ -925,8 +926,9 @@ export class ExternalOAuthProvider implements OAuthServerProvider {
         res.redirect(clientUrl.toString());
 
     } catch (err) {
-        this.logger.error('Callback handling failed', err as Error);
-        res.status(500).send('Internal Server Error during token exchange');
+        const correlationId = generateCorrelationId();
+        this.logger.error('Callback handling failed', err as Error, { correlationId });
+        res.status(500).send(`Internal Server Error (correlation ID: ${correlationId})`);
     }
   }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The HTTP response for unhandled errors during the OAuth token exchange callback hardcoded the context string `'during token exchange'`, which constitutes an information leak. It failed to implement the standard Sentinel generic error format and lacked a tracking correlation ID.
🎯 Impact: Attackers or malicious clients could infer internal system state or specific failure phases during authentication, while administrators lacked an explicit correlation ID to map the client error directly to backend error logs.
🔧 Fix: Updated `handleCallback` in `src/auth/oauth-provider.ts` to log errors internally with a unique Correlation ID, and to return a standard, generic `500 Internal Server Error (correlation ID: <id>)` string to the client.
✅ Verification: Ran the full unit test suite `npm run test` cleanly. Updated `src/auth/oauth-provider.test.ts` to explicitly assert the dynamic ID matches a safe regex.

---
*PR created automatically by Jules for task [14037355973866543601](https://jules.google.com/task/14037355973866543601) started by @davidruzicka*