### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix setTimeout memory leaks in Promise races

### DIFF
--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -2926,12 +2926,20 @@ export class MCPServer {
     const task = strategy.source === 'operation'
       ? this.executeAppsOperation(strategy.operation!, args, sessionId, profileId)
       : this.executeAppsComposite(strategy.compositeTool!, args, sessionId, profileId);
-    return await Promise.race([
-      task,
-      new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new ValidationError('Apps fetch timed out')), strategy.timeoutMs);
-      }),
-    ]);
+
+    let timeoutId: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        task,
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => reject(new ValidationError('Apps fetch timed out')), strategy.timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
   }
 
   private async executeAppsOperation(

--- a/src/security/ssrf-validator.ts
+++ b/src/security/ssrf-validator.ts
@@ -105,12 +105,14 @@ export class SSRFValidator {
     const timeoutMs = 2000; // Increased to 2s to be safe
 
     let results: Array<{ address: string }> = [];
+    let timeoutId: NodeJS.Timeout | undefined;
+
     try {
       results = (await Promise.race([
         lookup(hostname, { all: true, verbatim: true }) as Promise<Array<{ address: string }>>,
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error(`DNS lookup timeout after ${timeoutMs}ms`)), timeoutMs)
-        ),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => reject(new Error(`DNS lookup timeout after ${timeoutMs}ms`)), timeoutMs);
+        }),
       ])) as Array<{ address: string }>;
     } catch (error) {
       this.logger.warn('SSRF blocked: DNS lookup failed', {
@@ -119,6 +121,10 @@ export class SSRFValidator {
       });
       // Fail secure: if we can't resolve it, we can't verify it's safe.
       throw new ValidationError(`DNS lookup failed for hostname '${hostname}'`);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
     }
 
     const addresses = results.map(r => r.address).filter(Boolean);

--- a/src/transport/http-transport.ts
+++ b/src/transport/http-transport.ts
@@ -2560,14 +2560,17 @@ export class HttpTransport {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-      const response = await fetch(url.toString(), {
-        method,
-        headers,
-        signal: controller.signal,
-        redirect: 'error', // Prevent redirects to avoid SSRF bypass
-      });
-
-      clearTimeout(timeoutId);
+      let response: globalThis.Response;
+      try {
+        response = await fetch(url.toString(), {
+          method,
+          headers,
+          signal: controller.signal,
+          redirect: 'error', // Prevent redirects to avoid SSRF bypass
+        });
+      } finally {
+        clearTimeout(timeoutId);
+      }
 
       const isValid = response.status >= 200 && response.status < 300;
       


### PR DESCRIPTION
This PR addresses a medium-severity memory leak issue involving orphaned `setTimeout` timers.

When combining `setTimeout` with `Promise.race` or within general `fetch` structures, failing to clear the timeout manually results in the timer continuing to run in the Node event loop even after the primary promise resolves or rejects. 

The fix explicitly tracks the `timeoutId` and ensures `clearTimeout()` is called inside a `finally` block to guarantee it cleans up correctly.

Files changed:
* `src/security/ssrf-validator.ts`: Fixed timeout inside `lookupAllIpAddresses`.
* `src/mcp/mcp-server.ts`: Fixed timeout inside `executeAppsFetch`.
* `src/transport/http-transport.ts`: Ensured `clearTimeout` runs correctly in the `finally` block for token validation `fetch`.

Verification:
- The TypeScript compiler confirms all types are sound (fixed an overlap with Express `Response`).
- Tested via `npm run test`.

---
*PR created automatically by Jules for task [5366741925643808115](https://jules.google.com/task/5366741925643808115) started by @davidruzicka*