### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in CompositeExecutor

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,14 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2026-06-08 - [HIGH] Path Traversal in CompositeExecutor due to unencoded dots
+
+**Vulnerability:**
+The `CompositeExecutor` substitutes user-provided arguments directly into API path templates using `encodeURIComponent`. However, `encodeURIComponent` does not encode `.` characters. This allowed a malicious input like `../admin/secrets` to be encoded as `..%2Fadmin%2Fsecrets`. If a backend server decodes the URL before resolving path segments, it could be vulnerable to path traversal.
+
+**Learning:**
+`encodeURIComponent` is insufficient for completely preventing path traversal in all backend configurations because it leaves `.` unencoded.
+
+**Prevention:**
+1.  Always use `encodeURIComponent(value).replace(/\./g, '%2E')` when substituting values into path templates to ensure that `.` characters are explicitly encoded.

--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -65,9 +65,9 @@ describe('CompositeExecutor Security', () => {
 
     // Vulnerable behavior: path contains raw ".."
     // Fixed behavior: path contains encoded "%2E%2E"
-    // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
-    // The slashes inside the injected value are encoded, preventing directory traversal
-    const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
+    // Note: encodeURIComponent('../admin/secrets').replace(/\./g, '%2E') => %2E%2E%2Fadmin%2Fsecrets
+    // The slashes and dots inside the injected value are encoded, preventing directory traversal
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -171,14 +171,14 @@ export class CompositeExecutor {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
+        return encodeURIComponent(String(args[key])).replace(/\./g, '%2E');
       }
 
       // Try aliases from profile
       const possibleAliases = this.parameterAliases[key] || [];
       for (const alias of possibleAliases) {
         if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+          return encodeURIComponent(String(args[alias])).replace(/\./g, '%2E');
         }
       }
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix path traversal in CompositeExecutor

🚨 **Severity:** HIGH
💡 **Vulnerability:** Path Traversal via Parameter Injection in Composite Executor. User inputs containing `../` intended for API paths were being processed by `encodeURIComponent`, which ignores the `.` character (by design per RFC 3986). This allows the literal strings `../` to be sent to external/internal APIs, potentially breaking out of the intended URL paths.
🎯 **Impact:** If the receiving API server performs URL decoding prior to processing paths, the injected `../` could allow access to unauthorized endpoints.
🔧 **Fix:** Replaced native `encodeURIComponent(value)` interpolation with `encodeURIComponent(value).replace(/\./g, '%2E')` to explicitly encode dots.
✅ **Verification:** Updated the `composite-executor-security.test.ts` to assert that slashes *and* dots are properly encoded in path substitutions. Passed `npm run test`.

---
*PR created automatically by Jules for task [10849570461207230908](https://jules.google.com/task/10849570461207230908) started by @davidruzicka*