### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix memory leak in Promise.race timeouts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,15 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2026-08-06 - [MEDIUM] Memory Leak via Uncleared Timeout in Promise.race
+
+**Vulnerability:**
+The `mcp-server.ts` and `ssrf-validator.ts` files contained `Promise.race` blocks for timeouts where the `setTimeout` identifier was not cleared if the primary promise resolved first. This causes the Node.js event loop to keep the timer active until the timeout duration expires, potentially leading to memory leaks or Delayed DoS under high load.
+
+**Learning:**
+Any timeout mechanism used in a `Promise.race` must be explicitly canceled when the race concludes. JavaScript does not automatically clear pending timers just because the promise they were associated with was dropped or rejected early.
+
+**Prevention:**
+1. Always assign `setTimeout` calls within `Promise.race` to a variable.
+2. Use a `try/finally` block encompassing the `Promise.race` to call `clearTimeout` on that variable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -2926,12 +2926,17 @@ export class MCPServer {
     const task = strategy.source === 'operation'
       ? this.executeAppsOperation(strategy.operation!, args, sessionId, profileId)
       : this.executeAppsComposite(strategy.compositeTool!, args, sessionId, profileId);
-    return await Promise.race([
-      task,
-      new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new ValidationError('Apps fetch timed out')), strategy.timeoutMs);
-      }),
-    ]);
+    let timer: NodeJS.Timeout;
+    try {
+      return await Promise.race([
+        task,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new ValidationError('Apps fetch timed out')), strategy.timeoutMs);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer!);
+    }
   }
 
   private async executeAppsOperation(

--- a/src/security/ssrf-validator.ts
+++ b/src/security/ssrf-validator.ts
@@ -106,12 +106,17 @@ export class SSRFValidator {
 
     let results: Array<{ address: string }> = [];
     try {
-      results = (await Promise.race([
-        lookup(hostname, { all: true, verbatim: true }) as Promise<Array<{ address: string }>>,
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error(`DNS lookup timeout after ${timeoutMs}ms`)), timeoutMs)
-        ),
-      ])) as Array<{ address: string }>;
+      let timer: NodeJS.Timeout;
+      try {
+        results = (await Promise.race([
+          lookup(hostname, { all: true, verbatim: true }) as Promise<Array<{ address: string }>>,
+          new Promise<never>((_, reject) =>
+            (timer = setTimeout(() => reject(new Error(`DNS lookup timeout after ${timeoutMs}ms`)), timeoutMs))
+          ),
+        ])) as Array<{ address: string }>;
+      } finally {
+        clearTimeout(timer!);
+      }
     } catch (error) {
       this.logger.warn('SSRF blocked: DNS lookup failed', {
         hostname,


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Memory leak and potential DoS via uncleared timeouts in `Promise.race` constructs.
🎯 **Impact:** If an operation resolves quickly, the timeout `setTimeout` remains in the Node.js event loop until it fires. Under high load, this causes a buildup of pending timers, consuming memory and delaying garbage collection.
🔧 **Fix:** Wrapped the `Promise.race` blocks in `mcp-server.ts` (for apps fetch) and `ssrf-validator.ts` (for DNS lookup) with `try/finally` blocks and added explicit `clearTimeout` calls.
✅ **Verification:** Verified by running the full test suite (`npm run test`) to ensure no regressions. Tests continue to pass.

---
*PR created automatically by Jules for task [17779459994145349633](https://jules.google.com/task/17779459994145349633) started by @davidruzicka*