### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in composite executor and mcp server

### DIFF
--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1205,7 +1205,7 @@ export class MCPServer {
    */
   private encodePathSegment(value: unknown): string {
     const val = String(value);
-    return val.includes('/') ? encodeURIComponent(val) : val;
+    return encodeURIComponent(val).replace(/\./g, '%2E');
   }
 
   /**

--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -67,7 +67,7 @@ describe('CompositeExecutor Security', () => {
     // Fixed behavior: path contains encoded "%2E%2E"
     // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
     // The slashes inside the injected value are encoded, preventing directory traversal
-    const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -171,14 +171,14 @@ export class CompositeExecutor {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
+        return encodeURIComponent(String(args[key])).replace(/\./g, '%2E');
       }
 
       // Try aliases from profile
       const possibleAliases = this.parameterAliases[key] || [];
       for (const alias of possibleAliases) {
         if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+          return encodeURIComponent(String(args[alias])).replace(/\./g, '%2E');
         }
       }
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in composite executor and mcp server

🚨 Severity: CRITICAL
💡 Vulnerability: User input injected into URL path parameters using the composite executor or mcp server bypassed proper encoding, specifically failing to encode literal dot characters ("."). This allowed malicious payloads like ".." to perform directory path traversals.
🎯 Impact: Attackers could inject ".." into interpolated API paths (e.g., `GET /projects/{id}`) to bypass intended path endpoints, potentially accessing sensitive external APIs or resources.
🔧 Fix: Updated `encodePathSegment` in `src/mcp/mcp-server.ts` and `resolvePath` in `src/tooling/composite-executor.ts` to unconditionally `encodeURIComponent` user input and explicitly substitute all "." characters with `%2E` to prevent directory traversal sequence interpretation.
✅ Verification: Ran unit tests, updated `src/tooling/composite-executor-security.test.ts` to verify %2E transformation, which passed successfully.

---
*PR created automatically by Jules for task [17036135222361011174](https://jules.google.com/task/17036135222361011174) started by @davidruzicka*