### PR TITLE
🛡️ Sentinel: [MEDIUM] Add missing security headers

### DIFF
--- a/src/transport/http-transport-security.test.ts
+++ b/src/transport/http-transport-security.test.ts
@@ -147,6 +147,8 @@ describe('HttpTransport security behavior (no listen)', () => {
     expect(response.headers['cross-origin-resource-policy']).toBe('same-origin');
     expect(response.headers['x-permitted-cross-domain-policies']).toBe('none');
     expect(response.headers['x-dns-prefetch-control']).toBe('off');
+    expect(response.headers['x-xss-protection']).toBe('0');
+    expect(response.headers['strict-transport-security']).toBe('max-age=31536000; includeSubDomains');
     await transport.stop();
   });
 

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -328,6 +328,8 @@ export class HttpTransport {
       res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
       res.setHeader('X-Permitted-Cross-Domain-Policies', 'none');
       res.setHeader('X-DNS-Prefetch-Control', 'off');
+      res.setHeader('X-XSS-Protection', '0');
+      res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 
       next();
     });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The HTTP transport layer was missing the `X-XSS-Protection` and `Strict-Transport-Security` headers, which are standard security best practices for web servers.
🎯 Impact: Without `X-XSS-Protection: 0`, legacy browser XSS auditors could be abused to block legitimate scripts. Without HSTS, browsers may downgrade connections to plain HTTP, leaving them vulnerable to man-in-the-middle attacks.
🔧 Fix: Added the `X-XSS-Protection` (set to `0` to disable legacy auditors in favor of CSP) and `Strict-Transport-Security` (set to `max-age=31536000; includeSubDomains`) headers to the global Express middleware in `src/transport/http-transport.ts`.
✅ Verification: Ran `npm run test` and verified that the `http-transport-security.test.ts` suite passes with assertions checking for these specific headers.

---
*PR created automatically by Jules for task [16420423648511087317](https://jules.google.com/task/16420423648511087317) started by @davidruzicka*