### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix memory leak in Promise.race timeouts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,3 +126,16 @@ Error messages should never include raw values from sensitive sources like envir
 **Prevention:**
 1.  Avoid including raw values in error messages when the source is potentially sensitive (env vars, auth headers).
 2.  Use generic error messages for validation failures of sensitive data.
+
+## 2026-08-08 - [MEDIUM] Memory Leak via Lingering Timers in Promise.race
+
+**Vulnerability:**
+The `lookupAllIpAddresses` in `ssrf-validator.ts` and `executeAppsFetch` in `mcp-server.ts` used `Promise.race([task, new Promise((_, reject) => setTimeout(...))])` to implement timeouts. However, if the `task` completed before the timeout, the `setTimeout` was never cleared. This leaves a timer in Node.js's event loop, which can cause unreferenced timers to accumulate under high load, leading to a memory leak and potential Denial of Service (DoS).
+
+**Learning:**
+Any time `setTimeout` is used for a race condition or timeout inside an `async` function or a `Promise`, it MUST be explicitly cleared if the operation succeeds before the timeout expires. Relying on Node.js to eventually clean it up after the callback fires is insufficient under high load because the closures capture context.
+
+**Prevention:**
+1. Always assign `setTimeout` to a variable (e.g., `timeoutId`).
+2. Wrap the `Promise.race` call in a `try...finally` block.
+3. In the `finally` block, call `clearTimeout(timeoutId)` to ensure the timer is always cleaned up regardless of whether the promise resolves or rejects.

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -2926,12 +2926,18 @@ export class MCPServer {
     const task = strategy.source === 'operation'
       ? this.executeAppsOperation(strategy.operation!, args, sessionId, profileId)
       : this.executeAppsComposite(strategy.compositeTool!, args, sessionId, profileId);
-    return await Promise.race([
-      task,
-      new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new ValidationError('Apps fetch timed out')), strategy.timeoutMs);
-      }),
-    ]);
+
+    let timeoutId: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        task,
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => reject(new ValidationError('Apps fetch timed out')), strategy.timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timeoutId) clearTimeout(timeoutId);
+    }
   }
 
   private async executeAppsOperation(

--- a/src/security/ssrf-validator.ts
+++ b/src/security/ssrf-validator.ts
@@ -105,12 +105,13 @@ export class SSRFValidator {
     const timeoutMs = 2000; // Increased to 2s to be safe
 
     let results: Array<{ address: string }> = [];
+    let timeoutId: NodeJS.Timeout | undefined;
     try {
       results = (await Promise.race([
         lookup(hostname, { all: true, verbatim: true }) as Promise<Array<{ address: string }>>,
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error(`DNS lookup timeout after ${timeoutMs}ms`)), timeoutMs)
-        ),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => reject(new Error(`DNS lookup timeout after ${timeoutMs}ms`)), timeoutMs);
+        }),
       ])) as Array<{ address: string }>;
     } catch (error) {
       this.logger.warn('SSRF blocked: DNS lookup failed', {
@@ -119,6 +120,8 @@ export class SSRFValidator {
       });
       // Fail secure: if we can't resolve it, we can't verify it's safe.
       throw new ValidationError(`DNS lookup failed for hostname '${hostname}'`);
+    } finally {
+      if (timeoutId) clearTimeout(timeoutId);
     }
 
     const addresses = results.map(r => r.address).filter(Boolean);


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Uncontrolled resource consumption (Memory Leak) in `Promise.race` constructs used for timeouts.
🎯 **Impact:** If `task` resolves before the timeout, the `setTimeout` callback remains pending in the Node.js event loop. Under heavy load, these pending timeouts can accumulate, tying up memory and potentially leading to a Denial of Service (DoS).
🔧 **Fix:** Added `timeoutId` variables to capture the `setTimeout` reference, and cleared the timeouts using `clearTimeout(timeoutId)` within a `finally` block to ensure deterministic cleanup. Fixed in `src/security/ssrf-validator.ts` and `src/mcp/mcp-server.ts`.
✅ **Verification:** Verified that tests pass locally (`npm run test`) and no memory leaks persist when racing promises resolve immediately.

---
*PR created automatically by Jules for task [13709904761714342272](https://jules.google.com/task/13709904761714342272) started by @davidruzicka*