### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in URL interpolation

### DIFF
--- a/src/mcp/mcp-server-security.test.ts
+++ b/src/mcp/mcp-server-security.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MCPServer } from './mcp-server.js';
+
+describe('MCPServer Security', () => {
+  let server: MCPServer;
+
+  beforeEach(() => {
+    server = new (class extends MCPServer {
+      constructor() {
+        super();
+        // Mock the profile for aliases
+        (this as any).profile = { parameter_aliases: {} };
+      }
+
+      // Expose the private method for testing
+      public testResolvePath(template: string, args: Record<string, unknown>) {
+        return (this as any).resolvePath(template, args);
+      }
+    })();
+  });
+
+  it('vulnerability: path traversal via parameter injection', () => {
+    // This test demonstrates the vulnerability and fix in MCPServer.
+    // If the parameter is not encoded properly, ".." segments are injected into the path.
+    // NOTE: The fixed behavior is that path contains encoded "%2E%2E"
+    // encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets (without fix)
+    // and with fix it will be %2E%2E%2Fadmin%2Fsecrets
+
+    const maliciousId = '../admin/secrets';
+
+    // Testing the resolvePath directly
+    const path = (server as any).testResolvePath('/users/{id}/profile', { id: maliciousId });
+
+    // Vulnerable behavior: path contains raw ".."
+    // Fixed behavior: path contains encoded "%2E%2E"
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
+
+    expect(path).toBe(expectedFixedPath);
+  });
+
+  it('prevents path traversal with exactly ".." parameter', () => {
+    const maliciousId = '..';
+    const path = (server as any).testResolvePath('/users/{id}/profile', { id: maliciousId });
+
+    const expectedFixedPath = '/users/%2E%2E/profile';
+    expect(path).toBe(expectedFixedPath);
+  });
+
+  it('prevents path traversal with exact "." parameter', () => {
+    const maliciousId = '.';
+    const path = (server as any).testResolvePath('/users/{id}/profile', { id: maliciousId });
+
+    const expectedFixedPath = '/users/%2E/profile';
+    expect(path).toBe(expectedFixedPath);
+  });
+});

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1202,10 +1202,11 @@ export class MCPServer {
    *
    * Why: GitLab and other APIs require path parameters (like project paths)
    * to be URL-encoded when used in URL path.
+   * Also encodes dot characters to prevent Path Traversal vulnerabilities.
    */
   private encodePathSegment(value: unknown): string {
     const val = String(value);
-    return val.includes('/') ? encodeURIComponent(val) : val;
+    return encodeURIComponent(val).replace(/\./g, '%2E');
   }
 
   /**

--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -67,7 +67,7 @@ describe('CompositeExecutor Security', () => {
     // Fixed behavior: path contains encoded "%2E%2E"
     // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
     // The slashes inside the injected value are encoded, preventing directory traversal
-    const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -171,14 +171,14 @@ export class CompositeExecutor {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
+        return encodeURIComponent(String(args[key])).replace(/\./g, '%2E');
       }
 
       // Try aliases from profile
       const possibleAliases = this.parameterAliases[key] || [];
       for (const alias of possibleAliases) {
         if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+          return encodeURIComponent(String(args[alias])).replace(/\./g, '%2E');
         }
       }
 


### PR DESCRIPTION
Fixes a path traversal vulnerability in `CompositeExecutor` and `MCPServer` caused by the usage of `encodeURIComponent` for URL interpolation, which inherently leaves dot (`.`) characters unencoded and allows attackers to inject `..` segments to traverse URL paths.

The fix introduces replacing dots with `%2E` after `encodeURIComponent` to enforce encoding and prevent these elements from acting as directory traversal markers when processed by target backends. Included comprehensive regression tests as a safeguard.

---
*PR created automatically by Jules for task [12524046682930605957](https://jules.google.com/task/12524046682930605957) started by @davidruzicka*