### PR TITLE
Fix path traversal vulnerability due to unencoded dots in path segments

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,14 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2026-07-06 - [HIGH] Path Traversal due to Unencoded Dots
+
+**Vulnerability:**
+`encodeURIComponent` does not encode the dot (`.`) character. When substituting user input into path parameters, passing `../` resulted in `..%2F`. Depending on the downstream server's path normalization logic, this could still lead to directory traversal attacks.
+
+**Learning:**
+Standard URL encoding functions like `encodeURIComponent` are not fully sufficient for preventing path traversal in all contexts because they intentionally leave `.` unencoded.
+
+**Prevention:**
+1. Manually replace all `.` characters with `%2E` after applying `encodeURIComponent` when interpolating user input into URL path segments.

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -1319,7 +1319,7 @@ export class MCPServer {
    */
   private encodePathSegment(value: unknown): string {
     const val = String(value);
-    return val.includes('/') ? encodeURIComponent(val) : val;
+    return encodeURIComponent(val).replace(/\./g, '%2E');
   }
 
   /**

--- a/src/tooling/composite-executor-security.test.ts
+++ b/src/tooling/composite-executor-security.test.ts
@@ -67,7 +67,7 @@ describe('CompositeExecutor Security', () => {
     // Fixed behavior: path contains encoded "%2E%2E"
     // Note: encodeURIComponent('../admin/secrets') => ..%2Fadmin%2Fsecrets
     // The slashes inside the injected value are encoded, preventing directory traversal
-    const expectedFixedPath = '/users/..%2Fadmin%2Fsecrets/profile';
+    const expectedFixedPath = '/users/%2E%2E%2Fadmin%2Fsecrets/profile';
 
     expect(capturedPaths[0]).toBe(expectedFixedPath);
   });

--- a/src/tooling/composite-executor.ts
+++ b/src/tooling/composite-executor.ts
@@ -171,14 +171,14 @@ export class CompositeExecutor {
     return template.replace(/\{(\w+)\}/g, (_, key) => {
       // Try direct match first
       if (args[key] !== undefined) {
-        return encodeURIComponent(String(args[key]));
+        return encodeURIComponent(String(args[key])).replace(/\./g, '%2E');
       }
 
       // Try aliases from profile
       const possibleAliases = this.parameterAliases[key] || [];
       for (const alias of possibleAliases) {
         if (args[alias] !== undefined) {
-          return encodeURIComponent(String(args[alias]));
+          return encodeURIComponent(String(args[alias])).replace(/\./g, '%2E');
         }
       }
 


### PR DESCRIPTION
Fix path traversal vulnerability due to unencoded dots in path segments

This commit addresses a security issue where \`encodeURIComponent\`
was used to encode path segments, but intentionally left the \`.\`
character unencoded. As a result, injected paths like \`../\` were
encoded to \`..%2F\`, which could still lead to directory traversal
attacks depending on downstream path normalization logic.

The fix manually replaces all \`.\` characters with \`%2E\` after URL
encoding in \`resolvePath\` (CompositeExecutor) and \`encodePathSegment\` (MCPServer).
Also updated \`composite-executor-security.test.ts\` to reflect
this change and appended an entry to the \`.jules/sentinel.md\` security journal.

---
*PR created automatically by Jules for task [17107190927192117099](https://jules.google.com/task/17107190927192117099) started by @davidruzicka*