### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent info leakage in validation and configuration error messages

### DIFF
--- a/src/automation/artifact-signing-config.ts
+++ b/src/automation/artifact-signing-config.ts
@@ -53,5 +53,5 @@ function parseExplicitBoolean(value: string | undefined, envName: string): boole
     return false;
   }
 
-  throw new ConfigurationError(`${envName} must be either 'true' or 'false', got '${normalized}'.`);
+  throw new ConfigurationError(`${envName} must be either 'true' or 'false'.`);
 }

--- a/src/core/filtering.ts
+++ b/src/core/filtering.ts
@@ -275,13 +275,13 @@ function validateParameterValue(
     for (const item of argValue) {
       if (!isPrimitiveValue(item)) {
         throw new AuthorizationError(
-          `Filter conflict for '${canonical}': expected one of [${allowedValues.join(', ')}], got '${formatValue(item)}'.`
+          `Filter conflict for '${canonical}': expected one of [${allowedValues.join(', ')}].`
         );
       }
       const stringValue = String(item);
       if (!allowedSet.has(stringValue)) {
         throw new AuthorizationError(
-          `Filter conflict for '${canonical}': expected one of [${allowedValues.join(', ')}], got '${stringValue}'.`
+          `Filter conflict for '${canonical}': expected one of [${allowedValues.join(', ')}].`
         );
       }
     }
@@ -290,14 +290,14 @@ function validateParameterValue(
   
   if (typeof argValue === 'object' && argValue !== null) {
     throw new AuthorizationError(
-      `Filter conflict for '${canonical}': expected one of [${allowedValues.join(', ')}], got '${formatValue(argValue)}'.`
+      `Filter conflict for '${canonical}': expected one of [${allowedValues.join(', ')}].`
     );
   }
   
   const stringValue = String(argValue);
   if (!allowedSet.has(stringValue)) {
     throw new AuthorizationError(
-      `Filter conflict for '${canonical}': expected one of [${allowedValues.join(', ')}], got '${stringValue}'.`
+      `Filter conflict for '${canonical}': expected one of [${allowedValues.join(', ')}].`
     );
   }
 }
@@ -441,7 +441,7 @@ function validateFilterKeys(
   }
   const allowedList = Array.from(allowedKeys).sort().join(', ');
   throw new ValidationError(
-    `Unknown filter key '${unknownKeys[0]}'. Allowed keys: ${allowedList}`
+    `Unknown filter key present. Allowed keys: ${allowedList}`
   );
 }
 
@@ -497,18 +497,3 @@ function isPrimitiveValue(value: unknown): value is string | number | boolean {
   return ['string', 'number', 'boolean'].includes(typeof value);
 }
 
-function formatValue(value: unknown): string {
-  if (value === undefined) {
-    return 'undefined';
-  }
-  if (value === null) {
-    return 'null';
-  }
-  if (Array.isArray(value)) {
-    return 'array';
-  }
-  if (typeof value === 'object') {
-    return 'object';
-  }
-  return String(value);
-}

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -2822,9 +2822,8 @@ export class MCPServer {
     }
 
     if (originalCount > 0 && allowedCount === 0) {
-      const sources = request.rawEntries.length > 0 ? request.rawEntries.join(', ') : 'none';
       throw new ValidationError(
-        `X-Mcp4-Tools filtered out all tools (original: ${originalCount}). Removed by: ${sources}. Check session filter configuration.`
+        `X-Mcp4-Tools filtered out all tools (original: ${originalCount}). Check session filter configuration.`
       );
     }
 

--- a/src/tool-filter/config/env-config-parser.ts
+++ b/src/tool-filter/config/env-config-parser.ts
@@ -100,7 +100,7 @@ export class EnvConfigParser {
       }
 
       throw new ConfigurationError(
-        `MCP4_TOOL_FILTER_ALLOW_CATEGORIES supports only 'list' and 'read', got '${entry}'`
+        `MCP4_TOOL_FILTER_ALLOW_CATEGORIES supports only 'list' and 'read'.`
       );
     }
 

--- a/src/tool-filter/config/header-config-parser.ts
+++ b/src/tool-filter/config/header-config-parser.ts
@@ -63,8 +63,7 @@ export class HeaderConfigParser {
     for (const part of parts) {
       if (part.length > MAX_HEADER_ENTRY_LENGTH) {
         throw new ValidationError(
-          `X-Mcp4-Tools entry exceeds ${MAX_HEADER_ENTRY_LENGTH} chars: ` +
-          `'${part}' (${part.length} chars)`
+          `X-Mcp4-Tools entry exceeds ${MAX_HEADER_ENTRY_LENGTH} chars.`
         );
       }
     }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Several configuration parsers and validators were echoing raw user input, headers, or environment variable values directly into error messages (`ValidationError`, `ConfigurationError`, `AuthorizationError`). If an error message gets logged or bubbled up, this could lead to information leakage (e.g., if an environment variable holds a secret, or an input holds sensitive data) and potential log injection.
🎯 Impact: An attacker or a misconfiguration could cause the application to log or return sensitive values or inject malicious payload into logs by passing specifically crafted values to inputs that subsequently fail validation.
🔧 Fix: Updated the error messages across `env-config-parser`, `header-config-parser`, `artifact-signing-config`, `filtering.ts`, and `mcp-server.ts` to use generic, static messages that describe the issue without echoing the raw rejected values.
✅ Verification: Ran `npm run test` and `npm run lint` successfully, verifying that tests still pass with the sanitized error messages.

---
*PR created automatically by Jules for task [16917026771774080082](https://jules.google.com/task/16917026771774080082) started by @davidruzicka*