### PR TITLE
🛡️ Sentinel: [HIGH] Fix Promise.race un-cleared timeouts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,15 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2026-08-05 - [HIGH] Un-cleared Timeout in Promise.race
+
+**Vulnerability:**
+Both `MCPServer.executeAppsFetch` and `SSRFValidator.lookupAllIpAddresses` were using `Promise.race()` to enforce a timeout on an async operation using a nested `setTimeout`. If the main async operation completed before the timeout, the `setTimeout` was left running in the event loop until it fired.
+
+**Learning:**
+Leaving an un-cleared timeout function inside `Promise.race()` can cause memory leaks and Denial of Service (DoS). The hanging timeout delays garbage collection for the objects within the promise closure and stops the Node.js process from exiting gracefully, which can be critical for serverless environments.
+
+**Prevention:**
+1.  Always capture the `timeoutId` when setting timeouts inside `Promise.race()`.
+2.  Clear the timeout using `clearTimeout(timeoutId)` inside a `finally` block or when the promise resolves.

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -2926,12 +2926,20 @@ export class MCPServer {
     const task = strategy.source === 'operation'
       ? this.executeAppsOperation(strategy.operation!, args, sessionId, profileId)
       : this.executeAppsComposite(strategy.compositeTool!, args, sessionId, profileId);
-    return await Promise.race([
-      task,
-      new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new ValidationError('Apps fetch timed out')), strategy.timeoutMs);
-      }),
-    ]);
+
+    let timeoutId: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        task,
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => reject(new ValidationError('Apps fetch timed out')), strategy.timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    }
   }
 
   private async executeAppsOperation(

--- a/src/security/ssrf-validator.ts
+++ b/src/security/ssrf-validator.ts
@@ -105,11 +105,12 @@ export class SSRFValidator {
     const timeoutMs = 2000; // Increased to 2s to be safe
 
     let results: Array<{ address: string }> = [];
+    let timeoutId: NodeJS.Timeout | undefined;
     try {
       results = (await Promise.race([
         lookup(hostname, { all: true, verbatim: true }) as Promise<Array<{ address: string }>>,
         new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error(`DNS lookup timeout after ${timeoutMs}ms`)), timeoutMs)
+          timeoutId = setTimeout(() => reject(new Error(`DNS lookup timeout after ${timeoutMs}ms`)), timeoutMs)
         ),
       ])) as Array<{ address: string }>;
     } catch (error) {
@@ -119,6 +120,10 @@ export class SSRFValidator {
       });
       // Fail secure: if we can't resolve it, we can't verify it's safe.
       throw new ValidationError(`DNS lookup failed for hostname '${hostname}'`);
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
     }
 
     const addresses = results.map(r => r.address).filter(Boolean);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `setTimeout` handles used inside `Promise.race()` were not being cleared when the primary async operation completed first.
🎯 Impact: Un-cleared timeouts could lead to memory leaks, Denial of Service via resource exhaustion, and prevent the Node.js process from shutting down properly (critical in serverless environments).
🔧 Fix: Captured the `timeoutId` and added a `finally` block to execute `clearTimeout(timeoutId)`. 
✅ Verification: Ran the full test suite (`npm run test`) and all tests passed without regressions.

---
*PR created automatically by Jules for task [3235652805973971127](https://jules.google.com/task/3235652805973971127) started by @davidruzicka*