### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in URL interpolation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,15 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2026-06-09 - [HIGH] Path Traversal in URL Path Interpolation
+
+**Vulnerability:**
+Both `CompositeExecutor` (when substituting tool step arguments) and `MCPServer` (when encoding path segments) were vulnerable to path traversal. They failed to encode literal dot characters (`.`), allowing a payload like `..` to be passed verbatim into HTTP paths and traverse directory structures (e.g., `/users/../admin` -> `/admin`).
+
+**Learning:**
+`encodeURIComponent` explicitly does not encode certain characters according to RFC 2396, including the period (`.`). Relying solely on `encodeURIComponent` for path segment substitution leaves the application vulnerable to standard directory traversal attacks.
+
+**Prevention:**
+1. Always append `.replace(/\./g, '%2E')` after `encodeURIComponent()` when substituting user inputs into URL path segments.
+2. In custom path encoding logic, ensure encoding is always applied, regardless of the presence of slashes or other specific characters.

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1205,7 +1205,8 @@ export class MCPServer {
    */
   private encodePathSegment(value: unknown): string {
     const val = String(value);
-    return val.includes('/') ? encodeURIComponent(val) : val;
+    // Always encode and replace dots to prevent path traversal (e.g. `..`)
+    return encodeURIComponent(val).replace(/\./g, '%2E');
   }
 
   /**

--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -67,7 +67,7 @@ describe('CompositeExecutor Security', () => {
     // Fixed behavior: path contains encoded "%2E%2E"
     // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
     // The slashes inside the injected value are encoded, preventing directory traversal
-    const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -171,14 +171,14 @@ export class CompositeExecutor {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
+        return encodeURIComponent(String(args[key])).replace(/\./g, '%2E');
       }
 
       // Try aliases from profile
       const possibleAliases = this.parameterAliases[key] || [];
       for (const alias of possibleAliases) {
         if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+          return encodeURIComponent(String(args[alias])).replace(/\./g, '%2E');
         }
       }
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was vulnerable to path traversal due to the failure to URL-encode literal dot (`.`) characters during URL path interpolation. `encodeURIComponent` explicitly ignores the period character, meaning inputs like `..` were passed verbatim into HTTP path segments.
🎯 **Impact:** An attacker could craft a payload with `..` to traverse directory structures in API endpoints (e.g., transforming `/users/../admin` into `/admin`), potentially gaining unauthorized access to arbitrary endpoints or data.
🔧 **Fix:** Updated `resolvePath` in `CompositeExecutor` and `encodePathSegment` in `MCPServer` to ensure that dot characters are percent-encoded by chaining `.replace(/\./g, '%2E')` after `encodeURIComponent()`. Also removed an incorrect condition that skipped encoding if the string lacked a slash.
✅ **Verification:** Updated the `composite-executor-security.test.ts` to assert that `%2E%2E` is produced instead of `..`. Ran the full test suite via `npm run test` to verify all tests pass without regressions.

---
*PR created automatically by Jules for task [15214156873579455956](https://jules.google.com/task/15214156873579455956) started by @davidruzicka*