### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix memory leak in Promise.race with setTimeout

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,4 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+## 2026-06-24 - [Security] Prevent memory leak in Promise.race with setTimeout **Vulnerability:** Un-cleared setTimeout handlers within Promise.race calls accumulate in the Node.js event loop if the other promise resolves first, leading to a memory leak and potential Denial of Service (DoS). **Learning:** Even though Node.js handles late rejections gracefully, active timeouts keep the process alive and consume memory until they naturally expire. **Prevention:** Always assign the timeout to a variable and explicitly clear it using clearTimeout within a finally block when the Promise.race completes.

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -2603,12 +2603,18 @@ export class MCPServer {
     const task = strategy.source === 'operation'
       ? this.executeAppsOperation(strategy.operation!, args, sessionId, profileId)
       : this.executeAppsComposite(strategy.compositeTool!, args, sessionId, profileId);
-    return await Promise.race([
-      task,
-      new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new ValidationError('Apps fetch timed out')), strategy.timeoutMs);
-      }),
-    ]);
+
+    let timeoutId: NodeJS.Timeout;
+    try {
+      return await Promise.race([
+        task,
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => reject(new ValidationError('Apps fetch timed out')), strategy.timeoutMs);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timeoutId!);
+    }
   }
 
   private async executeAppsOperation(

--- a/src/security/ssrf-validator.ts
+++ b/src/security/ssrf-validator.ts
@@ -105,11 +105,12 @@ export class SSRFValidator {
     const timeoutMs = 2000; // Increased to 2s to be safe
 
     let results: Array<{ address: string }> = [];
+    let timeoutId: NodeJS.Timeout;
     try {
       results = (await Promise.race([
         lookup(hostname, { all: true, verbatim: true }) as Promise<Array<{ address: string }>>,
         new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error(`DNS lookup timeout after ${timeoutMs}ms`)), timeoutMs)
+          timeoutId = setTimeout(() => reject(new Error(`DNS lookup timeout after ${timeoutMs}ms`)), timeoutMs)
         ),
       ])) as Array<{ address: string }>;
     } catch (error) {
@@ -119,6 +120,8 @@ export class SSRFValidator {
       });
       // Fail secure: if we can't resolve it, we can't verify it's safe.
       throw new ValidationError(`DNS lookup failed for hostname '${hostname}'`);
+    } finally {
+      clearTimeout(timeoutId!);
     }
 
     const addresses = results.map(r => r.address).filter(Boolean);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Memory leak and potential Denial of Service (DoS) caused by un-cleared `setTimeout` handlers in `Promise.race`.
🎯 Impact: High-throughput applications could accumulate active timeouts in the Node.js event loop, leading to memory exhaustion and delayed garbage collection.
🔧 Fix: Saved the timeout ID and added a `finally` block to explicitly clear the timeout using `clearTimeout` when the `Promise.race` completes.
✅ Verification: Ran `npm run test` to verify no regressions were introduced. The fixes ensure proper resource cleanup in both `src/mcp/mcp-server.ts` and `src/security/ssrf-validator.ts`.

---
*PR created automatically by Jules for task [221061450081792942](https://jules.google.com/task/221061450081792942) started by @davidruzicka*