### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF in EnterpriseAuthProvider

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,15 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2026-06-19 - [HIGH] SSRF in Enterprise Auth Provider
+
+**Vulnerability:**
+The `EnterpriseAuthProvider` fetched OIDC discovery metadata (`/.well-known/openid-configuration`) using user-provided `issuer` configuration without validating the target URL. If an attacker created a malicious profile pointing the issuer to an internal network address (e.g., `http://169.254.169.254`), the server would send a request to that address, leading to a Server-Side Request Forgery (SSRF) vulnerability.
+
+**Learning:**
+Even built-in discovery mechanisms like OIDC metadata resolution are vulnerable to SSRF if the base URL originates from untrusted or user-configurable sources (like a profile definition).
+
+**Prevention:**
+1. Passed the `SSRFValidator` from `HttpTransport` into the `EnterpriseAuthProvider` constructor.
+2. Validated the `discoveryUrl` with the `SSRFValidator` prior to initiating the `fetch` request, allowing private networks only if explicitly permitted by the `MCP4_SSRF_ALLOW_PRIVATE_NETWORK` environment variable.

--- a/src/auth/enterprise-auth-provider.test.ts
+++ b/src/auth/enterprise-auth-provider.test.ts
@@ -36,6 +36,7 @@ describe('enterprise-auth-provider', () => {
       jwksCache: new JwksCache({ maxCachedIssuers: 4, maxCachedKeys: 8, refreshTimeoutMs: 5000, refreshBackoffMs: 0 }, logger),
       replayStore: new EnterpriseReplayStore({ maxEntries: 10 }),
       logger,
+      ssrfValidator: new (class SSRFValidator { validate = vi.fn().mockResolvedValue(undefined); })() as any,
     });
   }
 
@@ -89,6 +90,7 @@ describe('enterprise-auth-provider', () => {
       jwksCache: new JwksCache({ maxCachedIssuers: 4, maxCachedKeys: 8, refreshTimeoutMs: 5000, refreshBackoffMs: 0 }, logger),
       replayStore: new EnterpriseReplayStore({ maxEntries: 10 }),
       logger,
+      ssrfValidator: new (class SSRFValidator { validate = vi.fn().mockResolvedValue(undefined); })() as any,
     });
 
     const principal = await provider.validateAssertion(assertion, 'client-1');
@@ -121,6 +123,7 @@ describe('enterprise-auth-provider', () => {
       jwksCache: new JwksCache({ maxCachedIssuers: 4, maxCachedKeys: 8, refreshTimeoutMs: 5000, refreshBackoffMs: 0 }, logger),
       replayStore: new EnterpriseReplayStore({ maxEntries: 10 }),
       logger,
+      ssrfValidator: new (class SSRFValidator { validate = vi.fn().mockResolvedValue(undefined); })() as any,
     });
 
     await provider.validateAssertion(assertion, 'client-1');
@@ -154,6 +157,7 @@ describe('enterprise-auth-provider', () => {
       jwksCache: new JwksCache({ maxCachedIssuers: 4, maxCachedKeys: 8, refreshTimeoutMs: 5000, refreshBackoffMs: 0 }, logger),
       replayStore: new EnterpriseReplayStore({ maxEntries: 10 }),
       logger,
+      ssrfValidator: new (class SSRFValidator { validate = vi.fn().mockResolvedValue(undefined); })() as any,
     });
 
     const principal = await provider.validateAssertion(assertion, 'client-1');
@@ -311,6 +315,7 @@ describe('enterprise-auth-provider', () => {
       jwksCache: { getResolver: vi.fn(async () => async () => { throw new Error('boom'); }) } as unknown as JwksCache,
       replayStore: new EnterpriseReplayStore({ maxEntries: 10 }),
       logger,
+      ssrfValidator: new (class SSRFValidator { validate = vi.fn().mockResolvedValue(undefined); })() as any,
     });
 
     await expect(provider.validateAssertion(assertion, 'client-1')).rejects.toThrow('Enterprise assertion validation failed');

--- a/src/auth/enterprise-auth-provider.ts
+++ b/src/auth/enterprise-auth-provider.ts
@@ -4,6 +4,7 @@ import type { EnterpriseAuthorizationConfig } from '../types/profile.js';
 import { EnterpriseReplayStore } from './enterprise-replay-store.js';
 import { JwksCache } from './jwks-cache.js';
 import { buildEnterprisePrincipal } from './enterprise-policy.js';
+import { SSRFValidator } from '../security/ssrf-validator.js';
 import {
   EnterpriseIssuerDiscoveryError,
   EnterprisePolicyViolationError,
@@ -18,6 +19,7 @@ export interface EnterpriseAuthProviderOptions {
   jwksCache: JwksCache;
   replayStore: EnterpriseReplayStore;
   logger: Logger;
+  ssrfValidator: SSRFValidator;
 }
 
 export class EnterpriseAuthProvider {
@@ -26,6 +28,7 @@ export class EnterpriseAuthProvider {
   private readonly jwksCache: JwksCache;
   private readonly replayStore: EnterpriseReplayStore;
   private readonly logger: Logger;
+  private readonly ssrfValidator: SSRFValidator;
 
   constructor(options: EnterpriseAuthProviderOptions) {
     this.profileId = options.profileId;
@@ -33,6 +36,7 @@ export class EnterpriseAuthProvider {
     this.jwksCache = options.jwksCache;
     this.replayStore = options.replayStore;
     this.logger = options.logger;
+    this.ssrfValidator = options.ssrfValidator;
   }
 
   async validateAssertion(assertion: string, clientId?: string): Promise<AuthorizedPrincipal> {
@@ -102,6 +106,9 @@ export class EnterpriseAuthProvider {
     }
 
     const discoveryUrl = new URL('/.well-known/openid-configuration', this.config.issuer.issuer).toString();
+    await this.ssrfValidator.validate(discoveryUrl, {
+      allowPrivateNetwork: process.env.MCP4_SSRF_ALLOW_PRIVATE_NETWORK === 'true',
+    });
     const response = await fetch(discoveryUrl, {
       headers: { accept: 'application/json' },
       signal: AbortSignal.timeout(5000),

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -557,6 +557,7 @@ export class HttpTransport {
           jwksCache: this.enterpriseJwksCache,
           replayStore: this.enterpriseReplayStore,
           logger: this.logger,
+          ssrfValidator: this.ssrfValidator,
         })
       : null;
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `EnterpriseAuthProvider` fetched OIDC discovery metadata (`/.well-known/openid-configuration`) directly using user-provided `issuer` configuration without validating the target URL.
🎯 Impact: This allowed Server-Side Request Forgery (SSRF). An attacker could configure a malicious profile pointing the issuer to an internal network address (e.g., `http://169.254.169.254`), and the server would send a request to that address.
🔧 Fix:
- Added `SSRFValidator` to `EnterpriseAuthProviderOptions` and injected it into `EnterpriseAuthProvider`.
- Invoked `await this.ssrfValidator.validate(...)` on the `discoveryUrl` before fetching it in `resolveJwksUri()`.
- Updated `HttpTransport` to pass the `SSRFValidator` to `EnterpriseAuthProvider`.
- Updated unit tests with a mock `SSRFValidator`.
✅ Verification: Ran `npm run test` and `npm run test:unit src/auth/enterprise-auth-provider.test.ts`. All pass. Evaluated the fix in code review.

---
*PR created automatically by Jules for task [3011232071066293987](https://jules.google.com/task/3011232071066293987) started by @davidruzicka*