### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unbounded Profile Hint Cache (DoS)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,16 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2026-06-29 - [HIGH] Unbounded Profile Hint Cache (DoS)
+
+**Vulnerability:**
+The `HttpTransport` stored profile hints in an in-memory Map (`profileHintsByClient`) keyed by client IP and User-Agent. This map only evicted entries when they were accessed after expiration, allowing an attacker to cause memory exhaustion (Denial of Service) by continually sending requests with varying IP addresses (e.g., spoofing X-Forwarded-For if not strict) or User-Agents, filling up memory indefinitely.
+
+**Learning:**
+In-memory caches driven by unauthenticated or loosely authenticated client inputs (like IP or User-Agent) must always have a hard upper bound (size limit) in addition to TTL-based expiration. Without a hard limit, a determined attacker can bypass TTLs by creating new entries faster than they expire.
+
+**Prevention:**
+1. Implemented a `MAX_PROFILE_HINTS` constant to bound the cache size.
+2. Modified `storeProfileHint` to evict the oldest entry (FIFO) when the cache is full before adding a new one.
+3. Added proactive cleanup of expired profile hints to the existing `cleanupExpiredSessions` interval.

--- a/src/transport/http-transport-dos.test.ts
+++ b/src/transport/http-transport-dos.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { HttpTransport } from './http-transport.js';
+import { ConsoleLogger } from '../core/logger.js';
+
+
+describe('HttpTransport - DoS Prevention (Profile Hints)', () => {
+  let transport: HttpTransport;
+  let logger: ConsoleLogger;
+
+  beforeEach(() => {
+    logger = new ConsoleLogger();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (transport) {
+      transport.stop();
+    }
+  });
+
+  it('should evict the oldest profile hint when MAX_PROFILE_HINTS is reached', () => {
+    transport = new HttpTransport({ port: 0 }, logger);
+    // @ts-expect-error accessing private property for testing
+    const maxHints = HttpTransport.MAX_PROFILE_HINTS;
+
+    // Simulate requests to store profile hints
+    for (let i = 0; i < maxHints; i++) {
+      const mockReq = { ip: `10.0.0.${i % 256}`, get: () => `test-agent-${i}` } as any;
+      // @ts-expect-error accessing private method for testing
+      transport.storeProfileHint(mockReq, 'test-profile');
+    }
+
+    // @ts-expect-error accessing private property for testing
+    expect(transport.profileHintsByClient.size).toBe(maxHints);
+
+    // Get the first key (oldest)
+    // @ts-expect-error accessing private property for testing
+    const firstKey = transport.profileHintsByClient.keys().next().value;
+    expect(firstKey).toBe('10.0.0.0|test-agent-0');
+    // @ts-expect-error accessing private property for testing
+    expect(transport.profileHintsByClient.has(firstKey)).toBe(true);
+
+    // Add one more
+    const mockReqOverflow = { ip: '192.168.1.1', get: () => 'overflow-agent' } as any;
+    // @ts-expect-error accessing private method for testing
+    transport.storeProfileHint(mockReqOverflow, 'test-profile');
+
+    // Size should remain at maxHints
+    // @ts-expect-error accessing private property for testing
+    expect(transport.profileHintsByClient.size).toBe(maxHints);
+
+    // The oldest key should have been evicted
+    // @ts-expect-error accessing private property for testing
+    expect(transport.profileHintsByClient.has(firstKey)).toBe(false);
+
+    // The new key should exist
+    // @ts-expect-error accessing private property for testing
+    expect(transport.profileHintsByClient.has('192.168.1.1|overflow-agent')).toBe(true);
+  });
+
+  it('should refresh the LRU order when a hint is updated', () => {
+    transport = new HttpTransport({ port: 0 }, logger);
+    // @ts-expect-error accessing private property for testing
+    const maxHints = HttpTransport.MAX_PROFILE_HINTS;
+
+    // Insert maxHints hints
+    for (let i = 0; i < maxHints; i++) {
+      const mockReq = { ip: `10.0.0.${i % 256}`, get: () => `test-agent-${i}` } as any;
+      // @ts-expect-error accessing private method for testing
+      transport.storeProfileHint(mockReq, 'test-profile');
+    }
+
+    const firstKey = '10.0.0.0|test-agent-0';
+    const secondKey = '10.0.0.1|test-agent-1';
+
+    // "Update" the first key (mock another request from same client)
+    const mockReqFirst = { ip: '10.0.0.0', get: () => 'test-agent-0' } as any;
+    // @ts-expect-error accessing private method for testing
+    transport.storeProfileHint(mockReqFirst, 'test-profile');
+
+    // Add one more (overflow)
+    const mockReqOverflow = { ip: '192.168.1.1', get: () => 'overflow-agent' } as any;
+    // @ts-expect-error accessing private method for testing
+    transport.storeProfileHint(mockReqOverflow, 'test-profile');
+
+    // Size should remain maxHints
+    // @ts-expect-error accessing private property for testing
+    expect(transport.profileHintsByClient.size).toBe(maxHints);
+
+    // The first key was refreshed, so it shouldn't be evicted. The second key is now the oldest.
+    // @ts-expect-error accessing private property for testing
+    expect(transport.profileHintsByClient.has(firstKey)).toBe(true);
+    // @ts-expect-error accessing private property for testing
+    expect(transport.profileHintsByClient.has(secondKey)).toBe(false);
+  });
+
+  it('should periodically clean up expired profile hints', () => {
+    transport = new HttpTransport({ port: 0 }, logger);
+
+    const mockReq1 = { ip: '10.0.0.1', get: () => 'agent-1' } as any;
+    const mockReq2 = { ip: '10.0.0.2', get: () => 'agent-2' } as any;
+
+    // @ts-expect-error accessing private method for testing
+    transport.storeProfileHint(mockReq1, 'test-profile-1');
+
+    // Advance time by half the TTL
+    // @ts-expect-error accessing private property for testing
+    vi.advanceTimersByTime(HttpTransport.PROFILE_HINT_TTL_MS / 2);
+
+    // @ts-expect-error accessing private method for testing
+    transport.storeProfileHint(mockReq2, 'test-profile-2');
+
+    // @ts-expect-error accessing private property for testing
+    expect(transport.profileHintsByClient.size).toBe(2);
+
+    // Advance time so that the first hint expires, but not the second
+    // @ts-expect-error accessing private property for testing
+    vi.advanceTimersByTime((HttpTransport.PROFILE_HINT_TTL_MS / 2) + 1000);
+
+    // Trigger cleanup
+    // @ts-expect-error accessing private method for testing
+    transport.cleanupExpiredSessions();
+
+    // @ts-expect-error accessing private property for testing
+    expect(transport.profileHintsByClient.size).toBe(1);
+    // @ts-expect-error accessing private property for testing
+    expect(transport.profileHintsByClient.has('10.0.0.1|agent-1')).toBe(false);
+    // @ts-expect-error accessing private property for testing
+    expect(transport.profileHintsByClient.has('10.0.0.2|agent-2')).toBe(true);
+  });
+});

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -147,6 +147,7 @@ export class HttpTransport {
   private warnedMissingOAuthRedirectEnvVars: Set<string> = new Set();
   private profileHintsByClient: Map<string, { profileId: string; lastSeen: number }> = new Map();
   private static readonly PROFILE_HINT_TTL_MS = 10 * 60 * 1000;
+  private static readonly MAX_PROFILE_HINTS = 10000;
   private profileIndexProvider: (() => Promise<ListedProfileDetails[]>) | null = null;
   private profileAdminDescriptions: Map<string, string> | null = null;
   private ssrfValidator: SSRFValidator;
@@ -794,6 +795,17 @@ export class HttpTransport {
 
   private storeProfileHint(req: Request, profileId: string): void {
     const key = this.getClientHintKey(req);
+
+    // Evict oldest entry (FIFO) if cache is full, before inserting new one
+    if (this.profileHintsByClient.size >= HttpTransport.MAX_PROFILE_HINTS && !this.profileHintsByClient.has(key)) {
+      const oldestKey = this.profileHintsByClient.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.profileHintsByClient.delete(oldestKey);
+      }
+    }
+
+    // Deleting then setting ensures it's moved to the end of insertion order (acts as LRU/FIFO)
+    this.profileHintsByClient.delete(key);
     this.profileHintsByClient.set(key, { profileId, lastSeen: Date.now() });
   }
 
@@ -4171,6 +4183,19 @@ export class HttpTransport {
 
     if (expiredSessions.length > 0) {
       this.logger.info('Cleaned up expired sessions', { count: expiredSessions.length });
+    }
+
+    // Cleanup expired profile hints
+    let cleanedHintsCount = 0;
+    for (const [key, hint] of this.profileHintsByClient.entries()) {
+      if (now - hint.lastSeen > HttpTransport.PROFILE_HINT_TTL_MS) {
+        this.profileHintsByClient.delete(key);
+        cleanedHintsCount++;
+      }
+    }
+
+    if (cleanedHintsCount > 0) {
+      this.logger.debug('Cleaned up expired profile hints', { count: cleanedHintsCount });
     }
   }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `HttpTransport` stored profile hints in an unbounded in-memory map keyed by client IP and User-Agent. Entries were only evicted on subsequent accesses after expiration.
🎯 Impact: An attacker could cause memory exhaustion (Denial of Service) by continually sending requests with varying IPs or User-Agents, filling up memory indefinitely.
🔧 Fix: Added a hard cache limit (`MAX_PROFILE_HINTS`) with FIFO eviction, and integrated proactive TTL cleanup into the existing `cleanupExpiredSessions` interval.
✅ Verification: Created `http-transport-dos.test.ts` to verify the cache limit and cleanup behavior. All tests pass successfully.

---
*PR created automatically by Jules for task [194911666643702736](https://jules.google.com/task/194911666643702736) started by @davidruzicka*